### PR TITLE
Release 0.12.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,10 @@
 all: fmt check
 
 # Always keep the future version here, so we won't overwrite latest released manifests
-VERSION ?= 0.12.0
+VERSION ?= 0.13.0
 export VERSION := $(VERSION)
 # Always keep the last released version here
-VERSION_REPLACES ?= 0.11.0
+VERSION_REPLACES ?= 0.12.0
 
 DEPLOY_DIR ?= manifests
 

--- a/README.md
+++ b/README.md
@@ -167,16 +167,16 @@ spec:
 First install the operator itself:
 
 ```shell
-kubectl apply -f https://raw.githubusercontent.com/kubevirt/cluster-network-addons-operator/master/manifests/cluster-network-addons/0.11.0/namespace.yaml
-kubectl apply -f https://raw.githubusercontent.com/kubevirt/cluster-network-addons-operator/master/manifests/cluster-network-addons/0.11.0/network-addons-config.crd.yaml
-kubectl apply -f https://raw.githubusercontent.com/kubevirt/cluster-network-addons-operator/master/manifests/cluster-network-addons/0.11.0/operator.yaml
+kubectl apply -f https://raw.githubusercontent.com/kubevirt/cluster-network-addons-operator/master/manifests/cluster-network-addons/0.12.0/namespace.yaml
+kubectl apply -f https://raw.githubusercontent.com/kubevirt/cluster-network-addons-operator/master/manifests/cluster-network-addons/0.12.0/network-addons-config.crd.yaml
+kubectl apply -f https://raw.githubusercontent.com/kubevirt/cluster-network-addons-operator/master/manifests/cluster-network-addons/0.12.0/operator.yaml
 ```
 
 Then you need to create a configuration for the operator [example
 CR](manifests/cluster-network-addons/0.4.0/network-addons-config-example.cr.yaml):
 
 ```shell
-kubectl apply -f https://raw.githubusercontent.com/kubevirt/cluster-network-addons-operator/master/manifests/cluster-network-addons/0.11.0/network-addons-config-example.cr.yaml
+kubectl apply -f https://raw.githubusercontent.com/kubevirt/cluster-network-addons-operator/master/manifests/cluster-network-addons/0.12.0/network-addons-config-example.cr.yaml
 ```
 
 Finally you can wait for the operator to finish deployment:

