### PR TITLE
Bump kubemacpool v0.10.0

### DIFF
--- a/components.yaml
+++ b/components.yaml
@@ -10,7 +10,7 @@ components:
     commit: "2c01b100bcae0061a622d8b82e2c4db4ac092b4c" # 0.2.0
   kubemacpool:
     url: "https://github.com/k8snetworkplumbingwg/kubemacpool"
-    commit: "b3b7bde391b40c3f3f8446626a1efa0b62cf39c9" # v0.8.3
+    commit: "bd3057c490e011624ba7992af0b4e8d6bf8a5d81" # v0.10.0
   nmstate:
     url: "https://github.com/nmstate/kubernetes-nmstate"
     commit: "330667b2025f0ce489f54c24c2f6a3db86662ac5" # v0.20.0

--- a/data/kubemacpool/kubemacpool.yaml
+++ b/data/kubemacpool/kubemacpool.yaml
@@ -4,10 +4,77 @@ metadata:
   labels:
     control-plane: mac-controller-manager
     controller-tools.k8s.io: "1.0"
-    kubemacpool/ignoreAdmission: "true"
     openshift.io/run-level: "0"
     runlevel: "0"
   name: {{ .Namespace }}
+---
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: MutatingWebhookConfiguration
+metadata:
+  labels: null
+  name: kubemacpool-mutator
+webhooks:
+- clientConfig:
+    service:
+      name: kubemacpool-service
+      namespace: {{ .Namespace }}
+      path: /mutate-pods
+  failurePolicy: Fail
+  name: mutatepods.kubemacpool.io
+  namespaceSelector:
+    matchExpressions:
+    - key: runlevel
+      operator: NotIn
+      values:
+      - "0"
+      - "1"
+    - key: openshift.io/run-level
+      operator: NotIn
+      values:
+      - "0"
+      - "1"
+    matchLabels:
+      mutatepods.kubemacpool.io: allocateForAll
+  rules:
+  - apiGroups:
+    - ""
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    resources:
+    - pods
+- clientConfig:
+    service:
+      name: kubemacpool-service
+      namespace: {{ .Namespace }}
+      path: /mutate-virtualmachines
+  failurePolicy: Fail
+  name: mutatevirtualmachines.kubemacpool.io
+  namespaceSelector:
+    matchExpressions:
+    - key: runlevel
+      operator: NotIn
+      values:
+      - "0"
+      - "1"
+    - key: openshift.io/run-level
+      operator: NotIn
+      values:
+      - "0"
+      - "1"
+    matchLabels:
+      mutatevirtualmachines.kubemacpool.io: allocateForAll
+  rules:
+  - apiGroups:
+    - kubevirt.io
+    apiVersions:
+    - v1alpha3
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - virtualmachines
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -16,18 +83,19 @@ metadata:
   name: kubemacpool-manager-role
 rules:
 - apiGroups:
+  - certificates.k8s.io
+  resources:
+  - certificatesigningrequests
+  - certificatesigningrequests/approval
+  verbs:
+  - '*'
+- apiGroups:
   - admissionregistration.k8s.io
   resources:
   - mutatingwebhookconfigurations
   - validatingwebhookconfigurations
   verbs:
-  - get
-  - list
-  - watch
-  - create
-  - update
-  - patch
-  - delete
+  - '*'
 - apiGroups:
   - ""
   resources:
@@ -45,12 +113,7 @@ rules:
   resources:
   - configmaps
   verbs:
-  - get
-  - list
-  - watch
-  - update
-  - create
-  - delete
+  - '*'
 - apiGroups:
   - ""
   resources:
@@ -112,6 +175,12 @@ rules:
   - create
   - update
   - patch
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -138,6 +207,29 @@ metadata:
     controller-tools.k8s.io: "1.0"
   name: kubemacpool-mac-range-config
   namespace: '{{ .Namespace }}'
