### PR TITLE
Bump ovs version to v0.6.0

### DIFF
--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -26,8 +26,8 @@ const (
 	SriovCniImageDefault          = "quay.io/kubevirt/cluster-network-addon-sriov-cni:v1.1.0-1.git9e4c973"
 	KubeMacPoolImageDefault       = "quay.io/kubevirt/kubemacpool:v0.4.0"
 	NMStateHandlerImageDefault    = "quay.io/nmstate/kubernetes-nmstate-handler:v0.6.0"
-	OvsCniImageDefault            = "quay.io/kubevirt/ovs-cni-plugin:v0.5.0"
-	OvsMarkerImageDefault         = "quay.io/kubevirt/ovs-cni-marker:v0.5.0"
+	OvsCniImageDefault            = "quay.io/kubevirt/ovs-cni-plugin:v0.6.0"
+	OvsMarkerImageDefault         = "quay.io/kubevirt/ovs-cni-marker:v0.6.0"
 )
 
 type AddonsImages struct {

--- a/templates/cluster-network-addons/VERSION/cluster-network-addons-operator.VERSION.clusterserviceversion.yaml.in
+++ b/templates/cluster-network-addons/VERSION/cluster-network-addons-operator.VERSION.clusterserviceversion.yaml.in
@@ -23,6 +23,7 @@ metadata:
               "rangeEnd": "FD:FF:FF:FF:FF:FF"
             },
             "nmstate":{},
+            "ovs": {},
             "imagePullPolicy": "IfNotPresent"
           }
         }


### PR DESCRIPTION
This PR bump the ovs version.

The new ovs version was builed with a static GCC and the go ssl lib.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubevirt/cluster-network-addons-operator/207)
<!-- Reviewable:end -->
