### PR TITLE
make addons images configurable during `make manifests`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,8 +30,17 @@ cluster-sync:
 cluster-clean:
 	./cluster/clean.sh
 
+# Default images can be found in pkg/components/components.go
 manifests:
-	DEPLOY_DIR=$(DEPLOY_DIR) CONTAINER_PREFIX=$(IMAGE_REGISTRY) CONTAINER_TAG=$(IMAGE_TAG) ./hack/build-manifests.sh
+	DEPLOY_DIR=$(DEPLOY_DIR) \
+	CONTAINER_PREFIX=$(IMAGE_REGISTRY) \
+	CONTAINER_TAG=$(IMAGE_TAG) \
+	MULTUS_IMAGE=$(MULTUS_IMAGE) \
+	LINUX_BRIDGE_CNI_IMAGE=$(LINUX_BRIDGE_CNI_IMAGE) \
+	SRIOV_DP_IMAGE=$(SRIOV_DP_IMAGE) \
+	SRIOV_CNI_IMAGE=$(SRIOV_CNI_IMAGE) \
+	KUBEMACPOOL_IMAGE=$(KUBEMACPOOL_IMAGE) \
+		./hack/build-manifests.sh
 
 .PHONY:
 	docker-build \

--- a/deploy/olm-catalog/cluster-network-addons/0.0.0/cluster-network-addons-operator.v0.0.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/cluster-network-addons/0.0.0/cluster-network-addons-operator.v0.0.0.clusterserviceversion.yaml
@@ -148,7 +148,7 @@ spec:
                   - name: MULTUS_IMAGE
                     value: docker.io/nfvpe/multus:latest
                   - name: LINUX_BRIDGE_IMAGE
-                    value: quay.io/kubevirt/cni-default-plugins
+                    value: quay.io/kubevirt/cni-default-plugins:latest
                   - name: SRIOV_DP_IMAGE
                     value: quay.io/booxter/sriov-device-plugin:latest
                   - name: SRIOV_CNI_IMAGE

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -130,7 +130,7 @@ spec:
         - name: MULTUS_IMAGE
           value: docker.io/nfvpe/multus:latest
         - name: LINUX_BRIDGE_IMAGE
-          value: quay.io/kubevirt/cni-default-plugins
+          value: quay.io/kubevirt/cni-default-plugins:latest
         - name: SRIOV_DP_IMAGE
           value: quay.io/booxter/sriov-device-plugin:latest
         - name: SRIOV_CNI_IMAGE

