### PR TITLE
Update the kubemacpool image to use tag v0.2.0 and not latest

### DIFF
--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -18,7 +18,7 @@ const (
 	LinuxBridgeCniImageDefault = "quay.io/kubevirt/cni-default-plugins:latest"
 	SriovDpImageDefault        = "quay.io/booxter/sriov-device-plugin:latest"
 	SriovCniImageDefault       = "docker.io/nfvpe/sriov-cni:latest"
-	KubeMacPoolImageDefault    = "quay.io/kubevirt/kubemacpool:latest"
+	KubeMacPoolImageDefault    = "quay.io/kubevirt/kubemacpool:v0.2.0"
 )
 
 type AddonsImages struct {


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubevirt/cluster-network-addons-operator/83)
<!-- Reviewable:end -->
