### PR TITLE
Fill kubemacpool range in the fillDefaults function

### DIFF
--- a/pkg/apis/networkaddonsoperator/v1alpha1/networkaddonsconfig_types.go
+++ b/pkg/apis/networkaddonsoperator/v1alpha1/networkaddonsconfig_types.go
@@ -13,7 +13,7 @@ type NetworkAddonsConfigSpec struct {
 	Sriov           *Sriov            `json:"sriov,omitempty"`
 	KubeMacPool     *KubeMacPool      `json:"kubeMacPool,omitempty"`
 	ImagePullPolicy corev1.PullPolicy `json:"imagePullPolicy,omitempty"`
-	NMState         *NMState           `json:"nmstate,omitempty"`
+	NMState         *NMState          `json:"nmstate,omitempty"`
 }
 
 // +k8s:openapi-gen=true

--- a/pkg/controller/networkaddonsconfig/networkaddonsconfig_controller.go
+++ b/pkg/controller/networkaddonsconfig/networkaddonsconfig_controller.go
@@ -241,7 +241,11 @@ func (r *ReconcileNetworkAddonsConfig) renderObjects(networkAddonsConfig *opv1al
 	}
 
 	// Fill all defaults explicitly
-	network.FillDefaults(&networkAddonsConfig.Spec, prev)
+	if err := network.FillDefaults(&networkAddonsConfig.Spec, prev); err != nil {
+		log.Printf("failed to fill defaults: %v", err)
+		errors.Wrapf(err, "failed to fill defaults: %v", err)
+		return objs, err
+	}
 
 	// Compare against previous applied configuration to see if this change
 	// is safe.

--- a/pkg/network/image-pull-policy.go
+++ b/pkg/network/image-pull-policy.go
@@ -21,7 +21,7 @@ func validateImagePullPolicy(conf *opv1alpha1.NetworkAddonsConfigSpec) []error {
 	return []error{}
 }
 
-func fillDefaultsImagePullPolicy(conf, previous *opv1alpha1.NetworkAddonsConfigSpec) {
+func fillDefaultsImagePullPolicy(conf, previous *opv1alpha1.NetworkAddonsConfigSpec) []error {
 	if conf.ImagePullPolicy == "" {
 		if previous != nil && previous.ImagePullPolicy != "" {
 			conf.ImagePullPolicy = previous.ImagePullPolicy
@@ -29,13 +29,15 @@ func fillDefaultsImagePullPolicy(conf, previous *opv1alpha1.NetworkAddonsConfigS
 			conf.ImagePullPolicy = defaultImagePullPolicy
 		}
 	}
+
+	return []error{}
 }
 
 func changeSafeImagePullPolicy(prev, next *opv1alpha1.NetworkAddonsConfigSpec) []error {
 	if prev.ImagePullPolicy != "" && prev.ImagePullPolicy != next.ImagePullPolicy {
 		return []error{errors.Errorf("cannot modify ImagePullPolicy configuration once components were deployed")}
 	}
-	return nil
+	return []error{}
 }
 
 // Verify if the value is a valid PullPolicy

--- a/pkg/network/network.go
+++ b/pkg/network/network.go
@@ -37,8 +37,17 @@ func Validate(conf *opv1alpha1.NetworkAddonsConfigSpec, openshiftNetworkConfig *
 //
 // Defaults are carried forward from previous if it is provided. This is so we
 // can change defaults as we move forward, but won't disrupt existing clusters.
-func FillDefaults(conf, previous *opv1alpha1.NetworkAddonsConfigSpec) {
-	fillDefaultsImagePullPolicy(conf, previous)
+func FillDefaults(conf, previous *opv1alpha1.NetworkAddonsConfigSpec) error {
+	errs := []error{}
+
+	errs = append(errs, fillDefaultsImagePullPolicy(conf, previous)...)
+	errs = append(errs, fillDefaultsKubeMacPool(conf, previous)...)
+
+	if len(errs) > 0 {
+		return errors.Errorf("invalid configuration:\n%s", errorListToMultiLineString(errs))
+	}
+
+	return nil
 }
 
 // IsChangeSafe checks to see if the change between prev and next are allowed


### PR DESCRIPTION
This PR moves the range generation from the render to the fillDefaults functions.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubevirt/cluster-network-addons-operator/99)
<!-- Reviewable:end -->
