### PR TITLE
Replace multistage with vendored go

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,29 @@
+# We cannot call `docker build` out of top dir since this is controlled by
+# operator-sdk and it does not has the option to change that, but future
+# versin of operator-sdk is going to split the build process into small
+# makefile targets and we will be able to tune that, so this file will
+# be smaller
+
+# git stuff
+.git
+.github
+
+# The path for kubevirtci installation
+_kubevirtci
+
+# No need for source code is already compiled
+pkg
+cmd
+tools
+vendor
+docs
+
+# Test and infra
+test
+test_logs
+automation
+
+
+# go tools
+build/**/go*
+build/**/go

--- a/Makefile
+++ b/Makefile
@@ -34,18 +34,26 @@ E2E_SUITES = \
 	test/e2e/lifecycle \
 	test/e2e/workflow
 
-OPERATOR_SDK ?= build/_output/bin/operator-sdk
+BIN_DIR = $(CURDIR)/build/_output/bin/
+GOBIN = $(BIN_DIR)/go/bin/
 
-GITHUB_RELEASE ?= build/_output/bin/github-release
+OPERATOR_SDK ?= $(BIN_DIR)/operator-sdk
 
-$(GINKGO): go.mod
-	GOBIN=$$(pwd)/build/_output/bin/ go install ./vendor/github.com/onsi/ginkgo/ginkgo
+GITHUB_RELEASE ?= $(BIN_DIR)/github-release
 
-$(OPERATOR_SDK): go.mod
-	GOBIN=$$(pwd)/build/_output/bin/ go install ./vendor/github.com/operator-framework/operator-sdk/cmd/operator-sdk
+GO := $(GOBIN)/go
 
-$(GITHUB_RELEASE): go.mod
-	GOBIN=$$(pwd)/build/_output/bin/ go install ./vendor/github.com/github-release/github-release
+$(GO):
+	hack/install-go.sh $(BIN_DIR)
+
+$(GINKGO): $(GO) go.mod
+	GOBIN=$$(pwd)/build/_output/bin/ $(GO) install ./vendor/github.com/onsi/ginkgo/ginkgo
+
+$(OPERATOR_SDK): $(GO) go.mod
+	GOBIN=$$(pwd)/build/_output/bin/ $(GO) install ./vendor/github.com/operator-framework/operator-sdk/cmd/operator-sdk
+
+$(GITHUB_RELEASE): $(GO) go.mod
+	GOBIN=$$(pwd)/build/_output/bin/ $(GO) install ./vendor/github.com/github-release/github-release
 
 # Make does not offer a recursive wildcard function, so here's one:
 rwildcard=$(wildcard $1$2) $(foreach d,$(wildcard $1*),$(call rwildcard,$d/,$2))
@@ -60,7 +68,7 @@ apis_sources=$(call rwildcard,pkg/apis,*.go)
 fmt: whitespace goimports
 
 goimports: $(cmd_sources) $(pkg_sources)
-	go run ./vendor/golang.org/x/tools/cmd/goimports -w ./pkg ./cmd ./test/
+	$(GO) run ./vendor/golang.org/x/tools/cmd/goimports -w ./pkg ./cmd ./test/
 	touch $@
 
 whitespace: $(all_sources)
@@ -73,20 +81,26 @@ whitespace-check: $(all_sources)
 	./hack/whitespace.sh
 	touch $@
 
-vet: $(cmd_sources) $(pkg_sources)
-	go vet ./pkg/... ./cmd/... ./test/...
+vet: $(GO) $(cmd_sources) $(pkg_sources)
+	$(GO) vet ./pkg/... ./cmd/... ./test/...
 	touch $@
 
-goimports-check: $(cmd_sources) $(pkg_sources)
-	go run ./vendor/golang.org/x/tools/cmd/goimports -d ./pkg ./cmd
+goimports-check: $(GO) $(cmd_sources) $(pkg_sources)
+	$(GO) run ./vendor/golang.org/x/tools/cmd/goimports -d ./pkg ./cmd
 	touch $@
 
 test/unit: $(GINKGO)
 	$(GINKGO) $(GINKGO_ARGS) ./pkg/ ./cmd/
 
+manager: $(GO)
+	CGO_ENABLED=0 GOOS=linux $(GO) build -o $(BIN_DIR)/$@ ./cmd/...
+
+manifest-templator: $(GO)
+	CGO_ENABLED=0 GOOS=linux $(GO) build -o $(BIN_DIR)/$@ ./tools/manifest-templator/...
+
 docker-build: docker-build-operator docker-build-registry
 
-docker-build-operator:
+docker-build-operator: manager manifest-templator
 	docker build -f build/operator/Dockerfile -t $(IMAGE_REGISTRY)/$(OPERATOR_IMAGE):$(IMAGE_TAG) .
 
 docker-build-registry:
@@ -121,7 +135,7 @@ cluster-clean:
 	./cluster/clean.sh
 
 # Default images can be found in pkg/components/components.go
-gen-manifests:
+gen-manifests: manifest-templator
 	VERSION_REPLACES=$(VERSION_REPLACES) \
 	DEPLOY_DIR=$(DEPLOY_DIR) \
 	CONTAINER_PREFIX=$(IMAGE_REGISTRY) \
@@ -162,9 +176,9 @@ release: $(GITHUB_RELEASE)
 	    manifests/cluster-network-addons/cluster-network-addons.package.yaml \
 	    $(shell find manifests/cluster-network-addons/$(shell hack/version.sh) -type f)
 
-vendor:
-	go mod tidy
-	go mod vendor
+vendor: $(GO)
+	$(GO) mod tidy
+	$(GO) mod vendor
 
 .PHONY: \
 	$(E2E_SUITES) \
