### PR TITLE
Reduce kubemacpool requested CPU resource and limit

### DIFF
--- a/data/kubemacpool/003-deployment.yaml
+++ b/data/kubemacpool/003-deployment.yaml
@@ -50,10 +50,10 @@ spec:
               protocol: TCP
           resources:
             limits:
-              cpu: 800m
+              cpu: 300m
               memory: 800Mi
             requests:
-              cpu: 500m
+              cpu: 100m
               memory: 500Mi
       restartPolicy: Always
       terminationGracePeriodSeconds: 5


### PR DESCRIPTION
High requested CPU resource requirement seems to cause issues, which
frequently cause the pod scheduling issue.

Signed-off-by: Lev Veyde <lveyde@redhat.com>