### PR TITLE
Make components macvtap

### DIFF
--- a/components.yaml
+++ b/components.yaml
@@ -17,3 +17,6 @@ components:
   ovs-cni:
     url: "https://github.com/kubevirt/ovs-cni"
     commit: "23d572171e383009aefa693832d1d8a7b8d04b22" # v0.11.0
+  macvtap-cni:
+    url: "https://github.com/kubevirt/macvtap-cni"
+    commit: "0c1d111aab4b8222ac2b341d0ce53981649ba2a3" # v0.1.0

--- a/hack/components.sh
+++ b/hack/components.sh
@@ -71,3 +71,48 @@ KUBEMACPOOL_IMAGE=quay.io/kubevirt/kubemacpool
 KUBEMACPOOL_IMAGE_TAGGED=${KUBEMACPOOL_IMAGE}:${KUBEMACPOOL_TAG}
 sed -i "s#\"${KUBEMACPOOL_IMAGE}:.*\"#\"${KUBEMACPOOL_IMAGE_TAGGED}\"#" pkg/components/components.go
 sed -i "s#\"${KUBEMACPOOL_IMAGE}:.*\"#\"${KUBEMACPOOL_IMAGE_TAGGED}\"#" test/releases/${CNAO_VERSION}.go
+
+echo 'macvtap'
+MACVTAP_URL=$(cat components.yaml | shyaml get-value components.macvtap-cni.url)
+MACVTAP_COMMIT=$(cat components.yaml | shyaml get-value components.macvtap-cni.commit)
+MACVTAP_REPO=$(echo ${MACVTAP_URL} | sed 's#https://\(.*\)#\1#')
+MACVTAP_PATH=${GOPATH}/src/${MACVTAP_REPO}
+
+echo 'Fetch macvtap-cni sources'
+(
+    go get ${MACVTAP_REPO} || true
+    cd ${MACVTAP_PATH}
+    git fetch origin
+    git reset --hard
+    git checkout ${MACVTAP_COMMIT}
+)
+
+rm -rf data/macvtap/*
+echo 'Copy the templates from the macvtap-cni repo ...'
+cp ${MACVTAP_PATH}/templates/namespace.yaml.in data/macvtap/000-ns.yaml
+echo "{{ if .EnableSCC }}" >> data/macvtap/001-rbac.yaml
+cat ${MACVTAP_PATH}/templates/scc.yaml.in >> data/macvtap/001-rbac.yaml
+echo "{{ end }}" >> data/macvtap/001-rbac.yaml
+cat <<EOF > data/macvtap/002-macvtap-daemonset.yaml
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: macvtap-deviceplugin-config
+  namespace: {{ .Namespace }}
+data:
+  DP_MACVTAP_CONF: "[]"
+---
+EOF
+cat ${MACVTAP_PATH}/templates/macvtap.yaml.in >> data/macvtap/002-macvtap-daemonset.yaml
+
+echo 'Get macvtap-cni image name and update it under CNAO'
+MACVTAP_TAG=$(
+    cd ${MACVTAP_PATH}
+    git describe --tags
+)
+MACVTAP_IMAGE=quay.io/kubevirt/macvtap-cni
+MACVTAP_IMAGE_TAGGED=${MACVTAP_IMAGE}:${MACVTAP_TAG}
+sed -i "s#\"${MACVTAP_IMAGE}:.*\"#\"${MACVTAP_IMAGE_TAGGED}\"#" pkg/components/components.go
+# TODO: uncomment the following line *once* there is macvtap upgrade is supported
+#sed -i "s#\"${MACVTAP_IMAGE}:.*\"#\"${MACVTAP_IMAGE_TAGGED}\"#" test/releases/${CNAO_VERSION}.go


### PR DESCRIPTION
Automate macvtap component generation.

By doing `make components`, the specified version of macvtap-cni is cloned, and it's manifests copied, becoming available as CNAO provisioning files.

Depends-on: #346 
Depends-on: https://github.com/kubevirt/macvtap-cni/pull/20
