### PR TITLE
status_manager: only require single ready pod for deployment

### DIFF
--- a/pkg/controller/statusmanager/status_manager.go
+++ b/pkg/controller/statusmanager/status_manager.go
@@ -300,9 +300,7 @@ func (status *StatusManager) SetFromPods() {
 
 		// Finally check whether Pods belonging to this Deployments are being started or they
 		// are being scheduled.
-		if dep.Status.UnavailableReplicas > 0 {
-			progressing = append(progressing, fmt.Sprintf("Deployment %q is not available (awaiting %d nodes)", depName.String(), dep.Status.UnavailableReplicas))
-		} else if dep.Status.AvailableReplicas == 0 {
+		if dep.Status.AvailableReplicas == 0 {
 			progressing = append(progressing, fmt.Sprintf("Deployment %q is not yet scheduled on any nodes", depName.String()))
 		} else if dep.Status.ObservedGeneration < dep.Generation {
 			progressing = append(progressing, fmt.Sprintf("Deployment %q update is being processed (generation %d, observed generation %d)", depName.String(), dep.Generation, dep.Status.ObservedGeneration))

--- a/test/check/check.go
+++ b/test/check/check.go
@@ -322,7 +322,7 @@ func checkForDeployment(name string) error {
 		}
 	}
 
-	if deployment.Status.UnavailableReplicas > 0 || deployment.Status.AvailableReplicas == 0 {
+	if deployment.Status.AvailableReplicas == 0 {
 		manifest, err := yaml.Marshal(deployment)
 		if err != nil {
 			panic(err)


### PR DESCRIPTION
Currently we wait until all the pods in deployment become ready.
That is not necessary, we can turn Ready once at least one pod
in the deployment is able to serve requests.

This is needed, so we don't block when deployment uses leader
election in combination with readiness probe and only one pod is
marked as ready at the time.

Signed-off-by: Petr Horacek <phoracek@redhat.com>