### PR TITLE
WIP keep all components in single operators namespace

### DIFF
--- a/data/linux-bridge/000-ns.yaml
+++ b/data/linux-bridge/000-ns.yaml
@@ -1,6 +1,0 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: linux-bridge
-  labels:
-    name: linux-bridge

--- a/data/linux-bridge/000-rbac.yaml
+++ b/data/linux-bridge/000-rbac.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: linux-bridge
-  namespace: linux-bridge
+  namespace: {{ .Namespace }}
 ---
 apiVersion: security.openshift.io/v1
 kind: SecurityContextConstraints
@@ -17,5 +17,5 @@ runAsUser:
 seLinuxContext:
   type: RunAsAny
 users:
-- system:serviceaccount:linux-bridge:linux-bridge
+- system:serviceaccount:{{ .Namespace }}:linux-bridge
 {{ end }}

--- a/data/linux-bridge/001-linux-bridge.yaml
+++ b/data/linux-bridge/001-linux-bridge.yaml
@@ -3,7 +3,7 @@ apiVersion: extensions/v1beta1
 kind: DaemonSet
 metadata:
   name: kube-cni-linux-bridge-plugin
-  namespace: linux-bridge
+  namespace: {{ .Namespace }}
   labels:
     tier: node
     app: cni-linux-bridge-plugin

--- a/data/multus/000-ns.yaml
+++ b/data/multus/000-ns.yaml
@@ -1,6 +1,0 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: multus
-  labels:
-    name: multus

--- a/data/multus/000-rbac.yaml
+++ b/data/multus/000-rbac.yaml
@@ -29,13 +29,13 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: multus
-  namespace: multus
+  namespace: {{ .Namespace }}
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: multus
-  namespace: multus
+  namespace: {{ .Namespace }}
 {{ if .EnableSCC }}
 ---
 apiVersion: security.openshift.io/v1
@@ -49,5 +49,5 @@ runAsUser:
 seLinuxContext:
   type: RunAsAny
 users:
-- system:serviceaccount:multus:multus
+- system:serviceaccount:{{ .Namespace }}:multus
 {{ end }}

--- a/data/multus/001-multus.yaml
+++ b/data/multus/001-multus.yaml
@@ -25,7 +25,7 @@ apiVersion: extensions/v1beta1
 kind: DaemonSet
 metadata:
   name: kube-multus-ds-amd64
-  namespace: multus
+  namespace: {{ .Namespace }}
   labels:
     tier: node
     app: multus

--- a/deploy/cluster-network-addons-operator_03_deployment.yaml
+++ b/deploy/cluster-network-addons-operator_03_deployment.yaml
@@ -33,6 +33,10 @@ spec:
           value: "quay.io/kubevirt/cni-default-plugins"
         - name: WATCH_NAMESPACE
           value: ""
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         - name: POD_NAME
           valueFrom:
             fieldRef:

--- a/pkg/network/linux-bridge.go
+++ b/pkg/network/linux-bridge.go
@@ -20,7 +20,7 @@ func changeSafeLinuxBridge(prev, next *opv1alpha1.NetworkAddonsConfigSpec) []err
 }
 
 // renderLinuxBridge generates the manifests of Linux Bridge
-func renderLinuxBridge(conf *opv1alpha1.NetworkAddonsConfigSpec, manifestDir string, enableSCC bool) ([]*unstructured.Unstructured, error) {
+func renderLinuxBridge(conf *opv1alpha1.NetworkAddonsConfigSpec, manifestDir string, namespace string, enableSCC bool) ([]*unstructured.Unstructured, error) {
 	if conf.LinuxBridge == nil {
 		return nil, nil
 	}
@@ -29,6 +29,7 @@ func renderLinuxBridge(conf *opv1alpha1.NetworkAddonsConfigSpec, manifestDir str
 	data := render.MakeRenderData()
 	data.Data["LinuxBridgeImage"] = os.Getenv("LINUX_BRIDGE_IMAGE")
 	data.Data["ImagePullPolicy"] = os.Getenv("IMAGE_PULL_POLICY")
+	data.Data["Namespace"] = namespace
 	data.Data["EnableSCC"] = enableSCC
 
 	objs, err := render.RenderDir(filepath.Join(manifestDir, "linux-bridge"), &data)

--- a/pkg/network/multus.go
+++ b/pkg/network/multus.go
@@ -36,7 +36,7 @@ func changeSafeMultus(prev, next *opv1alpha1.NetworkAddonsConfigSpec) []error {
 }
 
 // RenderMultus generates the manifests of Multus
-func renderMultus(conf *opv1alpha1.NetworkAddonsConfigSpec, manifestDir string, openshiftNetworkConfig *osnetv1.NetworkConfig, enableSCC bool) ([]*unstructured.Unstructured, error) {
+func renderMultus(conf *opv1alpha1.NetworkAddonsConfigSpec, manifestDir string, openshiftNetworkConfig *osnetv1.NetworkConfig, namespace string, enableSCC bool) ([]*unstructured.Unstructured, error) {
 	if conf.Multus == nil || openshiftNetworkConfig != nil {
 		return nil, nil
 	}
@@ -44,6 +44,7 @@ func renderMultus(conf *opv1alpha1.NetworkAddonsConfigSpec, manifestDir string, 
 	// render manifests from disk
 	data := render.MakeRenderData()
 	data.Data["MultusImage"] = os.Getenv("MULTUS_IMAGE")
+	data.Data["Namespace"] = namespace
 	data.Data["EnableSCC"] = enableSCC
 
 	objs, err := render.RenderDir(filepath.Join(manifestDir, "multus"), &data)

--- a/pkg/network/network.go
+++ b/pkg/network/network.go
@@ -61,19 +61,19 @@ func IsChangeSafe(prev, next *opv1alpha1.NetworkAddonsConfigSpec) error {
 	return nil
 }
 
-func Render(conf *opv1alpha1.NetworkAddonsConfigSpec, manifestDir string, openshiftNetworkConfig *osnetv1.NetworkConfig, enableSCC bool) ([]*unstructured.Unstructured, error) {
+func Render(conf *opv1alpha1.NetworkAddonsConfigSpec, manifestDir string, openshiftNetworkConfig *osnetv1.NetworkConfig, namespace string, enableSCC bool) ([]*unstructured.Unstructured, error) {
 	log.Print("starting render phase")
 	objs := []*unstructured.Unstructured{}
 
 	// render Multus
-	o, err := renderMultus(conf, manifestDir, openshiftNetworkConfig, enableSCC)
+	o, err := renderMultus(conf, manifestDir, openshiftNetworkConfig, namespace, enableSCC)
 	if err != nil {
 		return nil, err
 	}
 	objs = append(objs, o...)
 
 	// render Linux Bridge
-	o, err = renderLinuxBridge(conf, manifestDir, enableSCC)
+	o, err = renderLinuxBridge(conf, manifestDir, namespace, enableSCC)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Let's group all components under a single namespace. It should make
it easier to track components deployed by the operator and it was
requested by hyperconverged-cluster-operator maintainers.

There will be a follow-up PR making namespace of the operato itself
configurable.