+---
+apiVersion: v1
+data:
+  tls.crt: YmFkIGNlcnRpZmljYXRlCg==
+  tls.key: YmFkIGtleQo=
+kind: Secret
+metadata:
+  name: kubemacpool-service
+  namespace: '{{ .Namespace }}'
+type: kubernetes.io/tls
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: kubemacpool-service
+  namespace: '{{ .Namespace }}'
+spec:
+  ports:
+  - port: 443
+    targetPort: 8000
+  publishNotReadyAddresses: true
+  selector:
+    kubemacpool-leader: "true"
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -197,13 +289,27 @@ spec:
             configMapKeyRef:
               key: RANGE_END
               name: kubemacpool-mac-range-config
+        - name: HEALTH_PROBE_HOST
+          value: 0.0.0.0
+        - name: HEALTH_PROBE_PORT
+          value: "9440"
         image: '{{ .KubeMacPoolImage }}'
         imagePullPolicy: '{{ .ImagePullPolicy }}'
         name: manager
         ports:
-        - containerPort: 9876
+        - containerPort: 8000
           name: webhook-server
           protocol: TCP
+        readinessProbe:
+          httpGet:
+            httpHeaders:
+            - name: Content-Type
+              value: application/json
+            path: /readyz
+            port: webhook-server
+            scheme: HTTPS
+          initialDelaySeconds: 10
+          periodSeconds: 10
         resources:
           limits:
             cpu: 300m
@@ -211,8 +317,16 @@ spec:
           requests:
             cpu: 100m
             memory: 300Mi
+        volumeMounts:
+        - mountPath: /etc/webhook/certs
+          name: tls-key-pair
+          readOnly: true
       restartPolicy: Always
       terminationGracePeriodSeconds: 5
+      volumes:
+      - name: tls-key-pair
+        secret:
+          secretName: kubemacpool-service
 ---
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget

--- a/hack/components.sh
+++ b/hack/components.sh
@@ -65,6 +65,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: mac-controller-manager
+  namespace: system
 spec:
   template:
     spec:
@@ -78,7 +79,7 @@ rm -rf data/kubemacpool/*
 (
     cd $KUBEMACPOOL_PATH
     kustomize build config/cnao | \
-        sed 's/name: kubemacpool-system/name: {{ .Namespace }}/' | \
+        sed 's/kubemacpool-system/{{ .Namespace }}/' | \
         sed 's/RANGE_START: .*/RANGE_START: {{ .RangeStart }}/' | \
         sed 's/RANGE_END: .*/RANGE_END: {{ .RangeEnd }}/'
 ) > data/kubemacpool/kubemacpool.yaml

--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -23,7 +23,7 @@ const (
 	MultusImageDefault            = "nfvpe/multus:v3.4.1"
 	LinuxBridgeCniImageDefault    = "quay.io/kubevirt/cni-default-plugins:v0.8.1"
 	LinuxBridgeMarkerImageDefault = "quay.io/kubevirt/bridge-marker:0.2.0"
-	KubeMacPoolImageDefault       = "quay.io/kubevirt/kubemacpool:v0.8.3"
+	KubeMacPoolImageDefault       = "quay.io/kubevirt/kubemacpool:v0.10.0"
 	NMStateHandlerImageDefault    = "quay.io/nmstate/kubernetes-nmstate-handler:v0.20.0"
 	OvsCniImageDefault            = "quay.io/kubevirt/ovs-cni-plugin:v0.11.0"
 	OvsMarkerImageDefault         = "quay.io/kubevirt/ovs-cni-marker:v0.11.0"

--- a/test/releases/99.0.0.go
+++ b/test/releases/99.0.0.go
@@ -30,7 +30,7 @@ func init() {
 				ParentName: "kubemacpool-mac-controller-manager",
 				ParentKind: "Deployment",
 				Name:       "manager",
-				Image:      "quay.io/kubevirt/kubemacpool:v0.8.3",
+				Image:      "quay.io/kubevirt/kubemacpool:v0.10.0",
 			},
 			opv1alpha1.Container{
 				ParentName: "nmstate-handler",


### PR DESCRIPTION
This PR bump kubemacpool to version v0.10.0, to introduce opt-in per namespace functionality, cert-manager upgrade so that kubemacpool can run on openshift, fixing flaky tests, and other infra updates.

```release-note
kubemacpool bumped to v0.10.0
```