### PR TITLE
reset list of tracked pods after CR removal

### DIFF
--- a/pkg/controller/networkaddonsconfig/networkaddonsconfig_controller.go
+++ b/pkg/controller/networkaddonsconfig/networkaddonsconfig_controller.go
@@ -175,6 +175,10 @@ func (r *ReconcileNetworkAddonsConfig) Reconcile(request reconcile.Request) (rec
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			// Request object not found, could have been deleted after reconcile request.
+			// Reset list of tracked objects.
+			// TODO: This can be dropped once we implement a finalizer waiting for all components to be removed
+			r.trackDeployedObjects([]*unstructured.Unstructured{})
+
 			// Owned objects are automatically garbage collected. Return and don't requeue
 			return reconcile.Result{}, nil
 		}


### PR DESCRIPTION
There is a bug where after NetworkAddonsConfig removal, we never
remove unprovisioned component pods from our tracked list. Due to
that, after recreation of NodeAddonsConfig, we fail because of missing
pods.

With this patch we make sure that during NetworkAddonsConfig removal,
we reset the list.