### PR TITLE
Bump kubemacpool to version v0.6.0

### DIFF
--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -22,7 +22,7 @@ const (
 	MultusImageDefault            = "quay.io/kubevirt/cluster-network-addon-multus:v3.2.0-1.gitbf61002"
 	LinuxBridgeCniImageDefault    = "quay.io/kubevirt/cni-default-plugins:v0.8.1"
 	LinuxBridgeMarkerImageDefault = "quay.io/kubevirt/bridge-marker:0.2.0"
-	KubeMacPoolImageDefault       = "quay.io/kubevirt/kubemacpool:v0.5.0"
+	KubeMacPoolImageDefault       = "quay.io/kubevirt/kubemacpool:v0.6.0"
 	NMStateHandlerImageDefault    = "quay.io/nmstate/kubernetes-nmstate-handler:v0.8.0"
 	OvsCniImageDefault            = "quay.io/kubevirt/ovs-cni-plugin:v0.7.0"
 	OvsMarkerImageDefault         = "quay.io/kubevirt/ovs-cni-marker:v0.7.0"

--- a/test/e2e/workflow/deployment_test.go
+++ b/test/e2e/workflow/deployment_test.go
@@ -32,7 +32,7 @@ var _ = Describe("NetworkAddonsConfig", func() {
 					LinuxBridge: &opv1alpha1.LinuxBridge{},
 				},
 				[]Component{LinuxBridgeComponent},
-			),//2303
+			), //2303
 			Entry(
 				MultusComponent.ComponentName,
 				opv1alpha1.NetworkAddonsConfigSpec{

--- a/test/e2e/workflow/recovery_test.go
+++ b/test/e2e/workflow/recovery_test.go
@@ -10,6 +10,7 @@ import (
 	. "github.com/kubevirt/cluster-network-addons-operator/test/check"
 	. "github.com/kubevirt/cluster-network-addons-operator/test/operations"
 )
+
 //2297
 var _ = Describe("NetworkAddonsConfig", func() {
 	Context("when invalid config is applied", func() {

--- a/test/releases/0.16.0.go
+++ b/test/releases/0.16.0.go
@@ -30,7 +30,7 @@ func init() {
 				ParentName: "kubemacpool-mac-controller-manager",
 				ParentKind: "Deployment",
 				Name:       "manager",
-				Image:      "quay.io/kubevirt/kubemacpool:v0.5.0",
+				Image:      "quay.io/kubevirt/kubemacpool:v0.6.0",
 			},
 			opv1alpha1.Container{
 				ParentName: "nmstate-handler",


### PR DESCRIPTION
This PR bump the kubemacpool version for our operator.

https://github.com/K8sNetworkPlumbingWG/kubemacpool/releases/tag/v0.6.0

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubevirt/cluster-network-addons-operator/237)
<!-- Reviewable:end -->
