### PR TITLE
identify OKD4 using NAO

### DIFF
--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -284,6 +284,19 @@ func GetClusterRole() *rbacv1.ClusterRole {
 			},
 			{
 				APIGroups: []string{
+					"operator.openshift.io",
+				},
+				Resources: []string{
+					"networks",
+				},
+				Verbs: []string{
+					"get",
+					"list",
+					"watch",
+				},
+			},
+			{
+				APIGroups: []string{
 					"networkaddonsoperator.network.kubevirt.io",
 				},
 				Resources: []string{

--- a/pkg/controller/networkaddonsconfig/networkaddonsconfig_controller.go
+++ b/pkg/controller/networkaddonsconfig/networkaddonsconfig_controller.go
@@ -406,7 +406,7 @@ func getOpenShiftNetworkConfig(ctx context.Context, c k8sclient.Client) (*osv1.N
 // Check whether running on OpenShift 4 by looking for operator objects that has been introduced
 // only in OpenShift 4
 func isRunningOnOpenShift4(c kubernetes.Interface) (bool, error) {
-	return isResourceAvailable(c, "configs", "imageregistry.operator.openshift.io", "v1")
+	return isResourceAvailable(c, "networks", "operator.openshift.io", "v1")
 }
 
 func isSCCAvailable(c kubernetes.Interface) (bool, error) {


### PR DESCRIPTION
In order to fix an issue with missing
configs.imageregistry.operator.openshift.io RBAC, let's use NAO
config to identify whether running on OKD4.

Resolves #189 