### PR TITLE
set max length for version string

### DIFF
--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -65,6 +65,12 @@ func (ai *AddonsImages) FillDefaults() *AddonsImages {
 
 func GetDeployment(version string, operatorVersion string, namespace string, repository string, imageName string, tag string, imagePullPolicy string, addonsImages *AddonsImages) *appsv1.Deployment {
 	image := fmt.Sprintf("%s/%s:%s", repository, imageName, tag)
+
+	// In case SHA is used for the version, we need to trim it to fit into labels
+	if len(operatorVersion) > 63 {
+		operatorVersion = operatorVersion[0:63]
+	}
+
 	deployment := &appsv1.Deployment{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "apps/v1",


### PR DESCRIPTION
When SHA hashes are used instead of tags for versioning, we are not able to
fit the whole version string to annotations and that causes the operator to
fail:

NetworkAddonsConfig is degraded: could not apply (/v1, Kind=ConfigMap)
openshift-cnv/cluster-networks-addons-operator-applied-cluster: could not
create (/v1, Kind=ConfigMap)
openshift-cnv/cluster-networks-addons-operator-applied-cluster: ConfigMap
"cluster-networks-addons-operator-applied-cluster" is invalid: [metadata.labels:
Invalid value:
"sha256:7343c7089f04f1c7affab12fe9a6614f24ee62d84d0943b24c170a6e30fe374e": must
be no more than 63 characters, metadata.labels: Invalid value:
"sha256:7343c7089f04f1c7affab12fe9a6614f24ee62d84d0943b24c170a6e30fe374e": a
valid label must be an empty string or consist of alphanumeric characters, '-',
'_' or '.', and must start and end with an alphanumeric character (e.g.
'MyValue', or 'my_value', or '12345', regex used for validation is
'(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?')]

With this patch, we make sure that the version string is always stripped down
to maximum 63 characters.

Signed-off-by: Petr Horacek <phoracek@redhat.com>