--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -13,7 +13,42 @@ import (
 
 const Name = "cluster-network-addons-operator"
 
-func GetDeployment(repository string, tag string, imagePullPolicy string) *appsv1.Deployment {
+const (
+	MultusImageDefault         = "docker.io/nfvpe/multus:latest"
+	LinuxBridgeCniImageDefault = "quay.io/kubevirt/cni-default-plugins:latest"
+	SriovDpImageDefault        = "quay.io/booxter/sriov-device-plugin:latest"
+	SriovCniImageDefault       = "docker.io/nfvpe/sriov-cni:latest"
+	KubeMacPoolImageDefault    = "quay.io/schseba/mac-controller:latest"
+)
+
+type AddonsImages struct {
+	Multus         string
+	LinuxBridgeCni string
+	SriovDp        string
+	SriovCni       string
+	KubeMacPool    string
+}
+
+func (ai *AddonsImages) FillDefaults() *AddonsImages {
+	if ai.Multus == "" {
+		ai.Multus = MultusImageDefault
+	}
+	if ai.LinuxBridgeCni == "" {
+		ai.LinuxBridgeCni = LinuxBridgeCniImageDefault
+	}
+	if ai.SriovDp == "" {
+		ai.SriovDp = SriovDpImageDefault
+	}
+	if ai.SriovCni == "" {
+		ai.SriovCni = SriovCniImageDefault
+	}
+	if ai.KubeMacPool == "" {
+		ai.KubeMacPool = KubeMacPoolImageDefault
+	}
+	return ai
+}
+
+func GetDeployment(repository string, tag string, imagePullPolicy string, addonsImages *AddonsImages) *appsv1.Deployment {
 	image := fmt.Sprintf("%s/%s:%s", repository, Name, tag)
 	deployment := &appsv1.Deployment{
 		TypeMeta: metav1.TypeMeta{
@@ -47,19 +82,19 @@ func GetDeployment(repository string, tag string, imagePullPolicy string) *appsv
 							Env: []corev1.EnvVar{
 								{
 									Name:  "MULTUS_IMAGE",
-									Value: "docker.io/nfvpe/multus:latest",
+									Value: addonsImages.Multus,
 								},
 								{
 									Name:  "LINUX_BRIDGE_IMAGE",
-									Value: "quay.io/kubevirt/cni-default-plugins",
+									Value: addonsImages.LinuxBridgeCni,
 								},
 								{
 									Name:  "SRIOV_DP_IMAGE",
-									Value: "quay.io/booxter/sriov-device-plugin:latest",
+									Value: addonsImages.SriovDp,
 								},
 								{
 									Name:  "SRIOV_CNI_IMAGE",
-									Value: "docker.io/nfvpe/sriov-cni:latest",
+									Value: addonsImages.SriovCni,
 								},
 								{
 									Name:  "SRIOV_ROOT_DEVICES",
@@ -67,7 +102,7 @@ func GetDeployment(repository string, tag string, imagePullPolicy string) *appsv
 								},
 								{
 									Name:  "KUBEMACPOOL_IMAGE",
-									Value: "quay.io/schseba/mac-controller:latest",
+									Value: addonsImages.KubeMacPool,
 								},
 								{
 									Name:  "OPERATOR_IMAGE",

--- a/tools/manifest-templator/manifest-templator.go
+++ b/tools/manifest-templator/manifest-templator.go
@@ -56,6 +56,7 @@ type templateData struct {
 	ContainerTag    string
 	ImagePullPolicy string
 	CNA             *operatorData
+	AddonsImages    *components.AddonsImages
 }
 
 func check(err error) {
@@ -138,6 +139,7 @@ func getCNA(data *templateData) {
 		data.ContainerPrefix,
 		data.ContainerTag,
 		data.ImagePullPolicy,
+		data.AddonsImages,
 	)
 	err := marshallObject(cnadeployment, &writer)
 	check(err)
@@ -213,6 +215,11 @@ func main() {
 	csvReplaces := flag.String("csv-replaces", "", "")
 	imagePullPolicy := flag.String("image-pull-policy", "Always", "")
 	inputFile := flag.String("input-file", "", "")
+	multusImage := flag.String("multus-image", "", "")
+	linuxBridgeCniImage := flag.String("linux-bridge-cni-image", "", "")
+	sriovDpImage := flag.String("sriov-dp-image", "", "")
+	sriovCniImage := flag.String("sriov-cni-image", "", "")
+	kubeMacPoolImage := flag.String("kubemacpool-image", "", "")
 	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
 	pflag.CommandLine.ParseErrorsWhitelist.UnknownFlags = true
 	pflag.Parse()
@@ -224,6 +231,13 @@ func main() {
 		ContainerPrefix: *containerPrefix,
 		ContainerTag:    *containerTag,
 		ImagePullPolicy: *imagePullPolicy,
+		AddonsImages: (&components.AddonsImages{
+			Multus:         *multusImage,
+			LinuxBridgeCni: *linuxBridgeCniImage,
+			SriovDp:        *sriovDpImage,
+			SriovCni:       *sriovCniImage,
+			KubeMacPool:    *kubeMacPoolImage,
+		}).FillDefaults(),
 	}
 
 	// Load in all CNA Resources


### PR DESCRIPTION
With this patch it is possible to build alternative operator manifests
grabbing network addons from alternative registries.

Resolves #56 