### PR TITLE
Fix registry Dockerfile to work with origin-registry-operator 4.2.0

### DIFF
--- a/build/registry/Dockerfile
+++ b/build/registry/Dockerfile
@@ -1,13 +1,13 @@
-FROM quay.io/openshift/origin-operator-registry:4.1.0
+FROM quay.io/openshift/origin-operator-registry:4.2.0
 
-COPY manifests /registry
+COPY manifests manifests
 
 # Bundle should include only manifests related to the CSV,
 # drop all additional files.
-RUN find /registry/cluster-network-addons/*/ -type f ! -name '*.crd.*' ! -name '*.clusterserviceversion.*' -exec rm -f {} \;
+RUN find manifests/cluster-network-addons/*/ -type f ! -name '*.crd.*' ! -name '*.clusterserviceversion.*' -exec rm -f {} \;
 
 # Initialize the database
-RUN initializer --manifests /registry --output bundles.db
+RUN initializer --manifests manifests --output bundles.db
 
 # There are multiple binaries in the origin-operator-registry
 # We want the registry-server


### PR DESCRIPTION
The 'latest' or '4.2.0' fails generating bundle.db at:
time="2019-08-09T07:01:21Z" level=fatal msg="could not decode contents of file
/registry/bundles.db into package:
error converting YAML to JSON: yaml: control characters are not allowed"

The error is already present at code base but was not fatal.

Issue was that initilizer is re-feeding itself with bundles.db that is not a JSON/YAML
this review move manifests to proper directory out of initializer

Signed-off-by: Quique Llorente <ellorent@redhat.com>