### PR TITLE
keep operator version as env variable

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -33,6 +33,7 @@ func printVersion() {
 	log.Printf("Go Version: %s", runtime.Version())
 	log.Printf("Go OS/Arch: %s/%s", runtime.GOOS, runtime.GOARCH)
 	log.Printf("version of operator-sdk: %v", sdkVersion.Version)
+	log.Printf("version of cluster-network-addons-operator: %v", os.Getenv("OPERATOR_VERSION"))
 }
 
 func main() {

--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -58,7 +58,7 @@ func (ai *AddonsImages) FillDefaults() *AddonsImages {
 	return ai
 }
 
-func GetDeployment(namespace string, repository string, tag string, imagePullPolicy string, addonsImages *AddonsImages) *appsv1.Deployment {
+func GetDeployment(version string, namespace string, repository string, tag string, imagePullPolicy string, addonsImages *AddonsImages) *appsv1.Deployment {
 	image := fmt.Sprintf("%s/%s:%s", repository, Name, tag)
 	deployment := &appsv1.Deployment{
 		TypeMeta: metav1.TypeMeta{
@@ -137,6 +137,10 @@ func GetDeployment(namespace string, repository string, tag string, imagePullPol
 								{
 									Name:  "OPERATOR_NAME",
 									Value: Name,
+								},
+								{
+									Name:  "OPERATOR_VERSION",
+									Value: version,
 								},
 								{
 									Name: "OPERATOR_NAMESPACE",

--- a/tools/manifest-templator/manifest-templator.go
+++ b/tools/manifest-templator/manifest-templator.go
@@ -136,6 +136,7 @@ func getCNA(data *templateData) {
 
 	// Get CNA Deployment
 	cnadeployment := components.GetDeployment(
+		data.Version,
 		data.Namespace,
 		data.ContainerPrefix,
 		data.ContainerTag,


### PR DESCRIPTION
With this patch, we keep operator version as env variable of the
operator's deployment. In this patch we print it during operator's
startup. In following patches, it will be exposed also on
NetworkAddonsConfig CR.