### PR TITLE
Bump linux bridge cni to version v0.8.1

### DIFF
--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -20,7 +20,7 @@ const (
 
 const (
 	MultusImageDefault            = "quay.io/kubevirt/cluster-network-addon-multus:v3.2.0-1.gitbf61002"
-	LinuxBridgeCniImageDefault    = "quay.io/kubevirt/cni-default-plugins:v0.8.0"
+	LinuxBridgeCniImageDefault    = "quay.io/kubevirt/cni-default-plugins:v0.8.1"
 	LinuxBridgeMarkerImageDefault = "quay.io/kubevirt/bridge-marker:0.1.0"
 	SriovDpImageDefault           = "quay.io/kubevirt/cluster-network-addon-sriov-device-plugin:v2.0.0-1.git9a20829"
 	SriovCniImageDefault          = "quay.io/kubevirt/cluster-network-addon-sriov-cni:v1.1.0-1.git9e4c973"

--- a/test/releases/0.12.0.go
+++ b/test/releases/0.12.0.go
@@ -27,7 +27,7 @@ func init() {
 				ParentName: "kube-cni-linux-bridge-plugin",
 				ParentKind: "DaemonSet",
 				Name:       "cni-plugins",
-				Image:      "quay.io/kubevirt/cni-default-plugins:v0.8.0",
+				Image:      "quay.io/kubevirt/cni-default-plugins:v0.8.1",
 			},
 			opv1alpha1.Container{
 				Namespace:  "kubemacpool-system",


### PR DESCRIPTION
Using https://github.com/containernetworking/plugins/releases/tag/v0.8.1

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubevirt/cluster-network-addons-operator/209)
<!-- Reviewable:end -->
