### PR TITLE
Upgrade kubernetes-nmstate-handler container to 0.8.0

### DIFF
--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -23,7 +23,7 @@ const (
 	LinuxBridgeCniImageDefault    = "quay.io/kubevirt/cni-default-plugins:v0.8.1"
 	LinuxBridgeMarkerImageDefault = "quay.io/kubevirt/bridge-marker:0.2.0"
 	KubeMacPoolImageDefault       = "quay.io/kubevirt/kubemacpool:v0.5.0"
-	NMStateHandlerImageDefault    = "quay.io/nmstate/kubernetes-nmstate-handler:v0.6.0"
+	NMStateHandlerImageDefault    = "quay.io/nmstate/kubernetes-nmstate-handler:v0.8.0"
 	OvsCniImageDefault            = "quay.io/kubevirt/ovs-cni-plugin:v0.7.0"
 	OvsMarkerImageDefault         = "quay.io/kubevirt/ovs-cni-marker:v0.7.0"
 )

--- a/test/releases/0.16.0.go
+++ b/test/releases/0.16.0.go
@@ -36,7 +36,7 @@ func init() {
 				ParentName: "nmstate-handler",
 				ParentKind: "DaemonSet",
 				Name:       "nmstate-handler",
-				Image:      "quay.io/nmstate/kubernetes-nmstate-handler:v0.6.0",
+				Image:      "quay.io/nmstate/kubernetes-nmstate-handler:v0.8.0",
 			},
 			opv1alpha1.Container{
 				ParentName: "ovs-cni-amd64",


### PR DESCRIPTION
- Support untagged vlan filtering linux bridge traffic
- Increase nmstate set timeout to 60 seconds