### PR TITLE
Handling special cases of outdated/incompatible objects during reconcile

### DIFF
--- a/data/multus/002-multus.yaml
+++ b/data/multus/002-multus.yaml
@@ -24,7 +24,7 @@ spec:
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
-  name: kube-multus-ds-amd64
+  name: multus
   namespace: {{ .Namespace }}
   labels:
     tier: node

--- a/pkg/controller/networkaddonsconfig/networkaddonsconfig_controller.go
+++ b/pkg/controller/networkaddonsconfig/networkaddonsconfig_controller.go
@@ -286,6 +286,13 @@ func (r *ReconcileNetworkAddonsConfig) renderObjects(networkAddonsConfig *opv1al
 		return objs, err
 	}
 
+	// Perform any special object changes that are impossible to do with regular Apply. e.g. Remove outdated objects
+	// and objects that cannot be modified by Apply method due to incompatible changes.
+	if err := network.SpecialCleanUp(&networkAddonsConfig.Spec, r.client); err != nil {
+		log.Printf("failed to Clean Up outdated objects: %v", err)
+		return objs, err
+	}
+
 	// The first object we create should be the record of our applied configuration
 	applied, err := appliedConfiguration(networkAddonsConfig, r.namespace)
 	if err != nil {

--- a/pkg/network/multus.go
+++ b/pkg/network/multus.go
@@ -1,13 +1,20 @@
 package network
 
 import (
+	"context"
+	"fmt"
+	"log"
 	"os"
 	"path/filepath"
 	"reflect"
 
 	osv1 "github.com/openshift/api/operator/v1"
 	"github.com/pkg/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	opv1alpha1 "github.com/kubevirt/cluster-network-addons-operator/pkg/apis/networkaddonsoperator/v1alpha1"
 	"github.com/kubevirt/cluster-network-addons-operator/pkg/network/cni"
@@ -34,6 +41,50 @@ func changeSafeMultus(prev, next *opv1alpha1.NetworkAddonsConfigSpec) []error {
 		return []error{errors.Errorf("cannot modify Multus configuration once it is deployed")}
 	}
 	return nil
+}
+
+// cleanUpMultus checks specific multus outdated objects or ones that are no longer compatible and deletes them.
+func cleanUpMultus(conf *opv1alpha1.NetworkAddonsConfigSpec, ctx context.Context, client k8sclient.Client) []error {
+	if conf.Multus == nil {
+		return nil
+	}
+
+	errs := []error{}
+	errs = append(errs, cleanUpMultusOldName(ctx, client)...)
+
+	return errs
+
+}
+
+// cleanUpMultusOldName deletes multus ds object with old name after a new name was introduces in version 0.25.0.
+// REQUIRED_FOR upgrade from multus <= 0.25.0.
+func cleanUpMultusOldName(ctx context.Context, client k8sclient.Client) []error {
+	// Get existing
+	existing := &unstructured.Unstructured{}
+	gvk := schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "DaemonSet"}
+	existing.SetGroupVersionKind(gvk)
+	namespace := "cluster-network-addons"
+	name := "kube-multus-ds-amd64"
+
+	err := client.Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, existing)
+	// if we found the object
+	if err == nil {
+		objDesc := fmt.Sprintf("(%s) %s/%s", gvk.String(), namespace, name)
+		log.Printf("Cleaning up %s Object", objDesc)
+
+		// Delete the object
+		err = client.Delete(ctx, existing)
+		if err != nil {
+			log.Printf("Failed Cleaning up %s Object", objDesc)
+			return []error{err}
+		}
+
+	} else if apierrors.IsNotFound(err) {
+		// object not found, no need for action.
+		return nil
+	}
+
+	return []error{err}
 }
 
 // RenderMultus generates the manifests of Multus

--- a/test/check/components.go
+++ b/test/check/components.go
@@ -31,7 +31,7 @@ var (
 		ClusterRole:                "multus",
 		ClusterRoleBinding:         "multus",
 		SecurityContextConstraints: "multus",
-		DaemonSets:                 []string{"kube-multus-ds-amd64"},
+		DaemonSets:                 []string{"multus"},
 	}
 	NMStateComponent = Component{
 		ComponentName:              "NMState",

--- a/test/releases/0.25.0.go
+++ b/test/releases/0.25.0.go
@@ -9,7 +9,7 @@ func init() {
 		Version: "0.25.0",
 		Containers: []opv1alpha1.Container{
 			opv1alpha1.Container{
-				ParentName: "kube-multus-ds-amd64",
+				ParentName: "multus",
 				ParentKind: "DaemonSet",
 				Name:       "kube-multus",
 				Image:      "quay.io/kubevirt/cluster-network-addon-multus:v3.2.0-1.gitbf61002",


### PR DESCRIPTION
When a change is introduced to an object's parameters during upgrade, it is sometimes not possible to perform the regular reconcile process to the newer version (such as changing a mutable name).
For this reason we need to add a Special delete functionality which should be added specifically per case when such as change occurs.
Testing this functionality is included as part of the lifecycle tests.