### PR TITLE
Copy *sriov to /opt/cni/bin

### DIFF
--- a/data/sriov/002-sriov-cni.yaml
+++ b/data/sriov/002-sriov-cni.yaml
@@ -31,6 +31,14 @@ spec:
       - name: kube-sriov-cni
         image: {{ .SriovCniImage }}
         imagePullPolicy: {{ .ImagePullPolicy }}
+        command:
+          - /bin/bash
+          - -c
+          - |
+            cp -f /usr/src/sriov-cni/bin/*sriov /host/opt/cni/bin/
+            cp -f /usr/bin/*sriov /host/opt/cni/bin/
+            echo "Entering sleep... (success)"
+            sleep infinity
         securityContext:
           privileged: true
         resources:


### PR DESCRIPTION
Plugin name may be changed in built images to accommodate for some
products (specifically, for Red Hat's CNV). Meaning, we would e.g. have
cnv-sriov instead of sriov, to avoid overriding the original upstream
plugin, or for other goals.

Note: current :latest upstream image is 5 months old and has sriov
binary located inside /usr/src/sriov-cni/bin instead of /usr/bin.
Current master branch of the sriov-cni repo puts the binary under
/usr/bin.  When they push an updated image to the docker repo we can
clean up the command in the manifest somewhat.