### PR TITLE
Increase nmstate-handler resources

### DIFF
--- a/data/nmstate/003-operator.yaml
+++ b/data/nmstate/003-operator.yaml
@@ -33,11 +33,11 @@ spec:
           imagePullPolicy: {{ .ImagePullPolicy }}
           resources:
             requests:
-              cpu: "100m"
-              memory: "60Mi"
+              cpu: "200m"
+              memory: "120Mi"
             limits:
-              cpu: "100m"
-              memory: "60Mi"
+              cpu: "200m"
+              memory: "120Mi"
           command:
           - kubernetes-nmstate
           env:


### PR DESCRIPTION
After changing limits at [1] some users has issues with
kubernets-nmstate going OOMKilled, duplicating resources
looks good enough.

[1] https://github.com/kubevirt/cluster-network-addons-operator/pull/254

Signed-off-by: Quique Llorente <ellorent@redhat.com>