### PR TITLE
Change KubeMacPool RBAC rule

### DIFF
--- a/data/kubemacpool/001-rbac.yaml
+++ b/data/kubemacpool/001-rbac.yaml
@@ -83,7 +83,7 @@ rules:
   - apiGroups:
       - apps
     resources:
-      - statefulsets
+      - deployments
     verbs:
       - get
       - create

--- a/data/kubemacpool/004-deployment.yaml
+++ b/data/kubemacpool/004-deployment.yaml
@@ -1,6 +1,6 @@
 ---
 apiVersion: apps/v1
-kind: StatefulSet
+kind: Deployment
 metadata:
   labels:
     control-plane: mac-controller-manager
@@ -13,7 +13,6 @@ spec:
     matchLabels:
       control-plane: mac-controller-manager
       controller-tools.k8s.io: "1.0"
-  serviceName: controller-manager-service
   template:
     metadata:
       labels:


### PR DESCRIPTION
Related to https://github.com/K8sNetworkPlumbingWG/kubemacpool/pull/10

Change the RBAC rule from statefulset to deployment

Change manager from statefulset to deployment

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubevirt/cluster-network-addons-operator/45)
<!-- Reviewable:end -->
