### PR TITLE
don't install ovs-vsctl binary

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,9 @@ systemctl start NetworkManager
 ## Open vSwitch
 
 The operator allows administrator to deploy [OVS CNI plugin](https://github.com/kubevirt/ovs-cni/)
-simply by adding `ovs` attribute to `NetworkAddonsConfig`.
+simply by adding `ovs` attribute to `NetworkAddonsConfig`. Please note that
+in order to use this plugin, `ovs-vsctl` binary has to be available on
+the node.
 
 ```yaml
 apiVersion: networkaddonsoperator.network.kubevirt.io/v1alpha1

--- a/data/ovs/002-ovs-daemonset.yaml
+++ b/data/ovs/002-ovs-daemonset.yaml
@@ -25,33 +25,6 @@ spec:
         - key: node-role.kubernetes.io/master
           operator: Exists
           effect: NoSchedule
-{{ if .EnableSCC }}
-      initContainers:
-        - name: ovs-vsctl
-          command:
-            - /bin/bash
-            - -c
-            - |
-              cp /usr/bin/ovs-vsctl /host/usr/local/bin/_ovs-vsctl
-              echo '#!/usr/bin/bash
-              _ovs-vsctl --db unix:///run/openvswitch/db.sock $@
-              ' > /host/usr/local/bin/ovs-vsctl
-              chmod +x /host/usr/local/bin/ovs-vsctl
-          image: {{ .OvsCNIImage }}
-          imagePullPolicy: {{ .ImagePullPolicy }}
-          resources:
-            requests:
-              cpu: "100m"
-              memory: "50Mi"
-            limits:
-              cpu: "100m"
-              memory: "50Mi"
-          securityContext:
-            privileged: true
-          volumeMounts:
-            - name: localbin
-              mountPath: /host/usr/local/bin
-{{ end }}
       containers:
         - name: ovs-cni-plugin
           image: {{ .OvsCNIImage }}


### PR DESCRIPTION
This mechanism only causes issues. Incompatibility with system it
is installed on, not being on PATH or read-only filesystems. Let's
drop it and replace by proper ovs.db socket based solution in
a following patch.