--- a/manifests/cluster-network-addons/0.12.0/cluster-network-addons-operator.0.12.0.clusterserviceversion.yaml
+++ b/manifests/cluster-network-addons/0.12.0/cluster-network-addons-operator.0.12.0.clusterserviceversion.yaml
@@ -1,0 +1,201 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  name: cluster-network-addons-operator.0.12.0
+  namespace: placeholder
+  annotations:
+    capabilities: "Full Lifecycle"
+    categories: "Networking"
+    alm-examples: |
+      [
+        {
+          "apiVersion":"networkaddonsoperator.network.kubevirt.io/v1alpha1",
+          "kind":"NetworkAddonsConfig",
+          "metadata": {
+            "name":"cluster"
+          },
+          "spec": {
+            "multus":{},
+            "linuxBridge":{},
+            "kubeMacPool": {
+              "rangeStart": "02:00:00:00:00:00",
+              "rangeEnd": "FD:FF:FF:FF:FF:FF"
+            },
+            "nmstate":{},
+            "ovs": {},
+            "imagePullPolicy": "IfNotPresent"
+          }
+        }
+      ]
+    description: Additional networking components for Kubernetes
+spec:
+  displayName: Cluster Network Addons
+  description: Deploy additional networking components for Kubernetes
+  keywords:
+    - Networking
+    - Multus
+    - CNI
+    - macpool
+    - SR-IOV
+    - Bridge
+    - nmstate
+    - KubeVirt
+    - Virtualization
+  version: 0.12.0
+  minKubeVersion: 1.10.0
+  maturity: alpha
+
+  replaces: cluster-network-addons-operator.0.11.0
+
+  maintainers:
+    - name: KubeVirt project
+      email: kubevirt-dev@googlegroups.com
+  provider:
+    name: KubeVirt project
+  links:
+    - name: Cluster Network Addons Operator
+      url: https://github.com/kubevirt/cluster-network-addons-operator
+  icon: []
+  labels:
+    alm-owner-kubevirt: cluster-network-addons
+    operated-by: cluster-network-addons
+  selector:
+    matchLabels:
+      alm-owner-kubevirt: cluster-network-addons
+      operated-by: cluster-network-addons
+  installModes:
+    - type: OwnNamespace
+      supported: true
+    - type: SingleNamespace
+      supported: true
+    - type: MultiNamespace
+      supported: true
+    - type: AllNamespaces
+      supported: true
+  install:
+    strategy: deployment
+    spec:
+      permissions:
+        - serviceAccountName: cluster-network-addons-operator
+          rules:
+            - apiGroups:
+              - ""
+              resources:
+              - pods
+              - configmaps
+              verbs:
+              - get
+              - list
+              - watch
+              - create
+              - patch
+              - update
+              - delete
+            - apiGroups:
+              - apps
+              resources:
+              - deployments
+              - replicasets
+              verbs:
+              - get
+              - list
+              - watch
+              - create
+              - patch
+              - update
+              - delete
+
+      clusterPermissions:
+        - serviceAccountName: cluster-network-addons-operator
+          rules:
+            - apiGroups:
+              - security.openshift.io
+              resourceNames:
+              - privileged
+              resources:
+              - securitycontextconstraints
+              verbs:
+              - get
+              - list
+              - watch
+            - apiGroups:
+              - operator.openshift.io
+              resources:
+              - networks
+              verbs:
+              - get
+              - list
+              - watch
+            - apiGroups:
+              - networkaddonsoperator.network.kubevirt.io
+              resources:
+              - networkaddonsconfigs
+              verbs:
+              - get
+              - list
+              - watch
+            - apiGroups:
+              - '*'
+              resources:
+              - '*'
+              verbs:
+              - '*'
+
+      deployments:
+        - name: cluster-network-addons-operator
+          spec:
+            replicas: 1
+            selector:
+              matchLabels:
+                name: cluster-network-addons-operator
+            strategy: {}
+            template:
+              metadata:
+                labels:
+                  name: cluster-network-addons-operator
+              spec:
+                containers:
+                - env:
+                  - name: MULTUS_IMAGE
+                    value: quay.io/kubevirt/cluster-network-addon-multus:v3.2.0-1.gitbf61002
+                  - name: LINUX_BRIDGE_IMAGE
+                    value: quay.io/kubevirt/cni-default-plugins:v0.8.1
+                  - name: LINUX_BRIDGE_MARKER_IMAGE
+                    value: quay.io/kubevirt/bridge-marker:0.2.0
+                  - name: NMSTATE_HANDLER_IMAGE
+                    value: quay.io/nmstate/kubernetes-nmstate-handler:v0.6.0
+                  - name: OVS_CNI_IMAGE
+                    value: quay.io/kubevirt/ovs-cni-plugin:v0.6.0
+                  - name: OVS_MARKER_IMAGE
+                    value: quay.io/kubevirt/ovs-cni-marker:v0.6.0
+                  - name: KUBEMACPOOL_IMAGE
+                    value: quay.io/kubevirt/kubemacpool:v0.4.0
+                  - name: OPERATOR_IMAGE
+                    value: quay.io/kubevirt/cluster-network-addons-operator:0.12.0
+                  - name: OPERATOR_NAME
+                    value: cluster-network-addons-operator
+                  - name: OPERATOR_VERSION
+                    value: 0.12.0
+                  - name: OPERATOR_NAMESPACE
+                    valueFrom:
+                      fieldRef:
+                        fieldPath: metadata.namespace
+                  - name: POD_NAME
+                    valueFrom:
+                      fieldRef:
+                        fieldPath: metadata.name
+                  - name: WATCH_NAMESPACE
+                  image: quay.io/kubevirt/cluster-network-addons-operator:0.12.0
+                  imagePullPolicy: Always
+                  name: cluster-network-addons-operator
+                  resources: {}
+                serviceAccountName: cluster-network-addons-operator
+
+  customresourcedefinitions:
+    owned:
+      - name: networkaddonsconfigs.networkaddonsoperator.network.kubevirt.io
+        version: v1alpha1
+        group: networkaddonsoperator.network.kubevirt.io
+        kind: NetworkAddonsConfig
+        displayName: Cluster Network Addons
+        description: Cluster Network Addons

