### PR TITLE
Add the option to change sriov type

### DIFF
--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -28,6 +28,16 @@ const (
 	NMStateHandlerImageDefault    = "quay.io/nmstate/kubernetes-nmstate-handler:v0.3.0"
 )
 
+const (
+	SriovNameDefault = "sriov-network"
+	SriovTypeDefault = "sriov"
+)
+
+type NetworkAttachmentDefinition struct {
+	SriovName string
+	SriovType string
+}
+
 type AddonsImages struct {
 	Multus            string
 	LinuxBridgeCni    string
@@ -36,6 +46,16 @@ type AddonsImages struct {
 	SriovCni          string
 	KubeMacPool       string
 	NMStateHandler    string
+}
+
+func (nad *NetworkAttachmentDefinition) FillDefaults() *NetworkAttachmentDefinition {
+	if nad.SriovName == "" {
+		nad.SriovName = SriovNameDefault
+	}
+	if nad.SriovType == "" {
+		nad.SriovType = SriovTypeDefault
+	}
+	return nad
 }
 
 func (ai *AddonsImages) FillDefaults() *AddonsImages {
@@ -63,7 +83,7 @@ func (ai *AddonsImages) FillDefaults() *AddonsImages {
 	return ai
 }
 
-func GetDeployment(version string, namespace string, repository string, tag string, imagePullPolicy string, addonsImages *AddonsImages) *appsv1.Deployment {
+func GetDeployment(version string, namespace string, repository string, tag string, imagePullPolicy string, addonsImages *AddonsImages, networkAttachmentDefinition *NetworkAttachmentDefinition) *appsv1.Deployment {
 	image := fmt.Sprintf("%s/%s:%s", repository, Name, tag)
 	deployment := &appsv1.Deployment{
 		TypeMeta: metav1.TypeMeta{
@@ -128,11 +148,11 @@ func GetDeployment(version string, namespace string, repository string, tag stri
 								},
 								{
 									Name:  "SRIOV_NETWORK_NAME",
-									Value: "sriov-network",
+									Value: networkAttachmentDefinition.SriovName,
 								},
 								{
 									Name:  "SRIOV_NETWORK_TYPE",
-									Value: "sriov",
+									Value: networkAttachmentDefinition.SriovType,
 								},
 								{
 									Name:  "KUBEMACPOOL_IMAGE",

--- a/tools/manifest-templator/manifest-templator.go
+++ b/tools/manifest-templator/manifest-templator.go
@@ -49,14 +49,15 @@ type operatorData struct {
 }
 
 type templateData struct {
-	Version         string
-	VersionReplaces string
-	Namespace       string
-	ContainerPrefix string
-	ContainerTag    string
-	ImagePullPolicy string
-	CNA             *operatorData
-	AddonsImages    *components.AddonsImages
+	Version                     string
+	VersionReplaces             string
+	Namespace                   string
+	ContainerPrefix             string
+	ContainerTag                string
+	ImagePullPolicy             string
+	CNA                         *operatorData
+	AddonsImages                *components.AddonsImages
+	NetworkAttachmentDefinition *components.NetworkAttachmentDefinition
 }
 
 func check(err error) {
@@ -142,6 +143,7 @@ func getCNA(data *templateData) {
 		data.ContainerTag,
 		data.ImagePullPolicy,
 		data.AddonsImages,
+		data.NetworkAttachmentDefinition,
 	)
 	err := marshallObject(cnadeployment, &writer)
 	check(err)
@@ -223,6 +225,8 @@ func main() {
 	sriovDpImage := flag.String("sriov-dp-image", "", "")
 	sriovCniImage := flag.String("sriov-cni-image", "", "")
 	kubeMacPoolImage := flag.String("kubemacpool-image", "", "")
+	sriovName := flag.String("sriov-name", "", "")
+	sriovType := flag.String("sriov-type", "", "")
 	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
 	pflag.CommandLine.ParseErrorsWhitelist.UnknownFlags = true
 	pflag.Parse()
@@ -241,6 +245,10 @@ func main() {
 			SriovDp:           *sriovDpImage,
 			SriovCni:          *sriovCniImage,
 			KubeMacPool:       *kubeMacPoolImage,
+		}).FillDefaults(),
+		NetworkAttachmentDefinition: (&components.NetworkAttachmentDefinition{
+			SriovName: *sriovName,
+			SriovType: *sriovType,
 		}).FillDefaults(),
 	}
 


### PR DESCRIPTION
Since sriov type is changed to 'cnv-sriov' in d/s,
adding an option to change it when gererating a CNA deployment manifest.

This importent for the the automatic build process
of the HCO

Signed-off-by: Ido Rosenzwig <irosenzw@redhat.com>