### PR TITLE
drop Failing condition from CR

### DIFF
--- a/pkg/controller/statusmanager/status_manager.go
+++ b/pkg/controller/statusmanager/status_manager.go
@@ -157,6 +157,9 @@ func (status *StatusManager) set(reachedAvailableLevel bool, conditions ...condi
 	config.Status.OperatorVersion = operatorVersion
 	config.Status.TargetVersion = operatorVersion
 
+	// Failing condition had been replaced by Degraded in 0.12.0, drop it from CR if needed
+	conditionsv1.RemoveStatusCondition(&config.Status.Conditions, conditionsv1.ConditionType("Failing"))
+
 	if reflect.DeepEqual(oldStatus, config.Status) {
 		return nil
 	}


### PR DESCRIPTION
Failing has been deprecated by Degraded in 0.12.0, remove it if
found after an upgrade.