### PR TITLE
Add bridge-marker manifests

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,10 @@ spec:
 Additionally, container image used to deliver this plugin can be set using
 `LINUX_BRIDGE_IMAGE` environment variable in operator deployment manifest.
 
+The bridge marker image used to deliver a bridge marker detecting the availability
+of linux bridges on nodes can be set using the `LINUX_BRIDGE_MARKER_IMAGE` environment
+variable in operator deployment manifest.
+
 ## SR-IOV
 
 The operator allows administrator to deploy SR-IOV

--- a/data/linux-bridge/0004-bridge-marker-daemonset.yaml
+++ b/data/linux-bridge/0004-bridge-marker-daemonset.yaml
@@ -1,0 +1,35 @@
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: bridge-marker
+  namespace: linux-bridge
+  labels:
+    tier: node
+    app: bridge-marker
+spec:
+  template:
+    metadata:
+      labels:
+        tier: node
+        app: bridge-marker
+    spec:
+      serviceAccountName: bridge-marker
+      hostNetwork: true
+      nodeSelector:
+        beta.kubernetes.io/arch: amd64
+      tolerations:
+      - key: node-role.kubernetes.io/master
+        operator: Exists
+        effect: NoSchedule
+      containers:
+      - name: bridge-marker
+        image: {{ .LinuxBridgeMarkerImage }}
+        imagePullPolicy: {{ .ImagePullPolicy }}
+        args:
+          - -node-name
+          - $(NODE_NAME)
+        env:
+          - name: NODE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName

--- a/data/linux-bridge/003-bridge-marker-rbac.yaml
+++ b/data/linux-bridge/003-bridge-marker-rbac.yaml
@@ -1,0 +1,48 @@
+apiVersion: extensions/v1beta1
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: bridge-marker-cr
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  - nodes/status
+  verbs:
+  - get
+  - update
+  - patch
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: bridge-marker-crb
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: bridge-marker-cr
+subjects:
+- kind: ServiceAccount
+  name: bridge-marker
+  namespace: linux-bridge
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: bridge-marker
+  namespace: linux-bridge
+{{ if .EnableSCC }}
+---
+apiVersion: security.openshift.io/v1
+kind: SecurityContextConstraints
+metadata:
+  name: bridge-marker
+allowHostNetwork: true
+runAsUser:
+  type: RunAsAny
+seLinuxContext:
+  type: RunAsAny
+users:
+- system:serviceaccount:linux-bridge:bridge-marker
+{{ end }}

--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -14,19 +14,21 @@ import (
 const Name = "cluster-network-addons-operator"
 
 const (
-	MultusImageDefault         = "docker.io/nfvpe/multus:latest"
-	LinuxBridgeCniImageDefault = "quay.io/kubevirt/cni-default-plugins:v0.1.0"
-	SriovDpImageDefault        = "quay.io/booxter/sriov-device-plugin:latest"
-	SriovCniImageDefault       = "docker.io/nfvpe/sriov-cni:latest"
-	KubeMacPoolImageDefault    = "quay.io/kubevirt/kubemacpool:v0.2.0"
+	MultusImageDefault            = "docker.io/nfvpe/multus:latest"
+	LinuxBridgeCniImageDefault    = "quay.io/kubevirt/cni-default-plugins:v0.1.0"
+	LinuxBridgeMarkerImageDefault = "quay.io/kubevirt/bridge-marker:0.1.0"
+	SriovDpImageDefault           = "quay.io/booxter/sriov-device-plugin:latest"
+	SriovCniImageDefault          = "docker.io/nfvpe/sriov-cni:latest"
+	KubeMacPoolImageDefault       = "quay.io/kubevirt/kubemacpool:v0.2.0"
 )
 
 type AddonsImages struct {
-	Multus         string
-	LinuxBridgeCni string
-	SriovDp        string
-	SriovCni       string
-	KubeMacPool    string
+	Multus            string
+	LinuxBridgeCni    string
+	LinuxBridgeMarker string
+	SriovDp           string
+	SriovCni          string
+	KubeMacPool       string
 }
 
 func (ai *AddonsImages) FillDefaults() *AddonsImages {
@@ -35,6 +37,9 @@ func (ai *AddonsImages) FillDefaults() *AddonsImages {
 	}
 	if ai.LinuxBridgeCni == "" {
 		ai.LinuxBridgeCni = LinuxBridgeCniImageDefault
+	}
+	if ai.LinuxBridgeMarker == "" {
+		ai.LinuxBridgeMarker = LinuxBridgeMarkerImageDefault
 	}
 	if ai.SriovDp == "" {
 		ai.SriovDp = SriovDpImageDefault
@@ -87,6 +92,10 @@ func GetDeployment(namespace string, repository string, tag string, imagePullPol
 								{
 									Name:  "LINUX_BRIDGE_IMAGE",
 									Value: addonsImages.LinuxBridgeCni,
+								},
+								{
+									Name:  "LINUX_BRIDGE_MARKER_IMAGE",
+									Value: addonsImages.LinuxBridgeMarker,
 								},
 								{
 									Name:  "SRIOV_DP_IMAGE",

--- a/pkg/network/linux-bridge.go
+++ b/pkg/network/linux-bridge.go
@@ -28,6 +28,7 @@ func renderLinuxBridge(conf *opv1alpha1.NetworkAddonsConfigSpec, manifestDir str
 
 	// render the manifests on disk
 	data := render.MakeRenderData()
+	data.Data["LinuxBridgeMarkerImage"] = os.Getenv("LINUX_BRIDGE_MARKER_IMAGE")
 	data.Data["LinuxBridgeImage"] = os.Getenv("LINUX_BRIDGE_IMAGE")
 	data.Data["ImagePullPolicy"] = conf.ImagePullPolicy
 	if clusterInfo.OpenShift4 {

--- a/tools/manifest-templator/manifest-templator.go
+++ b/tools/manifest-templator/manifest-templator.go
@@ -218,6 +218,7 @@ func main() {
 	inputFile := flag.String("input-file", "", "")
 	multusImage := flag.String("multus-image", "", "")
 	linuxBridgeCniImage := flag.String("linux-bridge-cni-image", "", "")
+	linuxBridgeMarkerImage := flag.String("linux-bridge-marker-image", "", "")
 	sriovDpImage := flag.String("sriov-dp-image", "", "")
 	sriovCniImage := flag.String("sriov-cni-image", "", "")
 	kubeMacPoolImage := flag.String("kubemacpool-image", "", "")
@@ -233,11 +234,12 @@ func main() {
 		ContainerTag:    *containerTag,
 		ImagePullPolicy: *imagePullPolicy,
 		AddonsImages: (&components.AddonsImages{
-			Multus:         *multusImage,
-			LinuxBridgeCni: *linuxBridgeCniImage,
-			SriovDp:        *sriovDpImage,
-			SriovCni:       *sriovCniImage,
-			KubeMacPool:    *kubeMacPoolImage,
+			Multus:            *multusImage,
+			LinuxBridgeCni:    *linuxBridgeCniImage,
+			LinuxBridgeMarker: *linuxBridgeMarkerImage,
+			SriovDp:           *sriovDpImage,
+			SriovCni:          *sriovCniImage,
+			KubeMacPool:       *kubeMacPoolImage,
 		}).FillDefaults(),
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds bridge-marker manifests to the linux bridge operator

**Release note**:
```release-note
The linux bridge operator will now add the bridge-marker daemon set.
```