### PR TITLE
Bump knmstate to v0.15.5

### DIFF
--- a/components.yaml
+++ b/components.yaml
@@ -13,7 +13,7 @@ components:
     commit: "b3b7bde391b40c3f3f8446626a1efa0b62cf39c9" # v0.8.3
   nmstate:
     url: "https://github.com/nmstate/kubernetes-nmstate"
-    commit: "32ab18423f20d80dbb715f7b909b6bbdcce2c85e" # v0.15.4
+    commit: "7fad7b948c4051cc3b1bac272d709048af896049" # v0.15.5
   ovs-cni:
     url: "https://github.com/kubevirt/ovs-cni"
     commit: "d61bd2b26f6c1df8ed38a4572b2ab4adaf48245d" # v0.10.0

--- a/data/nmstate/003-operator.yaml
+++ b/data/nmstate/003-operator.yaml
@@ -71,9 +71,13 @@ spec:
               value: "False"
             - name: PROFILER_PORT
               value: "6060"
+            - name: NMSTATE_INSTANCE_NODE_LOCK_FILE
+              value: "/var/k8s_nmstate/handler_lock"
           volumeMounts:
           - name: dbus-socket
             mountPath: /run/dbus/system_bus_socket
+          - name: nmstate-lock
+            mountPath: /var/k8s_nmstate
           securityContext:
             privileged: true
       volumes:
@@ -81,6 +85,9 @@ spec:
         hostPath:
           path: /run/dbus/system_bus_socket
           type: Socket
+      - name: nmstate-lock
+        hostPath:
+          path: /var/k8s_nmstate
 ---
 apiVersion: apps/v1
 kind: DaemonSet
@@ -152,9 +159,13 @@ spec:
               value: "False"
             - name: PROFILER_PORT
               value: "6060"
+            - name: NMSTATE_INSTANCE_NODE_LOCK_FILE
+              value: "/var/k8s_nmstate/handler_lock"
           volumeMounts:
             - name: dbus-socket
               mountPath: /run/dbus/system_bus_socket
+            - name: nmstate-lock
+              mountPath: /var/k8s_nmstate
           securityContext:
             privileged: true
       volumes:
@@ -162,6 +173,9 @@ spec:
           hostPath:
             path: /run/dbus/system_bus_socket
             type: Socket
+        - name: nmstate-lock
+          hostPath:
+            path: /var/k8s_nmstate
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -24,7 +24,7 @@ const (
 	LinuxBridgeCniImageDefault    = "quay.io/kubevirt/cni-default-plugins:v0.8.1"
 	LinuxBridgeMarkerImageDefault = "quay.io/kubevirt/bridge-marker:0.2.0"
 	KubeMacPoolImageDefault       = "quay.io/kubevirt/kubemacpool:v0.8.3"
-	NMStateHandlerImageDefault    = "quay.io/nmstate/kubernetes-nmstate-handler:v0.15.4"
+	NMStateHandlerImageDefault    = "quay.io/nmstate/kubernetes-nmstate-handler:v0.15.5"
 	OvsCniImageDefault            = "quay.io/kubevirt/ovs-cni-plugin:v0.10.0"
 	OvsMarkerImageDefault         = "quay.io/kubevirt/ovs-cni-marker:v0.10.0"
 )

--- a/test/releases/0.28.0.go
+++ b/test/releases/0.28.0.go
@@ -36,13 +36,13 @@ func init() {
 				ParentName: "nmstate-handler",
 				ParentKind: "DaemonSet",
 				Name:       "nmstate-handler",
-				Image:      "quay.io/nmstate/kubernetes-nmstate-handler:v0.15.4",
+				Image:      "quay.io/nmstate/kubernetes-nmstate-handler:v0.15.5",
 			},
 			opv1alpha1.Container{
 				ParentName: "nmstate-handler-worker",
 				ParentKind: "DaemonSet",
 				Name:       "nmstate-handler",
-				Image:      "quay.io/nmstate/kubernetes-nmstate-handler:v0.15.4",
+				Image:      "quay.io/nmstate/kubernetes-nmstate-handler:v0.15.5",
 			},
 			opv1alpha1.Container{
 				ParentName: "ovs-cni-amd64",


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Bump kubernetes-nmstate to v0.15.5 so it handles the upgrade between CNAO installed kubernetes-nmstate and non CNAO installed kubernetes-nmstate using a lock.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
knmstate: Lock handler if another handler is running at the same node, needed for upgrades between cnao installed knmstate and non-cnao installed knmstate.
```