--- a/manifests/cluster-network-addons/0.12.0/namespace.yaml
+++ b/manifests/cluster-network-addons/0.12.0/namespace.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: cluster-network-addons-operator
+  labels:
+    name: cluster-network-addons-operator

--- a/manifests/cluster-network-addons/0.12.0/network-addons-config-example.cr.yaml
+++ b/manifests/cluster-network-addons/0.12.0/network-addons-config-example.cr.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: networkaddonsoperator.network.kubevirt.io/v1alpha1
+kind: NetworkAddonsConfig
+metadata:
+  name: cluster
+spec:
+  imagePullPolicy: IfNotPresent
+  kubeMacPool: {}
+  linuxBridge: {}
+  multus: {}
+  nmstate: {}
+  ovs: {}

--- a/manifests/cluster-network-addons/0.12.0/network-addons-config.crd.yaml
+++ b/manifests/cluster-network-addons/0.12.0/network-addons-config.crd.yaml
@@ -1,0 +1,33 @@
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: networkaddonsconfigs.networkaddonsoperator.network.kubevirt.io
+spec:
+  group: networkaddonsoperator.network.kubevirt.io
+  names:
+    kind: NetworkAddonsConfig
+    listKind: NetworkAddonsConfigList
+    plural: networkaddonsconfigs
+    singular: networkaddonsconfig
+  scope: Cluster
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          type: string
+        kind:
+          type: string
+        metadata:
+          type: object
+        spec:
+          type: object
+        status:
+          type: object
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true

--- a/manifests/cluster-network-addons/0.12.0/operator.yaml
+++ b/manifests/cluster-network-addons/0.12.0/operator.yaml
@@ -1,0 +1,173 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    kubevirt.io: ""
+  name: cluster-network-addons-operator
+  namespace: cluster-network-addons-operator
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    name: cluster-network-addons-operator
+  name: cluster-network-addons-operator
+rules:
+- apiGroups:
+  - security.openshift.io
+  resourceNames:
+  - privileged
+  resources:
+  - securitycontextconstraints
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - operator.openshift.io
+  resources:
+  - networks
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - networkaddonsoperator.network.kubevirt.io
+  resources:
+  - networkaddonsconfigs
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - '*'
+  resources:
+  - '*'
+  verbs:
+  - '*'
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    kubevirt.io: ""
+  name: cluster-network-addons-operator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-network-addons-operator
+subjects:
+  - kind: ServiceAccount
+    name: cluster-network-addons-operator
+    namespace: cluster-network-addons-operator
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    name: cluster-network-addons-operator
+  name: cluster-network-addons-operator
+  namespace: cluster-network-addons-operator
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - patch
+  - update
+  - delete
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  - replicasets
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - patch
+  - update
+  - delete
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    kubevirt.io: ""
+  name: cluster-network-addons-operator
+  namespace: cluster-network-addons-operator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: cluster-network-addons-operator
+subjects:
+  - kind: ServiceAccount
+    name: cluster-network-addons-operator
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    networkaddonsoperator.network.kubevirt.io/version: 0.12.0
+  name: cluster-network-addons-operator
+  namespace: cluster-network-addons-operator
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: cluster-network-addons-operator
+  strategy: {}
+  template:
+    metadata:
+      labels:
+        name: cluster-network-addons-operator
+    spec:
+      containers:
+      - env:
+        - name: MULTUS_IMAGE
+          value: quay.io/kubevirt/cluster-network-addon-multus:v3.2.0-1.gitbf61002
+        - name: LINUX_BRIDGE_IMAGE
+          value: quay.io/kubevirt/cni-default-plugins:v0.8.1
+        - name: LINUX_BRIDGE_MARKER_IMAGE
+          value: quay.io/kubevirt/bridge-marker:0.2.0
+        - name: NMSTATE_HANDLER_IMAGE
+          value: quay.io/nmstate/kubernetes-nmstate-handler:v0.6.0
+        - name: OVS_CNI_IMAGE
+          value: quay.io/kubevirt/ovs-cni-plugin:v0.6.0
+        - name: OVS_MARKER_IMAGE
+          value: quay.io/kubevirt/ovs-cni-marker:v0.6.0
+        - name: KUBEMACPOOL_IMAGE
+          value: quay.io/kubevirt/kubemacpool:v0.4.0
+        - name: OPERATOR_IMAGE
+          value: quay.io/kubevirt/cluster-network-addons-operator:0.12.0
+        - name: OPERATOR_NAME
+          value: cluster-network-addons-operator
+        - name: OPERATOR_VERSION
+          value: 0.12.0
+        - name: OPERATOR_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: WATCH_NAMESPACE
+        image: quay.io/kubevirt/cluster-network-addons-operator:0.12.0
+        imagePullPolicy: Always
+        name: cluster-network-addons-operator
+        resources: {}
+      serviceAccountName: cluster-network-addons-operator

