### PR TITLE
use IfNotPresent pull policy in examples

### DIFF
--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -355,7 +355,7 @@ func GetCR() *cnav1alpha1.NetworkAddonsConfig {
 			Sriov:           &cnav1alpha1.Sriov{},
 			KubeMacPool:     &cnav1alpha1.KubeMacPool{},
 			NMState:         &cnav1alpha1.NMState{},
-			ImagePullPolicy: "Always",
+			ImagePullPolicy: corev1.PullIfNotPresent,
 		},
 	}
 }

--- a/templates/cluster-network-addons/VERSION/cluster-network-addons-operator.VERSION.clusterserviceversion.yaml.in
+++ b/templates/cluster-network-addons/VERSION/cluster-network-addons-operator.VERSION.clusterserviceversion.yaml.in
@@ -23,7 +23,7 @@ metadata:
               "rangeEnd": "FD:FF:FF:FF:FF:FF"
             },
             "nmstate":{},
-            "imagePullPolicy": "Always"
+            "imagePullPolicy": "IfNotPresent"
           }
         }
       ]


### PR DESCRIPTION
Let's use the default policy "IfNotPresent" in our examples. That
makes sure that users trying this out won't repull images all the
time.