### PR TITLE
Support OpenShift 4

### DIFF
--- a/cluster/sync.sh
+++ b/cluster/sync.sh
@@ -16,6 +16,6 @@ for i in $(seq 1 ${CLUSTER_NUM_NODES}); do
     ./cluster/cli.sh ssh "node$(printf "%02d" ${i})" 'sudo sysctl -w user.max_user_namespaces=1024'
 done
 
+./cluster/kubectl.sh create -f _out/namespace.yaml
 ./cluster/kubectl.sh create -f _out/crds/network-addons-config.crd.yaml
 ./cluster/kubectl.sh create -f _out/operator.yaml
-./cluster/kubectl.sh create -f _out/namespace.yaml

--- a/data/linux-bridge/002-linux-bridge.yaml
+++ b/data/linux-bridge/002-linux-bridge.yaml
@@ -54,4 +54,4 @@ spec:
       volumes:
         - name: cnibin
           hostPath:
-            path: /opt/cni/bin
+            path: {{ .CNIBinDir }}

--- a/data/multus/002-multus.yaml
+++ b/data/multus/002-multus.yaml
@@ -69,7 +69,7 @@ spec:
       volumes:
         - name: cni
           hostPath:
-            path: /etc/cni/net.d
+            path: {{ .CNIConfigDir }}
         - name: cnibin
           hostPath:
-            path: /opt/cni/bin
+            path: {{ .CNIBinDir }}

--- a/data/sriov/002-sriov-cni.yaml
+++ b/data/sriov/002-sriov-cni.yaml
@@ -46,4 +46,4 @@ spec:
       volumes:
         - name: cnibin
           hostPath:
-            path: /opt/cni/bin
+            path: {{ .CNIBinDir }}

--- a/pkg/controller/networkaddonsconfig/networkaddonsconfig_controller.go
+++ b/pkg/controller/networkaddonsconfig/networkaddonsconfig_controller.go
@@ -57,27 +57,36 @@ func Add(mgr manager.Manager) error {
 		return fmt.Errorf("environment variable OPERATOR_NAMESPACE has to be set")
 	}
 
+	runningOnOpenShift4, err := isRunningOnOpenShift4(clientset)
+	if err != nil {
+		return fmt.Errorf("failed to check whether running on OpenShift 4: %v", err)
+	}
+	if runningOnOpenShift4 {
+		log.Printf("Running on OpenShift 4")
+	}
+
 	sccIsAvailable, err := isSCCAvailable(clientset)
 	if err != nil {
 		return fmt.Errorf("failed to check for availability of SCC: %v", err)
 	}
 
-	return add(mgr, newReconciler(mgr, namespace, sccIsAvailable))
+	return add(mgr, newReconciler(mgr, namespace, runningOnOpenShift4, sccIsAvailable))
 }
 
 // newReconciler returns a new ReconcileNetworkAddonsConfig
