### PR TITLE
Use kubernetes core PullPolicy for imagePullPolicy

### DIFF
--- a/pkg/apis/networkaddonsoperator/v1alpha1/networkaddonsconfig_types.go
+++ b/pkg/apis/networkaddonsoperator/v1alpha1/networkaddonsconfig_types.go
@@ -8,11 +8,11 @@ import (
 // NetworkAddonsConfigSpec defines the desired state of NetworkAddonsConfig
 // +k8s:openapi-gen=true
 type NetworkAddonsConfigSpec struct {
-	Multus          *Multus      `json:"multus,omitempty"`
-	LinuxBridge     *LinuxBridge `json:"linuxBridge,omitempty"`
-	Sriov           *Sriov       `json:"sriov,omitempty"`
-	KubeMacPool     *KubeMacPool `json:"kubeMacPool,omitempty"`
-	ImagePullPolicy string       `json:"imagePullPolicy,omitempty"`
+	Multus          *Multus           `json:"multus,omitempty"`
+	LinuxBridge     *LinuxBridge      `json:"linuxBridge,omitempty"`
+	Sriov           *Sriov            `json:"sriov,omitempty"`
+	KubeMacPool     *KubeMacPool      `json:"kubeMacPool,omitempty"`
+	ImagePullPolicy corev1.PullPolicy `json:"imagePullPolicy,omitempty"`
 }
 
 // +k8s:openapi-gen=true

--- a/pkg/network/image-pull-policy.go
+++ b/pkg/network/image-pull-policy.go
@@ -7,7 +7,7 @@ import (
 	opv1alpha1 "github.com/kubevirt/cluster-network-addons-operator/pkg/apis/networkaddonsoperator/v1alpha1"
 )
 
-const defaultImagePullPolicy = string(v1.PullIfNotPresent)
+const defaultImagePullPolicy = v1.PullIfNotPresent
 
 func validateImagePullPolicy(conf *opv1alpha1.NetworkAddonsConfigSpec) []error {
 	if conf.ImagePullPolicy == "" {
@@ -39,8 +39,7 @@ func changeSafeImagePullPolicy(prev, next *opv1alpha1.NetworkAddonsConfigSpec) [
 }
 
 // Verify if the value is a valid PullPolicy
-func verifyPullPolicyType(policy string) bool {
-	imagePullPolicy := v1.PullPolicy(policy)
+func verifyPullPolicyType(imagePullPolicy v1.PullPolicy) bool {
 	switch imagePullPolicy {
 	case v1.PullAlways:
 		return true


### PR DESCRIPTION
Instead of a string, we should use Kubernetes Core v1 PullPolicy
type to specify image pull policy for components' pods.

This is done per request from https://github.com/kubevirt/hyperconverged-cluster-operator/pull/23#discussion_r273713084.