### PR TITLE
Bump ovs to version v0.5.0

### DIFF
--- a/data/ovs/002-ovs-daemonset.yaml
+++ b/data/ovs/002-ovs-daemonset.yaml
@@ -37,7 +37,7 @@ spec:
               _ovs-vsctl --db unix:///run/openvswitch/db.sock $@
               ' > /host/usr/local/bin/ovs-vsctl
               chmod +x /host/usr/local/bin/ovs-vsctl
-          image: docker.io/openshift/origin-node:v3.10.0-rc.0
+          image: {{ .OvsCNIImage }}
           imagePullPolicy: {{ .ImagePullPolicy }}
           resources:
             requests:

--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -26,8 +26,8 @@ const (
 	SriovCniImageDefault          = "quay.io/kubevirt/cluster-network-addon-sriov-cni:v1.1.0-1.git9e4c973"
 	KubeMacPoolImageDefault       = "quay.io/kubevirt/kubemacpool:v0.4.0"
 	NMStateHandlerImageDefault    = "quay.io/nmstate/kubernetes-nmstate-handler:v0.3.0"
-	OvsCniImageDefault            = "quay.io/kubevirt/ovs-cni-plugin:v0.4.0"
-	OvsMarkerImageDefault         = "quay.io/kubevirt/ovs-cni-marker:v0.4.0"
+	OvsCniImageDefault            = "quay.io/kubevirt/ovs-cni-plugin:v0.5.0"
+	OvsMarkerImageDefault         = "quay.io/kubevirt/ovs-cni-marker:v0.5.0"
 )
 
 type AddonsImages struct {


### PR DESCRIPTION
This PR also remove the ocp image and copy the ovs-vsctl binary
directly from the ovs-cni image.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubevirt/cluster-network-addons-operator/191)
<!-- Reviewable:end -->
