### PR TITLE
Bump kubemacpool version to v0.4.0

### DIFF
--- a/data/kubemacpool/003-deployment.yaml
+++ b/data/kubemacpool/003-deployment.yaml
@@ -55,14 +55,5 @@ spec:
             requests:
               cpu: 500m
               memory: 500Mi
-          volumeMounts:
-            - mountPath: /tmp/cert
-              name: cert
-              readOnly: true
       restartPolicy: Always
       terminationGracePeriodSeconds: 5
-      volumes:
-        - name: cert
-          secret:
-            defaultMode: 420
-            secretName: kubemacpool-webhook-secret

--- a/data/kubemacpool/003-secret.yaml
+++ b/data/kubemacpool/003-secret.yaml
@@ -1,6 +1,0 @@
----
-apiVersion: v1
-kind: Secret
-metadata:
-  name: kubemacpool-webhook-secret
-  namespace: kubemacpool-system

--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -24,7 +24,7 @@ const (
 	LinuxBridgeMarkerImageDefault = "quay.io/kubevirt/bridge-marker:0.1.0"
 	SriovDpImageDefault           = "quay.io/kubevirt/cluster-network-addon-sriov-device-plugin:v2.0.0-1.git9a20829"
 	SriovCniImageDefault          = "quay.io/kubevirt/cluster-network-addon-sriov-cni:v1.1.0-1.git9e4c973"
-	KubeMacPoolImageDefault       = "quay.io/kubevirt/kubemacpool:v0.3.0"
+	KubeMacPoolImageDefault       = "quay.io/kubevirt/kubemacpool:v0.4.0"
 	NMStateHandlerImageDefault    = "quay.io/nmstate/kubernetes-nmstate-handler:v0.3.0"
 )
 

--- a/test/releases/0.12.0.go
+++ b/test/releases/0.12.0.go
@@ -34,7 +34,7 @@ func init() {
 				ParentName: "kubemacpool-mac-controller-manager",
 				ParentKind: "Deployment",
 				Name:       "manager",
-				Image:      "quay.io/kubevirt/kubemacpool:v0.3.0",
+				Image:      "quay.io/kubevirt/kubemacpool:v0.4.0",
 			},
 		},
 		SupportedSpec: opv1alpha1.NetworkAddonsConfigSpec{


### PR DESCRIPTION
This version should allow us to remove the w/a waiting for kubemacpool

https://github.com/K8sNetworkPlumbingWG/kubemacpool/releases/tag/V0.4.0

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubevirt/cluster-network-addons-operator/185)
<!-- Reviewable:end -->
