### PR TITLE
set not failing only after setting progressing

### DIFF
--- a/pkg/controller/networkaddonsconfig/networkaddonsconfig_controller.go
+++ b/pkg/controller/networkaddonsconfig/networkaddonsconfig_controller.go
@@ -205,15 +205,15 @@ func (r *ReconcileNetworkAddonsConfig) Reconcile(request reconcile.Request) (rec
 	// Track state of all deployed pods
 	r.trackDeployedObjects(objs)
 
-	// Everything went smooth, remove failures from NetworkAddonsConfig if there are any from
-	// previous runs.
-	r.statusManager.SetNotFailing(statusmanager.OperatorConfig)
-
 	// From now on, r.podReconciler takes over NetworkAddonsConfig handling, it will track deployed
 	// objects if needed and set NetworkAddonsConfig.Status accordingly. However, if no pod was
 	// deployed, there is nothing that would trigger initial reconciliation. Therefore, let's
 	// perform the first check manually.
 	r.statusManager.SetFromPods()
+
+	// Everything went smooth, remove failures from NetworkAddonsConfig if there are any from
+	// previous runs.
+	r.statusManager.SetNotFailing(statusmanager.OperatorConfig)
 
 	return reconcile.Result{}, nil
 }

--- a/pkg/controller/statusmanager/status_manager.go
+++ b/pkg/controller/statusmanager/status_manager.go
@@ -247,9 +247,6 @@ func (status *StatusManager) SetFromPods() {
 		}
 	}
 
-	// If all pods are being created, mark deployment as not failing
-	status.SetNotFailing(PodDeployment)
-
 	// If there are any progressing Pods, list them in the condition with their state. Otherwise,
 	// mark NetworkAddonsConfig as "Ready".
 	if len(progressing) > 0 {
@@ -273,6 +270,9 @@ func (status *StatusManager) SetFromPods() {
 			},
 		)
 	}
+
+	// If all pods are being created, mark deployment as not failing
+	status.SetNotFailing(PodDeployment)
 }
 
 // Set condition in the Status field. In case condition with given Type already exists, update it.


### PR DESCRIPTION
We have to remove failures only after we add progressing condition. If
we do it the other way, we will have Ready=True for a moment before
Progressing=True takes place.