### PR TITLE
don't remove CRDs when their comonents are gone

### DIFF
--- a/pkg/controller/networkaddonsconfig/networkaddonsconfig_controller.go
+++ b/pkg/controller/networkaddonsconfig/networkaddonsconfig_controller.go
@@ -363,9 +363,9 @@ func (r *ReconcileNetworkAddonsConfig) applyObjects(networkAddonsConfig *opv1alp
 		// Mark the object to be GC'd if the owner is deleted.
 		// Don't set owner reference on namespaces if they are used by the operator itself
 		// Don't set owner reference on CRDs, they should survive removal of the operator
-		operatorNamespace := obj.GetKind() == "Namespace" && obj.GetName() == operatorNamespace
-		crd := obj.GetKind() == "CustomResourceDefinition"
-		if !crd && !operatorNamespace {
+		isOperatorNamespace := obj.GetKind() == "Namespace" && obj.GetName() == operatorNamespace
+		isCRD := obj.GetKind() == "CustomResourceDefinition"
+		if !isCRD && !isOperatorNamespace {
 			if err := controllerutil.SetControllerReference(networkAddonsConfig, obj, r.scheme); err != nil {
 				log.Printf("could not set reference for (%s) %s/%s: %v", obj.GroupVersionKind(), obj.GetNamespace(), obj.GetName(), err)
 				err = errors.Wrapf(err, "could not set reference for (%s) %s/%s", obj.GroupVersionKind(), obj.GetNamespace(), obj.GetName())

--- a/pkg/network/network.go
+++ b/pkg/network/network.go
@@ -145,7 +145,6 @@ func Render(conf *opv1alpha1.NetworkAddonsConfigSpec, manifestDir string, opensh
 func RenderObjsToRemove(prev, conf *opv1alpha1.NetworkAddonsConfigSpec, manifestDir string, openshiftNetworkConfig *osv1.Network, clusterInfo *ClusterInfo) ([]*unstructured.Unstructured, error) {
 	log.Print("starting rendering objects to delete phase")
 	objsToRemove := []*unstructured.Unstructured{}
-	objsToRemoveWithoutNamespace := []*unstructured.Unstructured{}
 
 	if prev == nil {
 		return nil, nil
@@ -202,15 +201,27 @@ func RenderObjsToRemove(prev, conf *opv1alpha1.NetworkAddonsConfigSpec, manifest
 
 	// Remove OPERAND_NAMESPACE occurences
 	// TODO cleanup OPERAND_NAMESPACE once there are no components using it.
+	objsToRemoveWithoutNamespace := []*unstructured.Unstructured{}
 	operandNamespace := os.Getenv("OPERAND_NAMESPACE")
 	for _, obj := range objsToRemove {
 		if !(obj.GetName() == operandNamespace && obj.GetKind() == "Namespace") {
 			objsToRemoveWithoutNamespace = append(objsToRemoveWithoutNamespace, obj)
 		}
 	}
+	objsToRemove = objsToRemoveWithoutNamespace
 
-	log.Printf("object removal render phase done, rendered %d objects to remove", len(objsToRemoveWithoutNamespace))
-	return objsToRemoveWithoutNamespace, nil
+	// Do not remove CustomResourceDefinitions, they should be kept even after
+	// removal of the operator
+	objsToRemoveWithoutCRDs := []*unstructured.Unstructured{}
+	for _, obj := range objsToRemove {
+		if obj.GetKind() != "CustomResourceDefinition" {
+			objsToRemoveWithoutCRDs = append(objsToRemoveWithoutCRDs, obj)
+		}
+	}
+	objsToRemove = objsToRemoveWithoutCRDs
+
+	log.Printf("object removal render phase done, rendered %d objects to remove", len(objsToRemove))
+	return objsToRemove, nil
 }
 
 func errorListToMultiLineString(errs []error) string {


### PR DESCRIPTION
We want to prevent deletion of CRs created by the user, even during removal of
the operator. Therefore, we don't set ownership reference on CRDs.

We also want to prevent deletion of CRDs during removal of a single component.