### PR TITLE
fix description and category in CSV

### DIFF
--- a/templates/cluster-network-addons/VERSION/cluster-network-addons-operator.VERSION.clusterserviceversion.yaml.in
+++ b/templates/cluster-network-addons/VERSION/cluster-network-addons-operator.VERSION.clusterserviceversion.yaml.in
@@ -5,7 +5,7 @@ metadata:
   namespace: placeholder
   annotations:
     capabilities: "Full Lifecycle"
-    categories: "Network/Networking"
+    categories: "Networking"
     alm-examples: |
       [
         {
@@ -32,8 +32,6 @@ spec:
   displayName: Cluster Network Addons
   description: Deploy additional networking components for Kubernetes
   keywords:
-    - KubeVirt
-    - Virtualization
     - Networking
     - Multus
     - CNI
@@ -41,6 +39,8 @@ spec:
     - SR-IOV
     - Bridge
     - nmstate
+    - KubeVirt
+    - Virtualization
   version: {{.Version}}
   maturity: alpha
 {{if .VersionReplaces}}
@@ -52,9 +52,7 @@ spec:
   provider:
     name: KubeVirt project
   links:
-    - name: KubeVirt
-      url: https://kubevirt.io
-    - name: Source Code
+    - name: Cluster Network Addons Operator
       url: https://github.com/kubevirt/cluster-network-addons-operator
   icon: []
   labels:


### PR DESCRIPTION
Category should be just "Networking", this category is already available
on operatorhub.io.

For GitHub link, be more explicit and state that it is Cluster Network
Addons Operator's homepage.