### PR TITLE
Release 0.9.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,9 @@
 all: fmt vet
 
 # Always keep the future version here, so we won't overwrite latest released manifests
-VERSION ?= 0.9.0
+VERSION ?= 0.10.0
 # Always keep the last released version here
-VERSION_REPLACES ?= 0.8.0
+VERSION_REPLACES ?= 0.9.0
 
 DEPLOY_DIR ?= manifests
 

--- a/README.md
+++ b/README.md
@@ -169,16 +169,16 @@ spec:
 First install the operator itself:
 
 ```shell
-kubectl apply -f https://raw.githubusercontent.com/kubevirt/cluster-network-addons-operator/master/manifests/cluster-network-addons/0.8.0/namespace.yaml
-kubectl apply -f https://raw.githubusercontent.com/kubevirt/cluster-network-addons-operator/master/manifests/cluster-network-addons/0.8.0/network-addons-config.crd.yaml
-kubectl apply -f https://raw.githubusercontent.com/kubevirt/cluster-network-addons-operator/master/manifests/cluster-network-addons/0.8.0/operator.yaml
+kubectl apply -f https://raw.githubusercontent.com/kubevirt/cluster-network-addons-operator/master/manifests/cluster-network-addons/0.9.0/namespace.yaml
+kubectl apply -f https://raw.githubusercontent.com/kubevirt/cluster-network-addons-operator/master/manifests/cluster-network-addons/0.9.0/network-addons-config.crd.yaml
+kubectl apply -f https://raw.githubusercontent.com/kubevirt/cluster-network-addons-operator/master/manifests/cluster-network-addons/0.9.0/operator.yaml
 ```
 
 Then you need to create a configuration for the operator [example
 CR](manifests/cluster-network-addons/0.4.0/network-addons-config-example.cr.yaml):
 
 ```shell
-kubectl apply -f https://raw.githubusercontent.com/kubevirt/cluster-network-addons-operator/master/manifests/cluster-network-addons/0.8.0/network-addons-config-example.cr.yaml
+kubectl apply -f https://raw.githubusercontent.com/kubevirt/cluster-network-addons-operator/master/manifests/cluster-network-addons/0.9.0/network-addons-config-example.cr.yaml
 ```
 
 Finally you can wait for the operator to finish deployment:
@@ -262,7 +262,7 @@ spec:
   name: cluster-network-addons
   source: cluster-network-addons
   sourceNamespace: openshift-operator-lifecycle-manager
