### PR TITLE
fix release target in the makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -155,8 +155,8 @@ release: $(GITHUB_RELEASE)
 	GITHUB_RELEASE=$(GITHUB_RELEASE) \
 	TAG=$(shell hack/version.sh) \
 	  hack/release.sh \
-	    manifests/cluster-network-addons.package.yaml \
-	    $(shell find manifests/$(shell hack/version.sh) -type f)
+	    manifests/cluster-network-addons/cluster-network-addons.package.yaml \
+	    $(shell find manifests/cluster-network-addons/$(shell hack/version.sh) -type f)
 
 .PHONY: \
 	$(E2E_SUITES) \

--- a/version/version.go
+++ b/version/version.go
@@ -5,3 +5,4 @@ var (
 )
 
 // * Force release after fixing automation scripts
+// * Force release after fixing release target


### PR DESCRIPTION
Wrong path was used for manifest assets.

Signed-off-by: Petr Horacek <phoracek@redhat.com>