### PR TITLE
increase timeout for functional tests

### DIFF
--- a/cluster/functest.sh
+++ b/cluster/functest.sh
@@ -54,4 +54,4 @@ spec:
   nmstate: {}
 EOF
 assert_condition Progressing 60s
-assert_condition Ready 300s
+assert_condition Ready 600s


### PR DESCRIPTION
Now when we added nmstate component to the operator, deployment
takes even more time and we need to increase test timeout in
order to make it pass on STD-CI.