### PR TITLE
Bump ovs-cni to 0.8.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,8 +136,7 @@ systemctl start NetworkManager
 
 The operator allows administrator to deploy [OVS CNI plugin](https://github.com/kubevirt/ovs-cni/)
 simply by adding `ovs` attribute to `NetworkAddonsConfig`. Please note that
-in order to use this plugin, `ovs-vsctl` binary has to be available on
-the node.
+in order to use this plugin, openvswitch have to be up and running at nodes.
 
 ```yaml
 apiVersion: networkaddonsoperator.network.kubevirt.io/v1alpha1

--- a/data/ovs/002-ovs-daemonset.yaml
+++ b/data/ovs/002-ovs-daemonset.yaml
@@ -57,10 +57,10 @@ spec:
             - -node-name
             - $(NODE_NAME)
             - -ovs-socket
-            - unix:///host/run/openvswitch/db.sock
+            - /host/var/run/openvswitch/db.sock
           volumeMounts:
-            - name: ovs-run
-              mountPath: /host/run/openvswitch
+            - name: ovs-var-run
+              mountPath: /host/var/run/openvswitch
           env:
             - name: NODE_NAME
               valueFrom:
@@ -73,6 +73,6 @@ spec:
         - name: cnibin
           hostPath:
             path: {{ .CNIBinDir }}
-        - name: ovs-run
+        - name: ovs-var-run
           hostPath:
-            path: /run/openvswitch
+            path: /var/run/openvswitch

--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -24,8 +24,8 @@ const (
 	LinuxBridgeMarkerImageDefault = "quay.io/kubevirt/bridge-marker:0.2.0"
 	KubeMacPoolImageDefault       = "quay.io/kubevirt/kubemacpool:v0.8.0"
 	NMStateHandlerImageDefault    = "quay.io/nmstate/kubernetes-nmstate-handler:v0.12.0"
-	OvsCniImageDefault            = "quay.io/kubevirt/ovs-cni-plugin:v0.7.0"
-	OvsMarkerImageDefault         = "quay.io/kubevirt/ovs-cni-marker:v0.7.0"
+	OvsCniImageDefault            = "quay.io/kubevirt/ovs-cni-plugin:v0.8.0"
+	OvsMarkerImageDefault         = "quay.io/kubevirt/ovs-cni-marker:v0.8.0"
 )
 
 type AddonsImages struct {

--- a/test/releases/0.23.0.go
+++ b/test/releases/0.23.0.go
@@ -42,13 +42,13 @@ func init() {
 				ParentName: "ovs-cni-amd64",
 				ParentKind: "DaemonSet",
 				Name:       "ovs-cni-plugin",
-				Image:      "quay.io/kubevirt/ovs-cni-plugin:v0.7.0",
+				Image:      "quay.io/kubevirt/ovs-cni-plugin:v0.8.0",
 			},
 			opv1alpha1.Container{
 				ParentName: "ovs-cni-amd64",
 				ParentKind: "DaemonSet",
 				Name:       "ovs-cni-marker",
-				Image:      "quay.io/kubevirt/ovs-cni-marker:v0.7.0",
+				Image:      "quay.io/kubevirt/ovs-cni-marker:v0.8.0",
 			},
 		},
 		SupportedSpec: opv1alpha1.NetworkAddonsConfigSpec{


### PR DESCRIPTION
To include the bridge reporting fix [1]

[1] https://github.com/kubevirt/ovs-cni/pull/93

Signed-off-by: Quique Llorente <ellorent@redhat.com>