### PR TITLE
update status even with empty configuration

### DIFF
--- a/pkg/controller/networkaddonsconfig/networkaddonsconfig_controller.go
+++ b/pkg/controller/networkaddonsconfig/networkaddonsconfig_controller.go
@@ -206,7 +206,10 @@ func (r *ReconcileNetworkAddonsConfig) Reconcile(request reconcile.Request) (rec
 	r.statusManager.SetNotFailing(statusmanager.OperatorConfig)
 
 	// From now on, r.podReconciler takes over NetworkAddonsConfig handling, it will track deployed
-	// objects and set NetworkAddonsConfig.Status accordingly
+	// objects if needed and set NetworkAddonsConfig.Status accordingly. However, if no pod was
+	// deployed, there is nothing that would trigger initial reconciliation. Therefore, let's
+	// perform the first check manually.
+	r.statusManager.SetFromPods()
 
 	return reconcile.Result{}, nil
 }


### PR DESCRIPTION
There is a bug, where after deployment of an empty NetworkAddonsConfig
Spec, we never set condition to running (that is usually done by Pod
reconciliation process after we reconcile the first monitored pod).
When however there are no pods being monitored, we never update the
status.

This patch triggers initial status update right after NodeNetworkConfig
reconciliation is done.