### PR TITLE
limit versions tested in lifecycle lane

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1999,6 +1999,7 @@
     "github.com/aktau/github-release",
     "github.com/blang/semver",
     "github.com/ghodss/yaml",
+    "github.com/gobwas/glob",
     "github.com/onsi/ginkgo",
     "github.com/onsi/ginkgo/extensions/table",
     "github.com/onsi/ginkgo/ginkgo",


### PR DESCRIPTION
Currently we always test upgrade from all released versions to the master
branch.

That has two major issues:

The upgrade test of more than 20 versions back is ran on every PR. This takes a
lot of time and slows down the development cycle. With this PR we test upgrades
only from releases pinned to HCO on regular PRs. That should be sufficient since
we test the full upgrade on release PRs.

When releasing, we test upgrade from to-be-released version to master. That is
failing since the to-be-released version is not yet accessible in Quay. With
this PR we make sure to exclude this version from the test.

Lifecycle tests without this change take around 1h20m on a regular PR. With this change, the time was reduced to 30m. Time needed for the workflow lane is around 20m (parallel to the lifecycle one).

We can further optimalize lifecycle upgrade tests in a follow-up PRs.

Signed-off-by: Petr Horacek <phoracek@redhat.com>