### PR TITLE
Add csv-generator to operator container image

### DIFF
--- a/build/operator/Dockerfile
+++ b/build/operator/Dockerfile
@@ -3,19 +3,25 @@ ENV GOPATH=/go
 WORKDIR /go/src/github.com/kubevirt/cluster-network-addons-operator/
 COPY . .
 RUN CGO_ENABLED=0 GOOS=linux go build -o /cluster-network-addons-operator github.com/kubevirt/cluster-network-addons-operator/cmd/manager
+RUN CGO_ENABLED=0 GOOS=linux go build -o /manifest-templator github.com/kubevirt/cluster-network-addons-operator/tools/manifest-templator
 
 FROM centos:centos7
 ENV ENTRYPOINT=/entrypoint \
     OPERATOR=/cluster-network-addons-operator \
+    MANIFEST_TEMPLATOR=/manifest-templator \
+    CSV_TEMPLATE=/cluster-network-addons-operator.VERSION.clusterserviceversion.yaml.in \
     USER_UID=1001 \
     USER_NAME=cluster-network-addons-operator
 RUN \
     yum -y update \
     yum clean all
 COPY --from=builder /go/src/github.com/kubevirt/cluster-network-addons-operator/build/operator/bin/user_setup /user_setup
+COPY --from=builder /go/src/github.com/kubevirt/cluster-network-addons-operator/build/operator/bin/csv-generator /usr/bin/csv-generator
+COPY --from=builder /go/src/github.com/kubevirt/cluster-network-addons-operator/templates/cluster-network-addons/VERSION/cluster-network-addons-operator.VERSION.clusterserviceversion.yaml.in cluster-network-addons-operator.VERSION.clusterserviceversion.yaml.in
 RUN /user_setup
 COPY --from=builder /go/src/github.com/kubevirt/cluster-network-addons-operator/data /data
 COPY --from=builder /cluster-network-addons-operator $OPERATOR
+COPY --from=builder /manifest-templator $MANIFEST_TEMPLATOR
 COPY --from=builder /go/src/github.com/kubevirt/cluster-network-addons-operator/build/operator/bin/entrypoint $ENTRYPOINT
 ENTRYPOINT $ENTRYPOINT
 USER $USER_UID

--- a/build/operator/bin/csv-generator
+++ b/build/operator/bin/csv-generator
@@ -1,0 +1,4 @@
+#!/bin/sh -e
+
+
+exec ${MANIFEST_TEMPLATOR} --input-file=${CSV_TEMPLATE} $@

--- a/tools/manifest-templator/manifest-templator.go
+++ b/tools/manifest-templator/manifest-templator.go
@@ -210,19 +210,22 @@ func getCNA(data *templateData) {
 }
 
 func main() {
-	version := flag.String("version", "", "")
-	versionReplaces := flag.String("version-replaces", "", "")
-	namespace := flag.String("namespace", components.Namespace, "")
-	containerPrefix := flag.String("container-prefix", "quay.io/kubevirt", "")
-	containerTag := flag.String("container-tag", "latest", "")
-	imagePullPolicy := flag.String("image-pull-policy", "Always", "")
-	inputFile := flag.String("input-file", "", "")
-	multusImage := flag.String("multus-image", "", "")
-	linuxBridgeCniImage := flag.String("linux-bridge-cni-image", "", "")
-	linuxBridgeMarkerImage := flag.String("linux-bridge-marker-image", "", "")
-	sriovDpImage := flag.String("sriov-dp-image", "", "")
-	sriovCniImage := flag.String("sriov-cni-image", "", "")
-	kubeMacPoolImage := flag.String("kubemacpool-image", "", "")
+	version := flag.String("version", "", "The csv version")
+	versionReplaces := flag.String("version-replaces", "", "The csv version this replaces")
+	namespace := flag.String("namespace", components.Namespace, "Namespace used by csv")
+	containerPrefix := flag.String("container-prefix", "quay.io/kubevirt", "The container repository used for the operator image")
+	containerTag := flag.String("container-tag", "latest", "The operator image's container tag")
+	imagePullPolicy := flag.String("image-pull-policy", "Always", "The pull policy to use on the operator image")
+	multusImage := flag.String("multus-image", components.MultusImageDefault, "The multus image managed by CNA")
+	linuxBridgeCniImage := flag.String("linux-bridge-cni-image", components.LinuxBridgeCniImageDefault, "The linux bridge cni image managed by CNA")
+	linuxBridgeMarkerImage := flag.String("linux-bridge-marker-image", components.LinuxBridgeMarkerImageDefault, "The linux bridge marker image managed by CNA")
+	sriovDpImage := flag.String("sriov-dp-image", components.SriovDpImageDefault, "The sriov-dp-image managed by CNA")
+	sriovCniImage := flag.String("sriov-cni-image", components.SriovCniImageDefault, "The sriov-cni-image managed by CNA")
+	kubeMacPoolImage := flag.String("kubemacpool-image", components.KubeMacPoolImageDefault, "The kubemacpool-image managed by CNA")
+	nmStateHandlerImage := flag.String("nm-state-handler-image", components.NMStateHandlerImageDefault, "The nmstate handler image managed by CNA")
+	ovsCniImage := flag.String("ovs-cni-image", components.OvsCniImageDefault, "The ovs cni image managed by CNA")
+	ovsMarkerImage := flag.String("ovs-marker-image", components.OvsMarkerImageDefault, "The ovs marker image managed by CNA")
+	inputFile := flag.String("input-file", "", "Not used for csv-generator")
 	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
 	pflag.CommandLine.ParseErrorsWhitelist.UnknownFlags = true
 	pflag.Parse()
@@ -241,6 +244,9 @@ func main() {
 			SriovDp:           *sriovDpImage,
 			SriovCni:          *sriovCniImage,
 			KubeMacPool:       *kubeMacPoolImage,
+			NMStateHandler:    *nmStateHandlerImage,
+			OvsCni:            *ovsCniImage,
+			OvsMarker:         *ovsMarkerImage,
 		}).FillDefaults(),
 	}
 


### PR DESCRIPTION
Every operator image that's integrated into the HCO is gaining the ability to dump a corresponding CSV file through the execution of the /usr/bin/csv-generator script/binary.

The CNA operator already has logic to generate the CSV, so this is as simple as including that logic into the operator container image. For consistency where this logic lives in all the other operator container images, the /usr/bin/csv-generator script was added as an entry point that redirects to the manifest-templator tool. 

HCO can use this to extract the corresponding CSV for a CNA operator build by executing the CNA operator's container.

**Example**
```
make docker-build-operator 
docker run --rm -it --entrypoint=/usr/bin/csv-generator quay.io/kubevirt/cluster-network-addons-operator:latest --version=1.1.1 > csv.yaml
```

The only other changes I made were to add some missing arguments related to images to the manifest-templator tool. 