### PR TITLE
Fix kubemacpool crash

### DIFF
--- a/data/kubemacpool/001-rbac.yaml
+++ b/data/kubemacpool/001-rbac.yaml
@@ -81,6 +81,17 @@ rules:
       - get
       - list
   - apiGroups:
+      - apps
+    resources:
+      - statefulsets
+    verbs:
+      - get
+      - create
+      - update
+      - patch
+      - list
+      - watch
+  - apiGroups:
       - kubevirt.io
     resources:
       - virtualmachines


### PR DESCRIPTION
related to this PR that was merge we need to update the rbac configuration in the operator
https://github.com/K8sNetworkPlumbingWG/kubemacpool/pull/8

Fixes #39

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubevirt/cluster-network-addons-operator/40)
<!-- Reviewable:end -->
