### PR TITLE
Added missing quotes for sriov network type and name fields

### DIFF
--- a/data/sriov/004-sriov-network.yaml
+++ b/data/sriov/004-sriov-network.yaml
@@ -7,7 +7,7 @@ metadata:
     k8s.v1.cni.cncf.io/resourceName: intel.com/sriov
 spec:
   config: '{
-  "type": {{ .SriovNetworkType }},
-  "name": {{ .SriovNetworkName }},
+  "type": "{{ .SriovNetworkType }}",
+  "name": "{{ .SriovNetworkName }}",
   "ipam": {}
 }'


### PR DESCRIPTION
Otherwise multus fails to parse the config and pass it to CNI plugin.