### PR TITLE
Fix life cycle test

### DIFF
--- a/test/e2e/lifecycle/upgrade_test.go
+++ b/test/e2e/lifecycle/upgrade_test.go
@@ -34,7 +34,12 @@ var _ = Context("Cluster Network Addons Operator", func() {
 					UninstallRelease(oldRelease)
 					InstallRelease(newRelease)
 					CheckOperatorIsReady(podsDeploymentTimeout)
-					ignoreInitialKubeMacPoolRestart()
+
+					// Check that operator and target versions will be set to the newer.
+					expectedOperatorVersion := newRelease.Version
+					expectedObservedVersion := newRelease.Version
+					expectedTargetVersion := newRelease.Version
+					CheckConfigVersions(expectedOperatorVersion, expectedObservedVersion, expectedTargetVersion, podsDeploymentTimeout, CheckDoNotRepeat)
 				})
 
 				It("it should report expected deployed container images", func() {


### PR DESCRIPTION
This PR fix the life cycle tests.
Before this PR the upgrade test where failing.

To fix the test I added a CheckConfigVersions in the BeforeEach function to wait for the operator to change the version in the cluster object.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubevirt/cluster-network-addons-operator/195)
<!-- Reviewable:end -->
