### PR TITLE
Bump linux bridge to v0.8.0

### DIFF
--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -15,7 +15,7 @@ const Name = "cluster-network-addons-operator"
 
 const (
 	MultusImageDefault              = "quay.io/kubevirt/cluster-network-addon-multus:v3.2.0-1.gitbf61002"
-	LinuxBridgeCniImageDefault      = "quay.io/kubevirt/cni-default-plugins:v0.1.0"
+	LinuxBridgeCniImageDefault      = "quay.io/kubevirt/cni-default-plugins:v0.8.0"
 	LinuxBridgeMarkerImageDefault   = "quay.io/kubevirt/bridge-marker:0.1.0"
 	SriovDpImageDefault             = "quay.io/kubevirt/cluster-network-addon-sriov-device-plugin:v2.0.0-1.git9a20829"
 	SriovCniImageDefault            = "quay.io/kubevirt/cluster-network-addon-sriov-cni:v1.1.0-1.git9e4c973"


### PR DESCRIPTION
This PR update the the linux_bridge image to use cni plugin version v0.8.0

CNI plugin version v0.8.0 contains the vlan feature for linux bridge

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubevirt/cluster-network-addons-operator/113)
<!-- Reviewable:end -->
