### PR TITLE
fix bridge-marker daemonset type

### DIFF
--- a/data/linux-bridge/0004-bridge-marker-daemonset.yaml
+++ b/data/linux-bridge/0004-bridge-marker-daemonset.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: bridge-marker
@@ -7,9 +7,13 @@ metadata:
     tier: node
     app: bridge-marker
 spec:
+  selector:
+    matchLabels:
+      name: bridge-marker
   template:
     metadata:
       labels:
+        name: bridge-marker
         tier: node
         app: bridge-marker
     spec:


### PR DESCRIPTION
Upgrade bridge-marker daemonset's apiVersion to apps/v1. Without
this change, status_monitor cannot observe changes in its pods.