@@ -176,6 +190,8 @@ vendor:
 	cluster-operator-push \
 	cluster-sync \
 	cluster-up \
+	manager \
+	manifests-templator \
 	docker-build \
 	docker-build-operator \
 	docker-build-registry \

--- a/build/operator/Dockerfile
+++ b/build/operator/Dockerfile
@@ -1,11 +1,3 @@
-FROM golang:1.12 AS builder
-WORKDIR /src/cluster-network-addons-operator/
-COPY . .
-ENV GOFLAGS=-mod=vendor
-ENV GO111MODULE=on
-RUN CGO_ENABLED=0 GOOS=linux go build -o /cluster-network-addons-operator github.com/kubevirt/cluster-network-addons-operator/cmd/manager
-RUN CGO_ENABLED=0 GOOS=linux go build -o /manifest-templator github.com/kubevirt/cluster-network-addons-operator/tools/manifest-templator
-
 FROM centos:centos7
 ENV ENTRYPOINT=/entrypoint \
     OPERATOR=/cluster-network-addons-operator \
@@ -16,13 +8,13 @@ ENV ENTRYPOINT=/entrypoint \
 RUN \
     yum -y update \
     yum clean all
-COPY --from=builder /src/cluster-network-addons-operator/build/operator/bin/user_setup /user_setup
-COPY --from=builder /src/cluster-network-addons-operator/build/operator/bin/csv-generator /usr/bin/csv-generator
-COPY --from=builder /src/cluster-network-addons-operator/templates/cluster-network-addons/VERSION/cluster-network-addons-operator.VERSION.clusterserviceversion.yaml.in cluster-network-addons-operator.VERSION.clusterserviceversion.yaml.in
+COPY build/operator/bin/user_setup /user_setup
+COPY build/operator/bin/csv-generator /usr/bin/csv-generator
+COPY templates/cluster-network-addons/VERSION/cluster-network-addons-operator.VERSION.clusterserviceversion.yaml.in cluster-network-addons-operator.VERSION.clusterserviceversion.yaml.in
 RUN /user_setup
-COPY --from=builder /src/cluster-network-addons-operator/data /data
-COPY --from=builder /cluster-network-addons-operator $OPERATOR
-COPY --from=builder /manifest-templator $MANIFEST_TEMPLATOR
-COPY --from=builder /src/cluster-network-addons-operator/build/operator/bin/entrypoint $ENTRYPOINT
+COPY data /data
+COPY build/_output/bin/manager $OPERATOR
+COPY build/_output/bin/manifest-templator $MANIFEST_TEMPLATOR
+COPY build/operator/bin/entrypoint $ENTRYPOINT
 ENTRYPOINT $ENTRYPOINT
 USER $USER_UID

--- a/hack/generate-manifests.sh
+++ b/hack/generate-manifests.sh
@@ -7,8 +7,6 @@ CONTAINER_PREFIX="${CONTAINER_PREFIX:-quay.io/kubevirt}"
 CONTAINER_TAG="${CONTAINER_TAG:-latest}"
 IMAGE_PULL_POLICY="${IMAGE_PULL_POLICY:-Always}"
 
-go build -o ${PROJECT_ROOT}/tools/manifest-templator/manifest-templator github.com/kubevirt/cluster-network-addons-operator/tools/manifest-templator
-
 templates=$(cd ${PROJECT_ROOT}/templates && find . -type f -name "*.yaml.in")
 for template in $templates; do
 	infile="${PROJECT_ROOT}/templates/${template}"
@@ -20,7 +18,7 @@ for template in $templates; do
 	file="${dir}/$(basename -s .in $template)"
 	file=${file/VERSION/$VERSION}
 	rendered=$( \
-		${PROJECT_ROOT}/tools/manifest-templator/manifest-templator \
+		${PROJECT_ROOT}/build/_output/bin/manifest-templator \
 		--version=${VERSION} \
 		--version-replaces=${VERSION_REPLACES} \
 		--operator-version=${VERSION} \
@@ -33,5 +31,3 @@ for template in $templates; do
 		echo -e "$rendered" > $file
 	fi
 done
-
-(cd ${PROJECT_ROOT}/tools/manifest-templator/ && go clean)

--- a/hack/install-go.sh
+++ b/hack/install-go.sh
@@ -1,0 +1,10 @@
+#!/bin/bash -xe
+
+destination=$1
+version=$(grep "^go " go.mod |awk '{print $2}')
+tarball=go$version.linux-amd64.tar.gz
+url=https://dl.google.com/go/
+
+mkdir -p $destination
+curl -L $url/$tarball -o $destination/$tarball
+tar -xf $destination/$tarball -C $destination


### PR DESCRIPTION
<!-- Thanks for sending a pull request!                                         
                                                                                
Before you click the 'Create pull request' make sure that:                      
- This PR introduces a single feature of fix, just one                          
- This PR does not leave the master branch broken                               
- Every commit in this PR has a commit message explaining what do you change,   
  why and what is the outcome                                                   
- If your change introduces a complex concept or a change to user interaction   
  with the project or the application, make sure to document it                 
                                                                                
If you don't comply with these rules, you waste your energy, time of reviewers  
and cause suffering of future generations.                                      
-->                                                                             
                                                                                
**What this PR does / why we need it**:
We are already not using multistage to run suff like vet or goimports, this PR remove it alltogether and uses a installed golang version that uses go.mod version to select it, it reduces build time and indirections.                                         
                                                                                
**Special notes for your reviewer**:                                            
                                                                                
**Release note**:                                                               
<!--  Write your release note:                                                  
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".                           
-->                                                                             
                                                                                
```release-note                                                                 
Golang tools vendored and multistage build removed.                                                                          
```                                                               