--- a/manifests/cluster-network-addons/cluster-network-addons.package.yaml
+++ b/manifests/cluster-network-addons/cluster-network-addons.package.yaml
@@ -1,4 +1,4 @@
 packageName: cluster-network-addons
 channels:
 - name: alpha
-  currentCSV: cluster-network-addons-operator.0.11.0
+  currentCSV: cluster-network-addons-operator.0.12.0

--- a/test/releases/0.13.0.go
+++ b/test/releases/0.13.0.go
@@ -1,0 +1,73 @@
+package releases
+
+import (
+	opv1alpha1 "github.com/kubevirt/cluster-network-addons-operator/pkg/apis/networkaddonsoperator/v1alpha1"
+)
+
+func init() {
+	release := Release{
+		Version: "0.13.0",
+		Containers: []opv1alpha1.Container{
+			opv1alpha1.Container{
+				Namespace:  "multus",
+				ParentName: "kube-multus-ds-amd64",
+				ParentKind: "DaemonSet",
+				Name:       "kube-multus",
+				Image:      "quay.io/kubevirt/cluster-network-addon-multus:v3.2.0-1.gitbf61002",
+			},
+			opv1alpha1.Container{
+				Namespace:  "linux-bridge",
+				ParentName: "bridge-marker",
+				ParentKind: "DaemonSet",
+				Name:       "bridge-marker",
+				Image:      "quay.io/kubevirt/bridge-marker:0.2.0",
+			},
+			opv1alpha1.Container{
+				Namespace:  "linux-bridge",
+				ParentName: "kube-cni-linux-bridge-plugin",
+				ParentKind: "DaemonSet",
+				Name:       "cni-plugins",
+				Image:      "quay.io/kubevirt/cni-default-plugins:v0.8.1",
+			},
+			opv1alpha1.Container{
+				Namespace:  "kubemacpool-system",
+				ParentName: "kubemacpool-mac-controller-manager",
+				ParentKind: "Deployment",
+				Name:       "manager",
+				Image:      "quay.io/kubevirt/kubemacpool:v0.4.0",
+			},
+			opv1alpha1.Container{
+				Namespace:  "nmstate",
+				ParentName: "nmstate-handler",
+				ParentKind: "DaemonSet",
+				Name:       "nmstate-handler",
+				Image:      "quay.io/nmstate/kubernetes-nmstate-handler:v0.6.0",
+			},
+			opv1alpha1.Container{
+				Namespace:  "ovs",
+				ParentName: "ovs-cni-amd64",
+				ParentKind: "DaemonSet",
+				Name:       "ovs-cni-plugin",
+				Image:      "quay.io/kubevirt/ovs-cni-plugin:v0.6.0",
+			},
+			opv1alpha1.Container{
+				Namespace:  "ovs",
+				ParentName: "ovs-cni-amd64",
+				ParentKind: "DaemonSet",
+				Name:       "ovs-cni-marker",
+				Image:      "quay.io/kubevirt/ovs-cni-marker:v0.6.0",
+			},
+		},
+		SupportedSpec: opv1alpha1.NetworkAddonsConfigSpec{
+			KubeMacPool: &opv1alpha1.KubeMacPool{},
+			LinuxBridge: &opv1alpha1.LinuxBridge{},
+			Multus:      &opv1alpha1.Multus{},
+			NMState:     &opv1alpha1.NMState{},
+			Ovs:         &opv1alpha1.Ovs{},
+		},
+		Manifests: []string{
+			"operator.yaml",
+		},
+	}
+	releases = append(releases, release)
+}


### PR DESCRIPTION
* ovs component added
* added upgrade support for ovs and nmstate
* updated bridge-marker to 0.2
* updated bridge-cni to v0.8.1
* removed sr-iov (obsoleted by openshift/sriov-network-operator)
* updated nmstate to v0.8.0
* expose unified HCO conditions