### PR TITLE
knmstate: fix Namespace variable in templates

### DIFF
--- a/data/nmstate/001-rbac.yaml
+++ b/data/nmstate/001-rbac.yaml
@@ -136,5 +136,5 @@ runAsUser:
 seLinuxContext:
   type: RunAsAny
 users:
-- system:serviceaccount:{{ .Namespace }}:nmstate-handler
+- system:serviceaccount:{{ .HandlerNamespace }}:nmstate-handler
 {{ end }}


### PR DESCRIPTION
During refactoring, we forget to rename Namespace to HandlerNamespace in the SCC
template. Since we don't test SCCs in our automation, this was not catched in
our CI.

/kind bug

```release-note
Fix kubernetes-nmstate RBAC template
```