### PR TITLE
Create sriov network attachment definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,18 @@ can deploy with default configuration file and then modify
 You may need to restart SR-IOV device plugin pods to catch up configuration
 file changes.
 
+The operator will also deploy a new network attachment definition for SR-IOV
+network. By default, its name is `sriov-network` but it can be changed using
+the `SRIOV_NETWORK_NAME` environment variable.
+
+One may also want to change the type of the newly created network attachment
+definition from the default `sriov` to something else. For example, this is
+needed for Red Hat's CNV product that is deployed on top of OpenShift that may
+be already shipped with `sriov` CNI plugin of different version incompatible
+with KubeVirt. In this case an admin may want to use different network types
+for KubeVirt and OpenShift SR-IOV CNI plugins. This can be achieved using the
+`SRIOV_NETWORK_TYPE` environment variable.
+
 Additionally, container images used to deliver these plugins can be set using
 `SRIOV_DP_IMAGE` and `SRIOV_CNI_IMAGE` environment variables in operator
 deployment manifest.
@@ -98,31 +110,6 @@ operator already supports SR-IOV deployment. But it uses older versions of
 components that are not compatible with KubeVirt SR-IOV feature. Therefore, if
 SR-IOV is requested in OpenShift cluster network operator, KubeVirt addons
 operator will return an error.
-
-**Note:** To use SR-IOV for KubeVirt, one should also create a corresponding
-network attachment definition resource. For example:
-
-```yaml
-apiVersion: "k8s.cni.cncf.io/v1"
-kind: NetworkAttachmentDefinition
-metadata:
-  name: sriov-net1
-  annotations:
-    k8s.v1.cni.cncf.io/resourceName: intel.com/sriov
-spec:
-  config: '{
-  "type": "sriov",
-  "name": "sriov-network",
-  "ipam": {
-    "type": "host-local",
-    "subnet": "10.56.217.0/24",
-    "routes": [{
-      "dst": "0.0.0.0/0"
-    }],
-    "gateway": "10.56.217.1"
-  }
-}'
-```
 
 ## Kubemacpool
 The operator allows administrator to deploy the [Kubemacpool](https://github.com/K8sNetworkPlumbingWG/kubemacpool)

--- a/data/sriov/002-sriov-cni.yaml
+++ b/data/sriov/002-sriov-cni.yaml
@@ -35,8 +35,8 @@ spec:
           - /bin/bash
           - -c
           - |
-            cp -f /usr/src/sriov-cni/bin/*sriov /host/opt/cni/bin/
-            cp -f /usr/bin/*sriov /host/opt/cni/bin/
+            cp -f /usr/src/sriov-cni/bin/sriov /host/opt/cni/bin/{{ .SriovNetworkType }}
+            cp -f /usr/bin/sriov /host/opt/cni/bin/{{ .SriovNetworkType }}
             echo "Entering sleep... (success)"
             sleep infinity
         securityContext:

--- a/data/sriov/004-sriov-network.yaml
+++ b/data/sriov/004-sriov-network.yaml
@@ -1,0 +1,13 @@
+apiVersion: "k8s.cni.cncf.io/v1"
+kind: NetworkAttachmentDefinition
+metadata:
+  namespace: sriov
+  name: {{ .SriovNetworkName }}
+  annotations:
+    k8s.v1.cni.cncf.io/resourceName: intel.com/sriov
+spec:
+  config: '{
+  "type": {{ .SriovNetworkType }},
+  "name": {{ .SriovNetworkName }},
+  "ipam": {}
+}'

--- a/deploy/olm-catalog/cluster-network-addons/0.0.0/cluster-network-addons-operator.v0.0.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/cluster-network-addons/0.0.0/cluster-network-addons-operator.v0.0.0.clusterserviceversion.yaml
@@ -153,6 +153,10 @@ spec:
                     value: quay.io/booxter/sriov-device-plugin:latest
                   - name: SRIOV_CNI_IMAGE
                     value: docker.io/nfvpe/sriov-cni:latest
+                  - name: SRIOV_NETWORK_NAME
+                    value: sriov-network
+                  - name: SRIOV_NETWORK_TYPE
+                    value: sriov
                   - name: SRIOV_ROOT_DEVICES
                   - name: KUBEMACPOOL_IMAGE
                     value: quay.io/schseba/mac-controller:latest

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -135,6 +135,10 @@ spec:
           value: quay.io/booxter/sriov-device-plugin:latest
         - name: SRIOV_CNI_IMAGE
           value: docker.io/nfvpe/sriov-cni:latest
+        - name: SRIOV_NETWORK_NAME
+          value: sriov-network
+        - name: SRIOV_NETWORK_TYPE
+          value: sriov
         - name: SRIOV_ROOT_DEVICES
         - name: KUBEMACPOOL_IMAGE
           value: quay.io/schseba/mac-controller:latest

--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -66,6 +66,14 @@ func GetDeployment(repository string, tag string, imagePullPolicy string) *appsv
 									Value: "",
 								},
 								{
+									Name:  "SRIOV_NETWORK_NAME",
+									Value: "sriov-network",
+								},
+								{
+									Name:  "SRIOV_NETWORK_TYPE",
+									Value: "sriov",
+								},
+								{
 									Name:  "KUBEMACPOOL_IMAGE",
 									Value: "quay.io/schseba/mac-controller:latest",
 								},

--- a/pkg/network/sriov.go
+++ b/pkg/network/sriov.go
@@ -87,6 +87,8 @@ func renderSriov(conf *opv1alpha1.NetworkAddonsConfigSpec, manifestDir string, c
 	data.Data["SriovRootDevices"] = getRootDevicesConfigString(os.Getenv("SRIOV_ROOT_DEVICES"))
 	data.Data["SriovDpImage"] = os.Getenv("SRIOV_DP_IMAGE")
 	data.Data["SriovCniImage"] = os.Getenv("SRIOV_CNI_IMAGE")
+	data.Data["SriovNetworkName"] = os.Getenv("SRIOV_NETWORK_NAME")
+	data.Data["SriovNetworkType"] = os.Getenv("SRIOV_NETWORK_TYPE")
 	data.Data["ImagePullPolicy"] = conf.ImagePullPolicy
 	if clusterInfo.OpenShift4 {
 		data.Data["CNIBinDir"] = cni.BinDirOpenShift4


### PR DESCRIPTION
To use SR-IOV with KubeVirt, one needs to have a network attachment
definition that links back to resourceName used in SR-IOV DP config
file. This is the last missing bit in end-to-end SR-IOV integration.

I am using the `default` namespace and not `sriov` because it's assumed
that regular users will attach their pods / VMIs to the network, so
keeping it under `default` seems to make more sense. Otherwise one would
need to refer to the new network with namespace prefix included, as in:
`sriov/sriov-network` which is a bit too wordy.

Note that this PR doesn't allow to configure IPAM parameters for the
new network. I'd like to leave this piece separate from this patch.