-func newReconciler(mgr manager.Manager, namespace string, sccIsAvailable bool) *ReconcileNetworkAddonsConfig {
+func newReconciler(mgr manager.Manager, namespace string, runningOnOpenShift4 bool, sccIsAvailable bool) *ReconcileNetworkAddonsConfig {
 	// Status manager is shared between both reconcilers and it is used to update conditions of
 	// NetworkAddonsConfig.State. NetworkAddonsConfig reconciler updates it with progress of rendering
 	// and applying of manifests. Pods reconciler updates it with progress of deployed pods.
 	statusManager := statusmanager.New(mgr.GetClient(), names.OPERATOR_CONFIG)
 	return &ReconcileNetworkAddonsConfig{
-		client:         mgr.GetClient(),
-		scheme:         mgr.GetScheme(),
-		namespace:      namespace,
-		podReconciler:  newPodReconciler(statusManager),
-		statusManager:  statusManager,
-		sccIsAvailable: sccIsAvailable,
+		client:              mgr.GetClient(),
+		scheme:              mgr.GetScheme(),
+		namespace:           namespace,
+		podReconciler:       newPodReconciler(statusManager),
+		statusManager:       statusManager,
+		runningOnOpenShift4: runningOnOpenShift4,
+		sccIsAvailable:      sccIsAvailable,
 	}
 }
 
@@ -138,12 +147,13 @@ var _ reconcile.Reconciler = &ReconcileNetworkAddonsConfig{}
 type ReconcileNetworkAddonsConfig struct {
 	// This client, initialized using mgr.Client() above, is a split client
 	// that reads objects from the cache and writes to the apiserver
-	client         client.Client
-	scheme         *runtime.Scheme
-	namespace      string
-	podReconciler  *ReconcilePods
-	statusManager  *statusmanager.StatusManager
-	sccIsAvailable bool
+	client              client.Client
+	scheme              *runtime.Scheme
+	namespace           string
+	podReconciler       *ReconcilePods
+	statusManager       *statusmanager.StatusManager
+	runningOnOpenShift4 bool
+	sccIsAvailable      bool
 }
 
 // Reconcile reads that state of the cluster for a NetworkAddonsConfig object and makes changes based on the state read
@@ -245,7 +255,7 @@ func (r *ReconcileNetworkAddonsConfig) renderObjects(networkAddonsConfig *opv1al
 	}
 
 	// Generate the objects
-	objs, err = network.Render(&networkAddonsConfig.Spec, ManifestPath, openshiftNetworkConfig, r.sccIsAvailable)
+	objs, err = network.Render(&networkAddonsConfig.Spec, ManifestPath, openshiftNetworkConfig, r.runningOnOpenShift4, r.sccIsAvailable)
 	if err != nil {
 		log.Printf("failed to render: %v", err)
 		err = errors.Wrapf(err, "failed to render")
@@ -325,6 +335,12 @@ func getOpenShiftNetworkConfig(ctx context.Context, c k8sclient.Client) (*osv1.N
 	}
 
 	return nc, nil
+}
+
+// Check whether running on OpenShift 4 by looking for operator objects that has been introduced
+// only in OpenShift 4
+func isRunningOnOpenShift4(c kubernetes.Interface) (bool, error) {
+	return isResourceAvailable(c, "configs", "imageregistry.operator.openshift.io", "v1")
 }
 
 func isSCCAvailable(c kubernetes.Interface) (bool, error) {

--- a/pkg/network/cluster-info.go
+++ b/pkg/network/cluster-info.go
@@ -1,0 +1,6 @@
+package network
+
+type ClusterInfo struct {
+	SCCAvailable bool
+	OpenShift4   bool
+}

--- a/pkg/network/cni/cni.go
+++ b/pkg/network/cni/cni.go
@@ -1,0 +1,8 @@
+package cni
+
+const (
+	ConfigDir           = "/etc/cni/net.d"
+	BinDir              = "/opt/cni/bin"
+	ConfigDirOpenShift4 = "/etc/kubernetes/cni/net.d"
+	BinDirOpenShift4    = "/var/lib/cni/bin"
+)

--- a/pkg/network/linux-bridge.go
+++ b/pkg/network/linux-bridge.go
@@ -21,7 +21,7 @@ func changeSafeLinuxBridge(prev, next *opv1alpha1.NetworkAddonsConfigSpec) []err
 }
 
 // renderLinuxBridge generates the manifests of Linux Bridge
-func renderLinuxBridge(conf *opv1alpha1.NetworkAddonsConfigSpec, manifestDir string, runningOnOpenShift4 bool, enableSCC bool) ([]*unstructured.Unstructured, error) {
+func renderLinuxBridge(conf *opv1alpha1.NetworkAddonsConfigSpec, manifestDir string, clusterInfo *ClusterInfo) ([]*unstructured.Unstructured, error) {
 	if conf.LinuxBridge == nil {
 		return nil, nil
 	}
@@ -30,12 +30,12 @@ func renderLinuxBridge(conf *opv1alpha1.NetworkAddonsConfigSpec, manifestDir str
 	data := render.MakeRenderData()
 	data.Data["LinuxBridgeImage"] = os.Getenv("LINUX_BRIDGE_IMAGE")
 	data.Data["ImagePullPolicy"] = conf.ImagePullPolicy
-	if runningOnOpenShift4 {
+	if clusterInfo.OpenShift4 {
 		data.Data["CNIBinDir"] = cni.BinDirOpenShift4
 	} else {
 		data.Data["CNIBinDir"] = cni.BinDir
 	}
-	data.Data["EnableSCC"] = enableSCC
+	data.Data["EnableSCC"] = clusterInfo.SCCAvailable
 
 	objs, err := render.RenderDir(filepath.Join(manifestDir, "linux-bridge"), &data)
 	if err != nil {

--- a/pkg/network/network.go
+++ b/pkg/network/network.go
@@ -67,26 +67,26 @@ func IsChangeSafe(prev, next *opv1alpha1.NetworkAddonsConfigSpec) error {
 	return nil
 }
 
-func Render(conf *opv1alpha1.NetworkAddonsConfigSpec, manifestDir string, openshiftNetworkConfig *osv1.Network, enableSCC bool) ([]*unstructured.Unstructured, error) {
+func Render(conf *opv1alpha1.NetworkAddonsConfigSpec, manifestDir string, openshiftNetworkConfig *osv1.Network, runningOnOpenShift4 bool, enableSCC bool) ([]*unstructured.Unstructured, error) {
 	log.Print("starting render phase")
 	objs := []*unstructured.Unstructured{}
 
 	// render Multus
-	o, err := renderMultus(conf, manifestDir, openshiftNetworkConfig, enableSCC)
+	o, err := renderMultus(conf, manifestDir, openshiftNetworkConfig, runningOnOpenShift4, enableSCC)
 	if err != nil {
 		return nil, err
 	}
 	objs = append(objs, o...)
 
 	// render Linux Bridge
-	o, err = renderLinuxBridge(conf, manifestDir, enableSCC)
+	o, err = renderLinuxBridge(conf, manifestDir, runningOnOpenShift4, enableSCC)
 	if err != nil {
 		return nil, err
 	}
 	objs = append(objs, o...)
 
 	// render SR-IOV
-	o, err = renderSriov(conf, manifestDir, enableSCC)
+	o, err = renderSriov(conf, manifestDir, runningOnOpenShift4, enableSCC)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/network/network.go
+++ b/pkg/network/network.go
@@ -67,26 +67,26 @@ func IsChangeSafe(prev, next *opv1alpha1.NetworkAddonsConfigSpec) error {
 	return nil
 }
 
-func Render(conf *opv1alpha1.NetworkAddonsConfigSpec, manifestDir string, openshiftNetworkConfig *osv1.Network, runningOnOpenShift4 bool, enableSCC bool) ([]*unstructured.Unstructured, error) {
+func Render(conf *opv1alpha1.NetworkAddonsConfigSpec, manifestDir string, openshiftNetworkConfig *osv1.Network, clusterInfo *ClusterInfo) ([]*unstructured.Unstructured, error) {
 	log.Print("starting render phase")
 	objs := []*unstructured.Unstructured{}
 
 	// render Multus
-	o, err := renderMultus(conf, manifestDir, openshiftNetworkConfig, runningOnOpenShift4, enableSCC)
+	o, err := renderMultus(conf, manifestDir, openshiftNetworkConfig, clusterInfo)
 	if err != nil {
 		return nil, err
 	}
 	objs = append(objs, o...)
 
 	// render Linux Bridge
-	o, err = renderLinuxBridge(conf, manifestDir, runningOnOpenShift4, enableSCC)
+	o, err = renderLinuxBridge(conf, manifestDir, clusterInfo)
 	if err != nil {
 		return nil, err
 	}
 	objs = append(objs, o...)
 
 	// render SR-IOV
-	o, err = renderSriov(conf, manifestDir, runningOnOpenShift4, enableSCC)
+	o, err = renderSriov(conf, manifestDir, clusterInfo)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/network/sriov.go
+++ b/pkg/network/sriov.go
@@ -14,6 +14,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	opv1alpha1 "github.com/kubevirt/cluster-network-addons-operator/pkg/apis/networkaddonsoperator/v1alpha1"
+	"github.com/kubevirt/cluster-network-addons-operator/pkg/network/cni"
 )
 
 // code below is copied from openshift/cluster-network-operator:pkg/network/sriov.go
@@ -76,7 +77,7 @@ func getRootDevicesConfigString(rootDevices string) string {
 }
 
 // renderSriov generates the manifests of SR-IOV plugins
-func renderSriov(conf *opv1alpha1.NetworkAddonsConfigSpec, manifestDir string, enableSCC bool) ([]*unstructured.Unstructured, error) {
+func renderSriov(conf *opv1alpha1.NetworkAddonsConfigSpec, manifestDir string, runningOnOpenShift4 bool, enableSCC bool) ([]*unstructured.Unstructured, error) {
 	if conf.Sriov == nil {
 		return nil, nil
 	}
@@ -87,6 +88,11 @@ func renderSriov(conf *opv1alpha1.NetworkAddonsConfigSpec, manifestDir string, e
 	data.Data["SriovDpImage"] = os.Getenv("SRIOV_DP_IMAGE")
 	data.Data["SriovCniImage"] = os.Getenv("SRIOV_CNI_IMAGE")
 	data.Data["ImagePullPolicy"] = conf.ImagePullPolicy
+	if runningOnOpenShift4 {
+		data.Data["CNIBinDir"] = cni.BinDirOpenShift4
+	} else {
+		data.Data["CNIBinDir"] = cni.BinDir
+	}
 	data.Data["EnableSCC"] = enableSCC
 
 	objs, err := render.RenderDir(filepath.Join(manifestDir, "sriov"), &data)

--- a/pkg/network/sriov.go
+++ b/pkg/network/sriov.go
@@ -77,7 +77,7 @@ func getRootDevicesConfigString(rootDevices string) string {
 }
 
 // renderSriov generates the manifests of SR-IOV plugins
-func renderSriov(conf *opv1alpha1.NetworkAddonsConfigSpec, manifestDir string, runningOnOpenShift4 bool, enableSCC bool) ([]*unstructured.Unstructured, error) {
+func renderSriov(conf *opv1alpha1.NetworkAddonsConfigSpec, manifestDir string, clusterInfo *ClusterInfo) ([]*unstructured.Unstructured, error) {
 	if conf.Sriov == nil {
 		return nil, nil
 	}
@@ -88,12 +88,12 @@ func renderSriov(conf *opv1alpha1.NetworkAddonsConfigSpec, manifestDir string, r
 	data.Data["SriovDpImage"] = os.Getenv("SRIOV_DP_IMAGE")
 	data.Data["SriovCniImage"] = os.Getenv("SRIOV_CNI_IMAGE")
 	data.Data["ImagePullPolicy"] = conf.ImagePullPolicy
-	if runningOnOpenShift4 {
+	if clusterInfo.OpenShift4 {
 		data.Data["CNIBinDir"] = cni.BinDirOpenShift4
 	} else {
 		data.Data["CNIBinDir"] = cni.BinDir
 	}
-	data.Data["EnableSCC"] = enableSCC
+	data.Data["EnableSCC"] = clusterInfo.SCCAvailable
 
 	objs, err := render.RenderDir(filepath.Join(manifestDir, "sriov"), &data)
 	if err != nil {


### PR DESCRIPTION
With OpenShift 4, CNI config and bin directories has been moved from
/opt/cni/bin to /var/lib/cni/bin and from /etc/cni/net.d to
/etc/kubernetes/cni/net.d.

With this patch, we check whether we are running on OpenShift 4 by
looking up operator objects introduced in OpenShift 4 and making
CNI paths in components' manifests based on that.