### PR TITLE
fix deployment manifest links in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,16 +151,16 @@ spec:
 First install the operator itself:
 
 ```shell
-kubectl apply -f https://github.com/kubevirt/cluster-network-addons-operator/blob/master/manifests/cluster-network-addons/0.4.0/namespace.yaml
-kubectl apply -f https://github.com/kubevirt/cluster-network-addons-operator/blob/master/manifests/cluster-network-addons/0.4.0/network-addons-config.crd.yaml
-kubectl apply -f https://github.com/kubevirt/cluster-network-addons-operator/blob/master/manifests/cluster-network-addons/0.4.0/operator.yaml
+kubectl apply -f https://raw.githubusercontent.com/kubevirt/cluster-network-addons-operator/master/manifests/cluster-network-addons/0.4.0/namespace.yaml
+kubectl apply -f https://raw.githubusercontent.com/kubevirt/cluster-network-addons-operator/master/manifests/cluster-network-addons/0.4.0/network-addons-config.crd.yaml
+kubectl apply -f https://raw.githubusercontent.com/kubevirt/cluster-network-addons-operator/master/manifests/cluster-network-addons/0.4.0/operator.yaml
 ```
 
 Then you need to create a configuration for the operator [example
 CR](manifests/cluster-network-addons/0.4.0/network-addons-config-example.cr.yaml):
 
 ```shell
-kubectl apply -f https://github.com/kubevirt/cluster-network-addons-operator/releases/download/0.4.0/network-addons-config-example.cr.yaml
+kubectl apply -f https://raw.githubusercontent.com/kubevirt/cluster-network-addons-operator/master/manifests/cluster-network-addons/0.4.0/network-addons-config-example.cr.yaml
 ```
 
 Finally you can wait for the operator to finish deployment:


### PR DESCRIPTION
Current links are to github page, we need to link to raw content.