-  startingCSV: cluster-network-addons-operator.0.8.0
+  startingCSV: cluster-network-addons-operator.0.9.0
 EOF
 ```
 

--- a/manifests/cluster-network-addons/0.9.0/cluster-network-addons-operator.0.9.0.clusterserviceversion.yaml
+++ b/manifests/cluster-network-addons/0.9.0/cluster-network-addons-operator.0.9.0.clusterserviceversion.yaml
@@ -1,0 +1,196 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  name: cluster-network-addons-operator.0.9.0
+  namespace: placeholder
+  annotations:
+    capabilities: "Full Lifecycle"
+    categories: "Network/Networking"
+    alm-examples: |
+      [
+        {
+          "apiVersion":"networkaddonsoperator.network.kubevirt.io/v1alpha1",
+          "kind":"NetworkAddonsConfig",
+          "metadata": {
+            "name":"cluster"
+          },
+          "spec": {
+            "multus":{},
+            "linuxBridge":{},
+            "sriov":{},
+            "kubeMacPool": {
+              "rangeStart": "02:00:00:00:00:00",
+              "rangeEnd": "FD:FF:FF:FF:FF:FF"
+            },
+            "nmstate":{},
+            "imagePullPolicy": "Always"
+          }
+        }
+      ]
+    description: Additional networking components for Kubernetes
+spec:
+  displayName: Cluster Network Addons
+  description: Deploy additional networking components for Kubernetes
+  keywords:
+    - KubeVirt
+    - Virtualization
+    - Networking
+    - Multus
+    - CNI
+    - macpool
+    - SR-IOV
+    - Bridge
+    - nmstate
+  version: 0.9.0
+  maturity: alpha
+
+  replaces: cluster-network-addons-operator.0.8.0
+
+  maintainers:
+    - name: KubeVirt project
+      email: kubevirt-dev@googlegroups.com
+  provider:
+    name: KubeVirt project
+  links:
+    - name: KubeVirt
+      url: https://kubevirt.io
+    - name: Source Code
+      url: https://github.com/kubevirt/cluster-network-addons-operator
+  icon: []
+  labels:
+    alm-owner-kubevirt: cluster-network-addons
+    operated-by: cluster-network-addons
+  selector:
+    matchLabels:
+      alm-owner-kubevirt: cluster-network-addons
+      operated-by: cluster-network-addons
+  installModes:
+    - type: OwnNamespace
+      supported: true
+    - type: SingleNamespace
+      supported: true
+    - type: MultiNamespace
+      supported: true
+    - type: AllNamespaces
+      supported: true
+  install:
+    strategy: deployment
+    spec:
+      permissions:
+        - serviceAccountName: cluster-network-addons-operator
+          rules:
+            - apiGroups:
+              - ""
+              resources:
+              - pods
+              - configmaps
+              verbs:
+              - get
+              - list
+              - watch
+              - create
+              - patch
+              - update
+              - delete
+            - apiGroups:
+              - apps
+              resources:
+              - deployments
+              - replicasets
+              verbs:
+              - get
+              - list
+              - watch
+              - create
+              - patch
+              - update
+              - delete
+
+      clusterPermissions:
+        - serviceAccountName: cluster-network-addons-operator
+          rules:
+            - apiGroups:
+              - security.openshift.io
+              resourceNames:
+              - privileged
+              resources:
+              - securitycontextconstraints
+              verbs:
+              - get
+              - list
+              - watch
+            - apiGroups:
+              - networkaddonsoperator.network.kubevirt.io
+              resources:
+              - networkaddonsconfigs
+              verbs:
+              - get
+              - list
+              - watch
+            - apiGroups:
+              - '*'
+              resources:
+              - '*'
+              verbs:
+              - '*'
+
+      deployments:
+        - name: cluster-network-addons-operator
+          spec:
+            replicas: 1
+            selector:
+              matchLabels:
+                name: cluster-network-addons-operator
+            strategy: {}
+            template:
+              metadata:
+                labels:
+                  name: cluster-network-addons-operator
+              spec:
+                containers:
+                - env:
+                  - name: MULTUS_IMAGE
+                    value: quay.io/kubevirt/cluster-network-addon-multus:v3.2.0-1.gitbf61002
+                  - name: LINUX_BRIDGE_IMAGE
+                    value: quay.io/kubevirt/cni-default-plugins:v0.8.0
+                  - name: LINUX_BRIDGE_MARKER_IMAGE
+                    value: quay.io/kubevirt/bridge-marker:0.1.0
+                  - name: SRIOV_DP_IMAGE
+                    value: quay.io/kubevirt/cluster-network-addon-sriov-device-plugin:v2.0.0-1.git9a20829
+                  - name: SRIOV_CNI_IMAGE
+                    value: quay.io/kubevirt/cluster-network-addon-sriov-cni:v1.1.0-1.git9e4c973
+                  - name: NMSTATE_STATE_HANDLER_IMAGE
+                    value: quay.io/nmstate/kubernetes-nmstate-state-handler:v0.2.0
+                  - name: SRIOV_ROOT_DEVICES
+                  - name: SRIOV_NETWORK_NAME
+                    value: sriov-network
+                  - name: SRIOV_NETWORK_TYPE
+                    value: sriov
+                  - name: KUBEMACPOOL_IMAGE
+                    value: quay.io/kubevirt/kubemacpool:v0.3.0
+                  - name: OPERATOR_IMAGE
+                    value: quay.io/kubevirt/cluster-network-addons-operator:0.9.0
+                  - name: OPERATOR_NAME
+                    value: cluster-network-addons-operator
+                  - name: OPERATOR_NAMESPACE
+                    valueFrom:
+                      fieldRef:
+                        fieldPath: metadata.namespace
+                  - name: POD_NAME
+                    valueFrom:
+                      fieldRef:
+                        fieldPath: metadata.name
+                  - name: WATCH_NAMESPACE
+                  image: quay.io/kubevirt/cluster-network-addons-operator:0.9.0
+                  imagePullPolicy: Always
+                  name: cluster-network-addons-operator
+                  resources: {}
+                serviceAccountName: cluster-network-addons-operator
+
+  customresourcedefinitions:
+    owned:
+      - name: networkaddonsconfigs.networkaddonsoperator.network.kubevirt.io
+        version: v1alpha1
+        kind: NetworkAddonsConfig
+        displayName: Cluster Network Addons
+        description: Cluster Network Addons

--- a/manifests/cluster-network-addons/0.9.0/namespace.yaml
+++ b/manifests/cluster-network-addons/0.9.0/namespace.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: cluster-network-addons-operator
+  labels:
+    name: cluster-network-addons-operator

--- a/manifests/cluster-network-addons/0.9.0/network-addons-config-example.cr.yaml
+++ b/manifests/cluster-network-addons/0.9.0/network-addons-config-example.cr.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: networkaddonsoperator.network.kubevirt.io/v1alpha1
+kind: NetworkAddonsConfig
+metadata:
+  name: cluster
+spec:
+  imagePullPolicy: Always
+  kubeMacPool: {}
+  linuxBridge: {}
+  multus: {}
+  nmstate: {}
+  sriov: {}

--- a/manifests/cluster-network-addons/0.9.0/network-addons-config.crd.yaml
+++ b/manifests/cluster-network-addons/0.9.0/network-addons-config.crd.yaml
@@ -1,0 +1,33 @@
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: networkaddonsconfigs.networkaddonsoperator.network.kubevirt.io
+spec:
+  group: networkaddonsoperator.network.kubevirt.io
+  names:
+    kind: NetworkAddonsConfig
+    listKind: NetworkAddonsConfigList
+    plural: networkaddonsconfigs
+    singular: networkaddonsconfig
+  scope: Cluster
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          type: string
+        kind:
+          type: string
+        metadata:
+          type: object
+        spec:
+          type: object
+        status:
+          type: object
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true

--- a/manifests/cluster-network-addons/0.9.0/operator.yaml
+++ b/manifests/cluster-network-addons/0.9.0/operator.yaml
@@ -1,0 +1,166 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    kubevirt.io: ""
+  name: cluster-network-addons-operator
+  namespace: cluster-network-addons-operator
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    name: cluster-network-addons-operator
+  name: cluster-network-addons-operator
+rules:
+- apiGroups:
+  - security.openshift.io
+  resourceNames:
+  - privileged
+  resources:
+  - securitycontextconstraints
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - networkaddonsoperator.network.kubevirt.io
+  resources:
+  - networkaddonsconfigs
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - '*'
+  resources:
+  - '*'
+  verbs:
+  - '*'
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    kubevirt.io: ""
+  name: cluster-network-addons-operator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-network-addons-operator
+subjects:
+  - kind: ServiceAccount
+    name: cluster-network-addons-operator
+    namespace: cluster-network-addons-operator
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    name: cluster-network-addons-operator
+  name: cluster-network-addons-operator
+  namespace: cluster-network-addons-operator
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - patch
+  - update
+  - delete
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  - replicasets
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - patch
+  - update
+  - delete
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    kubevirt.io: ""
+  name: cluster-network-addons-operator
+  namespace: cluster-network-addons-operator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: cluster-network-addons-operator
+subjects:
+  - kind: ServiceAccount
+    name: cluster-network-addons-operator
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cluster-network-addons-operator
+  namespace: cluster-network-addons-operator
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: cluster-network-addons-operator
+  strategy: {}
+  template:
+    metadata:
+      labels:
+        name: cluster-network-addons-operator
+    spec:
+      containers:
+      - env:
+        - name: MULTUS_IMAGE
+          value: quay.io/kubevirt/cluster-network-addon-multus:v3.2.0-1.gitbf61002
+        - name: LINUX_BRIDGE_IMAGE
+          value: quay.io/kubevirt/cni-default-plugins:v0.8.0
+        - name: LINUX_BRIDGE_MARKER_IMAGE
+          value: quay.io/kubevirt/bridge-marker:0.1.0
+        - name: SRIOV_DP_IMAGE
+          value: quay.io/kubevirt/cluster-network-addon-sriov-device-plugin:v2.0.0-1.git9a20829
+        - name: SRIOV_CNI_IMAGE
+          value: quay.io/kubevirt/cluster-network-addon-sriov-cni:v1.1.0-1.git9e4c973
+        - name: NMSTATE_STATE_HANDLER_IMAGE
+          value: quay.io/nmstate/kubernetes-nmstate-state-handler:v0.2.0
+        - name: SRIOV_ROOT_DEVICES
+        - name: SRIOV_NETWORK_NAME
+          value: sriov-network
+        - name: SRIOV_NETWORK_TYPE
+          value: sriov
+        - name: KUBEMACPOOL_IMAGE
+          value: quay.io/kubevirt/kubemacpool:v0.3.0
+        - name: OPERATOR_IMAGE
+          value: quay.io/kubevirt/cluster-network-addons-operator:0.9.0
+        - name: OPERATOR_NAME
+          value: cluster-network-addons-operator
+        - name: OPERATOR_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: WATCH_NAMESPACE
+        image: quay.io/kubevirt/cluster-network-addons-operator:0.9.0
+        imagePullPolicy: Always
+        name: cluster-network-addons-operator
+        resources: {}
+      serviceAccountName: cluster-network-addons-operator

--- a/manifests/cluster-network-addons/cluster-network-addons.package.yaml
+++ b/manifests/cluster-network-addons/cluster-network-addons.package.yaml
@@ -1,4 +1,4 @@
 packageName: cluster-network-addons
 channels:
 - name: alpha
-  currentCSV: cluster-network-addons-operator.0.8.0
+  currentCSV: cluster-network-addons-operator.0.9.0


### PR DESCRIPTION
This release contains:
* linux bridge version v0.8.0 using https://github.com/containernetworking/plugins/releases/tag/v0.8.0
* nmstate version v0.2.0 using https://github.com/nmstate/kubernetes-nmstate/releases/tag/v0.2.0

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubevirt/cluster-network-addons-operator/115)
<!-- Reviewable:end -->
