### PR TITLE
automatically detect multus configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,52 +16,15 @@ kind: NetworkAddonsConfig
 metadata:
   name: cluster
 spec:
-  multus:
-    delegates: |
-      [{
-        "type": "flannel",
-        "name": "flannel.1",
-        "delegate": {
-          "isDefaultGateway": true
-        }
-      }]
+  multus: {}
   linuxBridge: {}
 ```
 
 ## Multus
 
-The operator allows administrator to deploy multi-network [Multus plugin](https://github.com/intel/multus-cni). Configuration of this component varies based on used platform.
-
-### On Kubernetes
-
-On Kubernetes or OpenShift 3, operator can be used to deploy and configure
-Multus. It is done using `multus` attribute. `multus.delegates` attribute must
-be specified and contain CNI configuration for the default plugin used on your
-cluster.
-
-```yaml
-apiVersion: networkaddonsoperator.network.kubevirt.io/v1alpha1
-kind: NetworkAddonsConfig
-metadata:
-  name: cluster
-spec:
-  multus:
-    delegates: |
-      [{
-        "type": "flannel",
-        "name": "flannel.1",
-        "delegate": {
-          "isDefaultGateway": true
-        }
-      }]
-```
-
-Additionally, container image used to deliver this plugin can be set using
-`MULTUS_IMAGE` environment variable in operator deployment manifest.
-
-### On OpenShift 4
-
-OpenShift 4 is shipped with [Cluster Network Operator](https://github.com/openshift/cluster-network-operator). OpenShift operator already supports Multus deployment. Therefore, if Multus is requested in our operator using `multus` attribute, we just make sure that is is not disabled in the OpenShift one.
+The operator allows administrator to deploy multi-network
+[Multus plugin](https://github.com/intel/multus-cni). It is done using `multus`
+attribute.
 
 ```yaml
 apiVersion: networkaddonsoperator.network.kubevirt.io/v1alpha1
@@ -71,6 +34,11 @@ metadata:
 spec:
   multus: {}
 ```
+
+Additionally, container image used to deliver this plugin can be set using
+`MULTUS_IMAGE` environment variable in operator deployment manifest.
+
+**Note:** OpenShift 4 is shipped with [Cluster Network Operator](https://github.com/openshift/cluster-network-operator). OpenShift operator already supports Multus deployment. Therefore, if Multus is requested in our operator using `multus` attribute, we just make sure that is is not disabled in the OpenShift one.
 
 ## Linux Bridge
 
@@ -109,15 +77,7 @@ kind: NetworkAddonsConfig
 metadata:
   name: cluster
 spec:
-  multus:
-    delegates: |
-      [{
-        "type": "flannel",
-        "name": "flannel.1",
-        "delegate": {
-          "isDefaultGateway": true
-        }
-      }]
+  multus: {}
   linuxBridge: {}
 EOF
 ```

--- a/config-example.yaml
+++ b/config-example.yaml
@@ -3,13 +3,5 @@ kind: NetworkAddonsConfig
 metadata:
   name: cluster
 spec:
-  multus:
-    delegates: |
-      [{
-        "type": "flannel",
-        "name": "flannel.1",
-        "delegate": {
-          "isDefaultGateway": true
-        }
-      }]
+  multus: {}
   linuxBridge: {}

--- a/data/multus/002-multus.yaml
+++ b/data/multus/002-multus.yaml
@@ -21,23 +21,6 @@ spec:
             config:
               type: string
 ---
-kind: ConfigMap
-apiVersion: v1
-metadata:
-  name: multus-cni-config
-  namespace: multus
-  labels:
-    tier: node
-    app: multus
-data:
-  00-multus.json: |
-    {
-      "name": "multus-cni-network",
-      "type": "multus",
-      "delegates": {{ .MultusDelegates | indent 8}},
-      "kubeconfig": "/etc/cni/net.d/multus.d/multus.kubeconfig"
-    }
----
 apiVersion: extensions/v1beta1
 kind: DaemonSet
 metadata:
@@ -62,7 +45,7 @@ spec:
       containers:
       - name: kube-multus
         command: ["/entrypoint.sh"]
-        args: ["--multus-conf-file=/usr/src/multus-cni/images/00-multus.json"]
+        args: ["--multus-conf-file=auto"]
         image: {{ .MultusImage }}
         resources:
           requests:
@@ -78,8 +61,6 @@ spec:
           mountPath: /host/etc/cni/net.d
         - name: cnibin
           mountPath: /host/opt/cni/bin
-        - name: multus-cfg
-          mountPath: /usr/src/multus-cni/images/
       volumes:
         - name: cni
           hostPath:
@@ -87,6 +68,3 @@ spec:
         - name: cnibin
           hostPath:
             path: /opt/cni/bin
-        - name: multus-cfg
-          configMap:
-            name: multus-cni-config

--- a/pkg/apis/networkaddonsoperator/v1alpha1/networkaddonsconfig_types.go
+++ b/pkg/apis/networkaddonsoperator/v1alpha1/networkaddonsconfig_types.go
@@ -12,10 +12,9 @@ type NetworkAddonsConfigSpec struct {
 }
 
 // +k8s:openapi-gen=true
-type Multus struct {
-	Delegates string `json:"delegates,omitempty"`
-}
+type Multus struct{}
 
+// +k8s:openapi-gen=true
 type LinuxBridge struct{}
 
 // NetworkAddonsConfigStatus defines the observed state of NetworkAddonsConfig

--- a/pkg/network/multus.go
+++ b/pkg/network/multus.go
@@ -19,12 +19,7 @@ func validateMultus(conf *opv1alpha1.NetworkAddonsConfigSpec, openshiftNetworkCo
 		return []error{}
 	}
 
-	if openshiftNetworkConfig == nil {
-		if conf.Multus.Delegates == "" {
-			return []error{errors.Errorf("if multus is used, delegates must be specified")}
-		}
-		// TODO notify that multus configuration is left for openshift
-	} else {
+	if openshiftNetworkConfig != nil {
 		if openshiftNetworkConfig.Spec.DisableMultiNetwork == newTrue() {
 			return []error{errors.Errorf("multus has been requested, but is disabled on OpenShift Cluster Network Operator")}
 		}
@@ -49,7 +44,6 @@ func renderMultus(conf *opv1alpha1.NetworkAddonsConfigSpec, manifestDir string, 
 	// render manifests from disk
 	data := render.MakeRenderData()
 	data.Data["MultusImage"] = os.Getenv("MULTUS_IMAGE")
-	data.Data["MultusDelegates"] = conf.Multus.Delegates
 	data.Data["EnableSCC"] = enableSCC
 
 	objs, err := render.RenderDir(filepath.Join(manifestDir, "multus"), &data)


### PR DESCRIPTION
Multus is not capable of creating its own config file with delegators
pointing to detected default network. Let's use this option instead
of requiring administrator to pass delegates explicitly.

With this change, testing on both OpenShift and Kubernetes will become
easier as we can use the same NetworkAddonsConfig on both. Also integration
with https://github.com/kubevirt/hyperconverged-cluster-operator should
be straightforward.