### PR TITLE
Add KUBEVIRT_PROVIDER=external support

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,6 +279,25 @@ make cluster-clean
 make cluster-down
 ```
 
+For developing at an external cluster:
+
+```bash
+export KUBEVIRT_PROVIDER=external
+
+export KUBECONFIG=[path to external's cluster kubeconfig]
+
+# This is the registry used to push and pull the dev image
+# it has to be accessible by the external cluster
+export DEV_IMAGE_REGISTRY=quay.io/$USER
+
+# Then is possible to follow normal dev flow
+
+make cluster-operator-push
+make cluster-operator-install
+make test/e2e/workflow
+make test/e2e/lifecycle
+```
+
 # Releasing
 
 1. Checkout a public branch


### PR DESCRIPTION
It will add DEV_IMAGE_REPOSITORY as the intermediate repo between
developer and cluster also KUBECONFIG has to be set pointing to the
external cluster

Signed-off-by: Quique Llorente <ellorent@redhat.com>

```release-note
Support for KUBEVIRT_PROVIDER=external
```