### PR TITLE
increase test timeouts

### DIFF
--- a/test/e2e/lifecycle/deployment_test.go
+++ b/test/e2e/lifecycle/deployment_test.go
@@ -18,7 +18,7 @@ var _ = Context("Cluster Network Addons Operator", func() {
 		})
 
 		It("successfully turns ready", func() {
-			CheckOperatorIsReady(10 * time.Minute)
+			CheckOperatorIsReady(15 * time.Minute)
 		})
 
 		Context("and when NodeNetworkConfig with supported spec is created", func() {
@@ -27,7 +27,7 @@ var _ = Context("Cluster Network Addons Operator", func() {
 			})
 
 			It("reaches Available condition with all containers using expected images", func() {
-				CheckConfigCondition(ConditionAvailable, ConditionTrue, 10*time.Minute, CheckDoNotRepeat)
+				CheckConfigCondition(ConditionAvailable, ConditionTrue, 15*time.Minute, CheckDoNotRepeat)
 				CheckReleaseUsesExpectedContainerImages(masterRelease)
 			})
 
@@ -42,14 +42,14 @@ var _ = Context("Cluster Network Addons Operator", func() {
 
 					UninstallRelease(masterRelease)
 					InstallRelease(masterRelease)
-					CheckOperatorIsReady(10 * time.Minute)
+					CheckOperatorIsReady(15 * time.Minute)
 
 					// Give validator some time to verify conditions while the new installation is operating
 					time.Sleep(3 * time.Second)
 				}
 
 				// Wait until the configuration reaches Available state
-				CheckConfigCondition(ConditionAvailable, ConditionTrue, 10*time.Minute, CheckDoNotRepeat)
+				CheckConfigCondition(ConditionAvailable, ConditionTrue, 15*time.Minute, CheckDoNotRepeat)
 
 				// Make sure that configuration stays available during operator's reinstallation
 				KeepCheckingWhile(configIsAvailable, reinstallingOperator)

--- a/test/e2e/lifecycle/upgrade_test.go
+++ b/test/e2e/lifecycle/upgrade_test.go
@@ -11,7 +11,7 @@ import (
 	. "github.com/kubevirt/cluster-network-addons-operator/test/releases"
 )
 
-const podsDeploymentTimeout = 10 * time.Minute
+const podsDeploymentTimeout = 15 * time.Minute
 
 var _ = Context("Cluster Network Addons Operator", func() {
 	testUpgrade := func(oldRelease, newRelease Release) {
@@ -20,7 +20,7 @@ var _ = Context("Cluster Network Addons Operator", func() {
 				InstallRelease(oldRelease)
 				CheckOperatorIsReady(podsDeploymentTimeout)
 				CreateConfig(oldRelease.SupportedSpec)
-				CheckConfigCondition(ConditionAvailable, ConditionTrue, 10*time.Minute, CheckDoNotRepeat)
+				CheckConfigCondition(ConditionAvailable, ConditionTrue, 15*time.Minute, CheckDoNotRepeat)
 				ignoreInitialKubeMacPoolRestart()
 				CheckReleaseUsesExpectedContainerImages(oldRelease)
 				expectedOperatorVersion := oldRelease.Version

--- a/test/e2e/workflow/containers_test.go
+++ b/test/e2e/workflow/containers_test.go
@@ -19,7 +19,7 @@ var _ = Describe("NetworkAddonsConfig", func() {
 
 		BeforeEach(func() {
 			CreateConfig(configSpec)
-			CheckConfigCondition(ConditionAvailable, ConditionTrue, 10*time.Minute, CheckDoNotRepeat)
+			CheckConfigCondition(ConditionAvailable, ConditionTrue, 15*time.Minute, CheckDoNotRepeat)
 		})
 
 		It("should report non-empty list of deployed containers", func() {

--- a/test/e2e/workflow/deployment_test.go
+++ b/test/e2e/workflow/deployment_test.go
@@ -150,7 +150,7 @@ var _ = Describe("NetworkAddonsConfig", func() {
 
 		BeforeEach(func() {
 			CreateConfig(configSpec)
-			CheckConfigCondition(ConditionAvailable, ConditionTrue, 10*time.Minute, CheckDoNotRepeat)
+			CheckConfigCondition(ConditionAvailable, ConditionTrue, 15*time.Minute, CheckDoNotRepeat)
 		})
 
 		It("should remain in Available condition after applying the same config", func() {
@@ -166,7 +166,7 @@ var _ = Describe("NetworkAddonsConfig", func() {
 		It("should be able to remove the config and create it again", func() {
 			DeleteConfig()
 			CreateConfig(configSpec)
-			CheckConfigCondition(ConditionAvailable, ConditionTrue, 10*time.Minute, 30*time.Second)
+			CheckConfigCondition(ConditionAvailable, ConditionTrue, 15*time.Minute, 30*time.Second)
 		})
 	})
 
@@ -175,7 +175,7 @@ var _ = Describe("NetworkAddonsConfig", func() {
 			By("Deploying KubeMacPool")
 			config := opv1alpha1.NetworkAddonsConfigSpec{KubeMacPool: &opv1alpha1.KubeMacPool{}}
 			CreateConfig(config)
-			CheckConfigCondition(ConditionAvailable, ConditionTrue, 10*time.Minute, CheckDoNotRepeat)
+			CheckConfigCondition(ConditionAvailable, ConditionTrue, 15*time.Minute, CheckDoNotRepeat)
 		})
 
 		It("should modify the MAC range after being redeployed ", func() {
@@ -186,7 +186,7 @@ var _ = Describe("NetworkAddonsConfig", func() {
 
 			config := opv1alpha1.NetworkAddonsConfigSpec{KubeMacPool: &opv1alpha1.KubeMacPool{}}
 			CreateConfig(config)
-			CheckConfigCondition(ConditionAvailable, ConditionTrue, 10*time.Minute, CheckDoNotRepeat)
+			CheckConfigCondition(ConditionAvailable, ConditionTrue, 15*time.Minute, CheckDoNotRepeat)
 			rangeStart, rangeEnd := CheckUnicastAndValidity()
 
 			By("Comparing the ranges")
@@ -213,7 +213,7 @@ func checkConfigChange(components []Component) {
 
 		// Wait until Available condition is reported. It may take a few minutes the first time
 		// we are pulling component images to the Node
-		CheckConfigCondition(ConditionAvailable, ConditionTrue, 10*time.Minute, CheckDoNotRepeat)
+		CheckConfigCondition(ConditionAvailable, ConditionTrue, 15*time.Minute, CheckDoNotRepeat)
 		CheckConfigCondition(ConditionProgressing, ConditionFalse, CheckImmediately, CheckDoNotRepeat)
 
 		// Check that all requested components have been deployed

--- a/test/e2e/workflow/version_test.go
+++ b/test/e2e/workflow/version_test.go
@@ -26,7 +26,7 @@ var _ = Describe("NetworkAddonsConfig", func() {
 		})
 
 		It("should set observedVersion once turns it Available", func() {
-			CheckConfigCondition(ConditionAvailable, ConditionTrue, 10*time.Minute, CheckDoNotRepeat)
+			CheckConfigCondition(ConditionAvailable, ConditionTrue, 15*time.Minute, CheckDoNotRepeat)
 			CheckConfigVersions(operatorVersion, operatorVersion, operatorVersion, CheckImmediately, CheckDoNotRepeat)
 		})
 	})
@@ -37,7 +37,7 @@ var _ = Describe("NetworkAddonsConfig", func() {
 				Multus: &opv1alpha1.Multus{},
 			}
 			CreateConfig(configSpec)
-			CheckConfigCondition(ConditionAvailable, ConditionTrue, 10*time.Minute, CheckDoNotRepeat)
+			CheckConfigCondition(ConditionAvailable, ConditionTrue, 15*time.Minute, CheckDoNotRepeat)
 		})
 
 		It("should keep reported versions while being changed", func() {
@@ -55,7 +55,7 @@ var _ = Describe("NetworkAddonsConfig", func() {
 				time.Sleep(3 * time.Second)
 
 				UpdateConfig(configSpec)
-				CheckConfigCondition(ConditionAvailable, ConditionTrue, 10*time.Minute, CheckDoNotRepeat)
+				CheckConfigCondition(ConditionAvailable, ConditionTrue, 15*time.Minute, CheckDoNotRepeat)
 
 				// Give validator some time to verify versions while we stay in updated config
 				time.Sleep(3 * time.Second)


### PR DESCRIPTION
Now when we added more components to the operator, the first deployment
of all of them will take more time. Increase the timeout accordingly.