### PR TITLE
Set NetworkManager as a requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,13 @@ The operator allows the administrator to deploy the [NmState State Controller](h
 This project manages host networking settings in a declarative manner. The networking state is described by a pre-defined schema. Reporting of current state and changes to it (desired state) both conform to the schema.
 Nmstate is aimed to satisfy enterprise needs to manage host networking through a northbound declarative API and multi provider support on the southbound. NetworkManager acts as the main (and currently the only) provider supported.
 
+It communicate with a NetworkManager instance running on the node using D-Bus. Make sure that NetworkManager is installed and running on each node.
+
+```shell
+yum install NetworkManager
+systemctl start NetworkManager
+```
+
 ## Image Pull Policy
 
 Administrator can specify [image pull policy](https://kubernetes.io/docs/concepts/containers/images/)

--- a/cluster/up.sh
+++ b/cluster/up.sh
@@ -68,3 +68,10 @@ echo 'Wait until all nodes are ready'
 until [[ $(./cluster/kubectl.sh get nodes --no-headers | wc -l) -eq $(./cluster/kubectl.sh get nodes --no-headers | grep ' Ready' | wc -l) ]]; do
     sleep 1
 done
+
+echo 'Install NetworkManager on nodes'
+for i in $(seq 1 ${KUBEVIRT_NUM_NODES}); do
+    ./cluster/cli.sh ssh "node$(printf "%02d" ${i})" -- sudo yum install -y NetworkManager
+    ./cluster/cli.sh ssh "node$(printf "%02d" ${i})" -- sudo systemctl daemon-reload
+    ./cluster/cli.sh ssh "node$(printf "%02d" ${i})" -- sudo systemctl restart NetworkManager
+done


### PR DESCRIPTION
Now that kubernetes-nmstate is supported it needs NetworkManager to be
installed on the hosts, this patch document that and also add the
installation process at make cluster-up