### PR TITLE
Pin quay.io/openshift/origin-operator-registry to 4.1.0

### DIFF
--- a/build/registry/Dockerfile
+++ b/build/registry/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/openshift/origin-operator-registry
+FROM quay.io/openshift/origin-operator-registry:4.1.0
 
 COPY manifests /registry
 


### PR DESCRIPTION
The 'latest' or '4.2.0' fails generating bundle.db at:
time="2019-08-09T07:01:21Z" level=fatal msg="could not decode contents of file
/registry/bundles.db into package:
error converting YAML to JSON: yaml: control characters are not allowed"

The error is already present at code base but was not fatal.

Looks like it's an operator-framework/registry-operator issue
https://github.com/operator-framework/operator-registry/issues/70

Signed-off-by: Quique Llorente <ellorent@redhat.com>