### PR TITLE
tests: try to catch progressing state more reliably

### DIFF
--- a/test/e2e/workflow/deployment_test.go
+++ b/test/e2e/workflow/deployment_test.go
@@ -181,16 +181,26 @@ var _ = Describe("NetworkAddonsConfig", func() {
 })
 
 func testConfigCreate(configSpec opv1alpha1.NetworkAddonsConfigSpec, components []Component) {
-	CreateConfig(configSpec)
-	checkConfigChange(components)
+	checkConfigChange(components, func() {
+		CreateConfig(configSpec)
+	})
 }
 
 func testConfigUpdate(configSpec opv1alpha1.NetworkAddonsConfigSpec, components []Component) {
-	UpdateConfig(configSpec)
-	checkConfigChange(components)
+	checkConfigChange(components, func() {
+		UpdateConfig(configSpec)
+	})
 }
 
-func checkConfigChange(components []Component) {
+func checkConfigChange(components []Component, while func()) {
+
+	// Start the function with a little delay to give the Progressing check a better chance
+	// of catching the event
+	go func() {
+		time.Sleep(time.Second)
+		while()
+	}()
+
 	// On OpenShift 4, Multus is already deployed by default
 	onlyMultusOnOKDCluster := (len(components) == 1 &&
 		IsOnOKDCluster() &&

--- a/test/e2e/workflow/deployment_test.go
+++ b/test/e2e/workflow/deployment_test.go
@@ -192,6 +192,14 @@ func testConfigUpdate(configSpec opv1alpha1.NetworkAddonsConfigSpec, components 
 	})
 }
 
+// checkConfigChange verifies that given components transition through
+// Progressing to Available state while and after the given callback function is
+// executed. We start the monitoring sooner than the callback to ensure we catch
+// all transitions from the very beginning.
+//
+// TODO This should be replaced by a solution based around `Watch` once it is
+// available on operator-sdk test framework:
+// https://github.com/operator-framework/operator-sdk/issues/2655
 func checkConfigChange(components []Component, while func()) {
 
 	// Start the function with a little delay to give the Progressing check a better chance


### PR DESCRIPTION
There is a race on our CI where we sometimes don't catch Progressing state. That
can happen when the the image of a deployed component is already in registry and
therefore the start of it is swift. With this change, we run configuration
change with a little delay after we start listening for the progressing state.
This can still fail, but our chances are better. Better approach would be to
start a monitor instead of polling, that is however not yet supported in the
controller-runtime Client.

Signed-off-by: Petr Horacek <phoracek@redhat.com>