### PR TITLE
bridge cni: always deploy cnv- prefixed binaries

### DIFF
--- a/data/linux-bridge/002-linux-bridge.yaml
+++ b/data/linux-bridge/002-linux-bridge.yaml
@@ -37,6 +37,11 @@ spec:
             - |
               cp -rf /usr/src/containernetworking/plugins/bin/*bridge /opt/cni/bin/
               cp -rf /usr/src/containernetworking/plugins/bin/*tuning /opt/cni/bin/
+              # Some projects (e.g. openshift/console) use cnv- prefix to distinguish between
+              # binaries shipped by OpenShift and those shipped by KubeVirt (D/S matters).
+              # Following two lines make sure we will provide both names when needed.
+              find /opt/cni/bin/cnv-bridge || ln -s /opt/cni/bin/bridge /opt/cni/bin/cnv-bridge
+              find /opt/cni/bin/cnv-tuning || ln -s /opt/cni/bin/tuning /opt/cni/bin/cnv-tuning
               echo "Entering sleep... (success)"
               sleep infinity
           resources:


### PR DESCRIPTION
Some projects (e.g. openshift/console) use cnv- prefix to distinguish between
binaries shipped by OpenShift and those shipped by KubeVirt (D/S matters).
Following two lines make sure we will provide both names when needed.

Signed-off-by: Petr Horacek <phoracek@redhat.com>