### PR TITLE
drop limitations of resources

### DIFF
--- a/data/linux-bridge/0004-bridge-marker-daemonset.yaml
+++ b/data/linux-bridge/0004-bridge-marker-daemonset.yaml
@@ -33,9 +33,6 @@ spec:
           requests:
             cpu: "100m"
             memory: "40Mi"
-          limits:
-            cpu: "100m"
-            memory: "40Mi"
         args:
           - -node-name
           - $(NODE_NAME)

--- a/data/linux-bridge/002-linux-bridge.yaml
+++ b/data/linux-bridge/002-linux-bridge.yaml
@@ -48,9 +48,6 @@ spec:
             requests:
               cpu: "60m"
               memory: "30Mi"
-            limits:
-              cpu: "60m"
-              memory: "30Mi"
           securityContext:
             privileged: true
           volumeMounts:

--- a/data/multus/002-multus.yaml
+++ b/data/multus/002-multus.yaml
@@ -56,9 +56,6 @@ spec:
           requests:
             cpu: "60m"
             memory: "30Mi"
-          limits:
-            cpu: "60m"
-            memory: "30Mi"
         securityContext:
           privileged: true
         volumeMounts:

--- a/data/nmstate/003-operator.yaml
+++ b/data/nmstate/003-operator.yaml
@@ -36,9 +36,6 @@ spec:
             requests:
               cpu: "200m"
               memory: "120Mi"
-            limits:
-              cpu: "200m"
-              memory: "120Mi"
           command:
           - kubernetes-nmstate
           env:
@@ -122,9 +119,6 @@ spec:
           imagePullPolicy: {{ .ImagePullPolicy }}
           resources:
             requests:
-              cpu: "200m"
-              memory: "120Mi"
-            limits:
               cpu: "200m"
               memory: "120Mi"
           command:

--- a/data/ovs/002-ovs-daemonset.yaml
+++ b/data/ovs/002-ovs-daemonset.yaml
@@ -33,9 +33,6 @@ spec:
             requests:
               cpu: "60m"
               memory: "30Mi"
-            limits:
-              cpu: "60m"
-              memory: "30Mi"
           securityContext:
             privileged: true
           volumeMounts:
@@ -46,9 +43,6 @@ spec:
           imagePullPolicy: {{ .ImagePullPolicy }}
           resources:
             requests:
-              cpu: "100m"
-              memory: "40Mi"
-            limits:
               cpu: "100m"
               memory: "40Mi"
           securityContext:


### PR DESCRIPTION
There seems to be a bug in CRI-O causing pods to fail with
"lstat /proc/63538/ns/ipc: no such file or directory" when there is not enough
resources allocated to them.

With this PR we drop all the resource limitations. As long as the cluster is not
low on resources, we should not trigger the bug.

BZ: https://bugzilla.redhat.com/1776236

Signed-off-by: Petr Horacek <phoracek@redhat.com>