### PR TITLE
don't fail the test if we fail to list all objects

### DIFF
--- a/test/check/check.go
+++ b/test/check/check.go
@@ -404,8 +404,7 @@ func checkConfigCondition(conf *opv1alpha1.NetworkAddonsConfig, conditionType Co
 
 func describeAll() string {
 	description, err := Kubectl("-n", components.Namespace, "describe", "all")
-	Expect(err).ToNot(HaveOccurred())
-	return description
+	return fmt.Sprintf("description:\n%v\nerror:\n%v", description, err)
 }
 
 func isNotSupportedKind(err error) bool {


### PR DESCRIPTION
With the current, kubectl describe sometimes fail to list objects that
are being removed. It is probably between listing of all objects and obtaining
of their descriptions. In any case, we can merely print both the description
and error if this helper function fails.

Signed-off-by: Petr Horacek <phoracek@redhat.com>