### PR TITLE
Add cniVersion to multus CNI

### DIFF
--- a/data/multus/002-multus.yaml
+++ b/data/multus/002-multus.yaml
@@ -49,7 +49,7 @@ spec:
       containers:
       - name: kube-multus
         command: ["/entrypoint.sh"]
-        args: ["--multus-conf-file=auto"]
+        args: ["--multus-conf-file=auto","--cni-version=0.3.1"]
         image: {{ .MultusImage }}
         imagePullPolicy: {{ .ImagePullPolicy }}
         resources:


### PR DESCRIPTION
With newer multus cniVersion is mandatory.

Signed-off-by: Quique Llorente <ellorent@redhat.com>