### PR TITLE
bump to k8s 1.17

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ GINKGO_ARGS ?= --v -r --progress $(GINKGO_EXTRA_ARGS)
 GINKGO ?= build/_output/bin/ginkgo
 
 E2E_TEST_EXTRA_ARGS ?=
-E2E_TEST_ARGS ?= $(strip -test.v -test.timeout 2h -ginkgo.v $(E2E_TEST_EXTRA_ARGS))
+E2E_TEST_ARGS ?= $(strip -test.v -test.timeout 3h -ginkgo.v $(E2E_TEST_EXTRA_ARGS))
 E2E_SUITES = \
 	test/e2e/lifecycle \
 	test/e2e/workflow

--- a/automation/check-patch.e2e-lifecycle-k8s.sh
+++ b/automation/check-patch.e2e-lifecycle-k8s.sh
@@ -12,7 +12,7 @@ teardown() {
 }
 
 main() {
-    export KUBEVIRT_PROVIDER='k8s-1.14.6'
+    export KUBEVIRT_PROVIDER='k8s-1.17.0'
 
     source automation/check-patch.e2e.setup.sh
     cd ${TMP_PROJECT_PATH}

--- a/automation/check-patch.e2e-workflow-k8s.sh
+++ b/automation/check-patch.e2e-workflow-k8s.sh
@@ -12,7 +12,7 @@ teardown() {
 }
 
 main() {
-    export KUBEVIRT_PROVIDER='k8s-1.14.6'
+    export KUBEVIRT_PROVIDER='k8s-1.17.0'
 
     source automation/check-patch.e2e.setup.sh
     cd ${TMP_PROJECT_PATH}

--- a/cluster/kubevirtci.sh
+++ b/cluster/kubevirtci.sh
@@ -12,9 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-export KUBEVIRT_PROVIDER=${KUBEVIRT_PROVIDER:-'k8s-1.14.6'}
+export KUBEVIRT_PROVIDER=${KUBEVIRT_PROVIDER:-'k8s-1.17.0'}
 
-KUBEVIRTCI_VERSION='0e5b027098796137a9b95aed57943061e185bfcd'
+KUBEVIRTCI_VERSION='9b8707c02d59ee1a7924103b6beca9b9cd010633'
 KUBEVIRTCI_PATH="${PWD}/_kubevirtci"
 
 function kubevirtci::install() {

--- a/test/check/check.go
+++ b/test/check/check.go
@@ -26,6 +26,7 @@ import (
 	"github.com/kubevirt/cluster-network-addons-operator/pkg/components"
 	"github.com/kubevirt/cluster-network-addons-operator/pkg/names"
 
+	. "github.com/kubevirt/cluster-network-addons-operator/test/kubectl"
 	. "github.com/kubevirt/cluster-network-addons-operator/test/okd"
 )
 
@@ -323,7 +324,7 @@ func checkForDeployment(name string) error {
 		if err != nil {
 			panic(err)
 		}
-		return fmt.Errorf("Deployment %s/%s is not ready, current state:\n%v", components.Namespace, name, string(manifest))
+		return fmt.Errorf("Deployment %s/%s is not ready, current state:\n%v\ndescribe all:\n%v", components.Namespace, name, string(manifest), describeAll())
 	}
 
 	return nil
@@ -389,7 +390,7 @@ func checkConfigCondition(conf *opv1alpha1.NetworkAddonsConfig, conditionType Co
 			if condition.Status == corev1.ConditionStatus(conditionStatus) {
 				return nil
 			}
-			return fmt.Errorf("condition %q is not in expected state %q, obtained state %q, obtained config %v", conditionType, conditionStatus, condition.Status, configToYaml(conf))
+			return fmt.Errorf("condition %q is not in expected state %q, obtained state %q, obtained config:\n%vdescribe all:\n%v", conditionType, conditionStatus, condition.Status, configToYaml(conf), describeAll())
 		}
 	}
 
@@ -399,6 +400,12 @@ func checkConfigCondition(conf *opv1alpha1.NetworkAddonsConfig, conditionType Co
 	}
 
 	return fmt.Errorf("condition %q has not been found in the config", conditionType)
+}
+
+func describeAll() string {
+	description, err := Kubectl("-n", components.Namespace, "describe", "all")
+	Expect(err).ToNot(HaveOccurred())
+	return description
 }
 
 func isNotSupportedKind(err error) bool {


### PR DESCRIPTION
There was an issue with previous version of Kubernetes where we
ran out of available IPs during lifecycle tests (with dozens of
pods being created and removed in a short period of time).

This PR is adding more logging information when one of our asserts
fail and it also bumps the used k8s version to 1.17.

Signed-off-by: Petr Horacek <phoracek@redhat.com>