### PR TITLE
keep the order of webhooks while merging

### DIFF
--- a/pkg/apply/merge_test.go
+++ b/pkg/apply/merge_test.go
@@ -386,8 +386,8 @@ webhooks:
 			expected := k8s.UnstructuredFromYaml(fmt.Sprintf(template, "kubernetes-nmstate-2", "caBundle: ca1", "caBundle: ca2", "caBundle: ca3"))
 			err := apply.MergeObjectForUpdate(current, updated)
 			Expect(err).ToNot(HaveOccurred(), "should successfully execut merge function")
-			Expect(*updated).To(Equal(*expected))
 
+			Expect(*updated).To(Equal(*expected), "the object should be updated as expected, with original caBundles left intact")
 		})
 	})
 })


### PR DESCRIPTION
In the current code, we first transform both the current and the new
list of webhooks into a map of webhooks by names. The problem with that
is that a hashmap does not keep the original order. Due to that, the
result of the merging is inconsistent, causing tests to fail and it
would also cause us to reapply config, even when there is nothing needed
to be changed.

With this patch, we iterate the original list of webhooks without
translating it to a map, to keep the original order.

Signed-off-by: Petr Horacek <phoracek@redhat.com>