### PR TITLE
specify minKubeVersion in CSV

### DIFF
--- a/templates/cluster-network-addons/VERSION/cluster-network-addons-operator.VERSION.clusterserviceversion.yaml.in
+++ b/templates/cluster-network-addons/VERSION/cluster-network-addons-operator.VERSION.clusterserviceversion.yaml.in
@@ -42,6 +42,7 @@ spec:
     - Bridge
     - nmstate
   version: {{.Version}}
+  minKubeVersion: 1.10.0
   maturity: alpha
 {{if .VersionReplaces}}
   replaces: cluster-network-addons-operator.{{.VersionReplaces}}


### PR DESCRIPTION
Without this parameter specified, CSV reports failing status:

```
  requirementStatus:
  - group: operators.coreos.com
    kind: ClusterServiceVersion
    message: CSV missing minimum kube version specification
    name: cluster-network-addons-operator.0.9.0
    status: NotPresent
    version: v1alpha1
```