### PR TITLE
fix Release sort

### DIFF
--- a/test/releases/releases.go
+++ b/test/releases/releases.go
@@ -37,9 +37,13 @@ func Releases() []Release {
 
 	sort.Slice(releases, func(a, b int) bool {
 		releaseAVersion, err := semver.Make(releases[a].Version)
-		Expect(err).NotTo(HaveOccurred())
+		if err != nil {
+			panic(err)
+		}
 		releaseBVersion, err := semver.Make(releases[b].Version)
-		Expect(err).NotTo(HaveOccurred())
+		if err != nil {
+			panic(err)
+		}
 		return releaseAVersion.LT(releaseBVersion)
 	})
 	releasesSorted = true


### PR DESCRIPTION
Let's not call gomega functions outside tests scope.