### PR TITLE
Call syncFailing on SetNotFailing method

### DIFF
--- a/pkg/controller/statusmanager/status_manager.go
+++ b/pkg/controller/statusmanager/status_manager.go
@@ -122,8 +122,8 @@ func (status *StatusManager) SetFailing(level StatusLevel, reason, message strin
 func (status *StatusManager) SetNotFailing(level StatusLevel) {
 	if status.failing[level] != nil {
 		status.failing[level] = nil
-		status.syncFailing()
 	}
+	status.syncFailing()
 }
 
 func (status *StatusManager) SetDaemonSets(daemonSets []types.NamespacedName) {


### PR DESCRIPTION
https://github.com/openshift/cluster-network-operator/pull/136:

Since nil is used as value for having a condition as
non failing, we need to call it outside of the if
otherwise the failing condition will always set to nil.