### PR TITLE
fix nmstate version to v0.1.0

### DIFF
--- a/data/nmstate/003-nmstated.yaml
+++ b/data/nmstate/003-nmstated.yaml
@@ -30,6 +30,10 @@ spec:
           - name: dbus-socket
             mountPath: /run/dbus/system_bus_socket
           env:
+          - name: NODE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
           - name: POD_NAME
             valueFrom:
               fieldRef:

--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -20,7 +20,7 @@ const (
 	SriovDpImageDefault             = "quay.io/kubevirt/cluster-network-addon-sriov-device-plugin:v2.0.0-1.git9a20829"
 	SriovCniImageDefault            = "quay.io/kubevirt/cluster-network-addon-sriov-cni:v1.1.0-1.git9e4c973"
 	KubeMacPoolImageDefault         = "quay.io/kubevirt/kubemacpool:v0.3.0"
-	NMStateStateHandlerImageDefault = "quay.io/nmstate/kubernetes-nmstate-state-handler:latest"
+	NMStateStateHandlerImageDefault = "quay.io/nmstate/kubernetes-nmstate-state-handler:v0.1.0"
 )
 
 type AddonsImages struct {


### PR DESCRIPTION
We need to use fixed images version, otherwise, a change in :latest
component's image might be devastating in combination with manifests
shipped by us.