### PR TITLE
drop stdci .mounts and .packages

### DIFF
--- a/automation/check-patch.e2e-lifecycle-k8s.mounts
+++ b/automation/check-patch.e2e-lifecycle-k8s.mounts
@@ -1,1 +1,0 @@
-check-patch.e2e.mounts

--- a/automation/check-patch.e2e-lifecycle-k8s.packages
+++ b/automation/check-patch.e2e-lifecycle-k8s.packages
@@ -1,1 +1,0 @@
-check-patch.e2e.packages

--- a/automation/check-patch.e2e-lifecycle-okd.mounts
+++ b/automation/check-patch.e2e-lifecycle-okd.mounts
@@ -1,1 +1,0 @@
-check-patch.e2e.mounts

--- a/automation/check-patch.e2e-lifecycle-okd.packages
+++ b/automation/check-patch.e2e-lifecycle-okd.packages
@@ -1,1 +1,0 @@
-check-patch.e2e.packages

--- a/automation/check-patch.e2e-workflow-k8s.mounts
+++ b/automation/check-patch.e2e-workflow-k8s.mounts
@@ -1,1 +1,0 @@
-check-patch.e2e.mounts

--- a/automation/check-patch.e2e-workflow-k8s.packages
+++ b/automation/check-patch.e2e-workflow-k8s.packages
@@ -1,1 +1,0 @@
-check-patch.e2e.packages

--- a/automation/check-patch.e2e-workflow-okd.mounts
+++ b/automation/check-patch.e2e-workflow-okd.mounts
@@ -1,1 +1,0 @@
-check-patch.e2e.mounts

--- a/automation/check-patch.e2e-workflow-okd.packages
+++ b/automation/check-patch.e2e-workflow-okd.packages
@@ -1,1 +1,0 @@
-check-patch.e2e.packages

--- a/automation/check-patch.e2e.mounts
+++ b/automation/check-patch.e2e.mounts
@@ -1,1 +1,0 @@
-/var/run/docker.sock:/var/run/docker.sock


### PR DESCRIPTION
This configuration is not needed anymore. Cleaning up.

We keep .packages, so it is clear what are the dependencies to run our jobs.

Signed-off-by: Petr Horacek <phoracek@redhat.com>