### PR TITLE
disable knmstate webhook

### DIFF
--- a/data/nmstate/003-operator.yaml
+++ b/data/nmstate/003-operator.yaml
@@ -44,8 +44,8 @@ spec:
           env:
             - name: WATCH_NAMESPACE
               value: ""
-            - name: RUN_WEBHOOK_SERVER
-              value: ""
+            #- name: RUN_WEBHOOK_SERVER
+            #  value: ""
             - name: POD_NAME
               valueFrom:
                 fieldRef:


### PR DESCRIPTION
We dropped the webhook configuration, but forgot to disable the webhook
server. This is causing knmstate pod to fail.

Signed-off-by: Petr Horacek <phoracek@redhat.com>