### PR TITLE
add JSONSchema type to the root of our CRD

### DIFF
--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -359,6 +359,7 @@ func GetCrd() *extv1beta1.CustomResourceDefinition {
 
 			Validation: &extv1beta1.CustomResourceValidation{
 				OpenAPIV3Schema: &extv1beta1.JSONSchemaProps{
+					Type: "object",
 					Properties: map[string]extv1beta1.JSONSchemaProps{
 						"apiVersion": extv1beta1.JSONSchemaProps{
 							Type: "string",


### PR DESCRIPTION
Without this setting, the json schema validation fails with:

CustomResourceDefinition.apiextensions.k8s.io "networkaddonsconfigs.networkaddonsoperator.network.kubevirt.io" is invalid: spec.validation.openAPIV3Schema.type: Required value: must not be empty at the root

Signed-off-by: Petr Horacek <phoracek@redhat.com>