### PR TITLE
Bump kubemacpool to version v0.7.0

### DIFF
--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -22,7 +22,7 @@ const (
 	MultusImageDefault            = "quay.io/kubevirt/cluster-network-addon-multus:v3.2.0-1.gitbf61002"
 	LinuxBridgeCniImageDefault    = "quay.io/kubevirt/cni-default-plugins:v0.8.1"
 	LinuxBridgeMarkerImageDefault = "quay.io/kubevirt/bridge-marker:0.2.0"
-	KubeMacPoolImageDefault       = "quay.io/kubevirt/kubemacpool:v0.6.0"
+	KubeMacPoolImageDefault       = "quay.io/kubevirt/kubemacpool:v0.7.0"
 	NMStateHandlerImageDefault    = "quay.io/nmstate/kubernetes-nmstate-handler:v0.8.0"
 	OvsCniImageDefault            = "quay.io/kubevirt/ovs-cni-plugin:v0.7.0"
 	OvsMarkerImageDefault         = "quay.io/kubevirt/ovs-cni-marker:v0.7.0"

--- a/test/releases/0.17.0.go
+++ b/test/releases/0.17.0.go
@@ -30,7 +30,7 @@ func init() {
 				ParentName: "kubemacpool-mac-controller-manager",
 				ParentKind: "Deployment",
 				Name:       "manager",
-				Image:      "quay.io/kubevirt/kubemacpool:v0.6.0",
+				Image:      "quay.io/kubevirt/kubemacpool:v0.7.0",
 			},
 			opv1alpha1.Container{
 				ParentName: "nmstate-handler",


### PR DESCRIPTION
This PR bump the kubemacpool version to a version that ignore errors on the pod webhook

Signed-off-by: Sebastian Sch <sebassch@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubevirt/cluster-network-addons-operator/241)
<!-- Reviewable:end -->
