### PR TITLE
Change the linux deployment yaml

### DIFF
--- a/data/linux-bridge/002-linux-bridge.yaml
+++ b/data/linux-bridge/002-linux-bridge.yaml
@@ -31,8 +31,8 @@ spec:
             - /bin/bash
             - -c
             - |
-              cp -rf /usr/src/containernetworking/plugins/bin/bridge /opt/cni/bin/
-              cp -rf /usr/src/containernetworking/plugins/bin/tuning /opt/cni/bin/
+              cp -rf /usr/src/containernetworking/plugins/bin/*bridge /opt/cni/bin/
+              cp -rf /usr/src/containernetworking/plugins/bin/*tuning /opt/cni/bin/
               echo "Entering sleep... (success)"
               sleep infinity
           resources:


### PR DESCRIPTION
Every file that contains a postfix of bridge and tuning will be copy

CNV is Red Hat product based on KubeVirt.
We plan to ship these plugins with cnv-* prefix to make sure they don't break regular openshift plugins if they are also deployed on the same node.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubevirt/cluster-network-addons-operator/27)
<!-- Reviewable:end -->
