### PR TITLE
drop additional manifests from bundle

### DIFF
--- a/build/registry/Dockerfile
+++ b/build/registry/Dockerfile
@@ -2,6 +2,10 @@ FROM quay.io/openshift/origin-operator-registry
 
 COPY manifests /registry
 
+# Bundle should include only manifests related to the CSV,
+# drop all additional files.
+RUN find /registry/cluster-network-addons/*/ -type f ! -name '*.crd.*' ! -name '*.clusterserviceversion.*' -exec rm -f {} \;
+
 # Initialize the database
 RUN initializer --manifests /registry --output bundles.db
 


### PR DESCRIPTION
All manifests included in OLM bundle are automatically installed.
Therefore, we have to remove all extra manifests (e.g. namespace,
RBAC, deployment) from our bundle while building it.