### PR TITLE
Bump macvtap-cni to 0.2.0

### DIFF
--- a/components.yaml
+++ b/components.yaml
@@ -19,4 +19,4 @@ components:
     commit: "23d572171e383009aefa693832d1d8a7b8d04b22" # v0.11.0
   macvtap-cni:
     url: "https://github.com/kubevirt/macvtap-cni"
-    commit: "0c1d111aab4b8222ac2b341d0ce53981649ba2a3" # v0.1.0
+    commit: "14e5a3c7bf516bd4542366a78b7af02f04230ac5" # v0.2.0

--- a/data/macvtap/002-macvtap-daemonset.yaml
+++ b/data/macvtap/002-macvtap-daemonset.yaml
@@ -2,7 +2,7 @@
 kind: ConfigMap
 apiVersion: v1
 metadata:
-  name: macvtap-dp-config
+  name: macvtap-deviceplugin-config
   namespace: {{ .Namespace }}
 data:
   DP_MACVTAP_CONF: "[]"
@@ -28,7 +28,7 @@ spec:
         command: [ "/macvtap-deviceplugin", "-v", "3", "-logtostderr"]
         envFrom:
           - configMapRef:
-              name: macvtap-dp-config
+              name: macvtap-deviceplugin-config
         image: {{ .MacvtapImage }}
         imagePullPolicy: {{ .ImagePullPolicy }}
         resources:

--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -27,7 +27,7 @@ const (
 	NMStateHandlerImageDefault    = "quay.io/nmstate/kubernetes-nmstate-handler:v0.18.0"
 	OvsCniImageDefault            = "quay.io/kubevirt/ovs-cni-plugin:v0.11.0"
 	OvsMarkerImageDefault         = "quay.io/kubevirt/ovs-cni-marker:v0.11.0"
-	MacvtapCniImageDefault        = "quay.io/kubevirt/macvtap-cni:v0.1.0"
+	MacvtapCniImageDefault        = "quay.io/kubevirt/macvtap-cni:v0.2.0"
 )
 
 type AddonsImages struct {


### PR DESCRIPTION
Bump macvtap-cni to 0.2.0

```release-note
Macvtap-cni now exposes all physical host links (also bonds) in each k8s node by default.
```