### PR TITLE
Pin sriovdp to specific version

### DIFF
--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -17,7 +17,7 @@ const (
 	MultusImageDefault            = "quay.io/kubevirt/cluster-network-addon-multus:v3.2.0-1.gitbf61002"
 	LinuxBridgeCniImageDefault    = "quay.io/kubevirt/cni-default-plugins:v0.1.0"
 	LinuxBridgeMarkerImageDefault = "quay.io/kubevirt/bridge-marker:0.1.0"
-	SriovDpImageDefault           = "quay.io/booxter/sriov-device-plugin:latest"
+	SriovDpImageDefault           = "quay.io/kubevirt/cluster-network-addon-sriov-device-plugin:v2.0.0-1.git9a20829"
 	SriovCniImageDefault          = "quay.io/kubevirt/cluster-network-addon-sriov-cni:v1.1.0-1.git9e4c973"
 	KubeMacPoolImageDefault       = "quay.io/kubevirt/kubemacpool:v0.2.0"
 )


### PR DESCRIPTION
This pin also bumps version to the latest in upstream master. It should
work fine because we already create sriovdp configuration file and the
latest image is not broken anymore. (It was at some point broken by
alpine change, which was the original reason to pin it in
kubevirt-ansible, from where the forked image migrated to this
operator).