### PR TITLE
fix merge reconcile of mutatingWebhookConfiguration when both current…

### DIFF
--- a/pkg/apply/merge.go
+++ b/pkg/apply/merge.go
@@ -183,13 +183,11 @@ func mergeWebhookConfiguration(current, updated *unstructured.Unstructured) erro
 		if err != nil {
 			return errors.Wrapf(err, "failed searching caBundle 'field' at webhook %s", updatedWebhookName)
 		}
-		if !found {
-			continue
-		}
-
-		err = unstructured.SetNestedField(updatedWebhook.(map[string]interface{}), caBundle, "clientConfig", "caBundle")
-		if err != nil {
-			return errors.Wrapf(err, "failed copying caBundle from current config to updated config at webhook %s", updatedWebhookName)
+		if found {
+			err = unstructured.SetNestedField(updatedWebhook.(map[string]interface{}), caBundle, "clientConfig", "caBundle")
+			if err != nil {
+				return errors.Wrapf(err, "failed copying caBundle from current config to updated config at webhook %s", updatedWebhookName)
+			}
 		}
 
 		mergedWebhooks = append(mergedWebhooks, updatedWebhook)


### PR DESCRIPTION
… and updated have no caBundle.

Currently when we reconcile webhookConfiguration instances, we make sure to pass the current caBundle to the updated instance should it not have it, but if both don't have a caBundle then it removes the entire webhook section in the webhookConfiguration instance.
in order to fix this, a fix in the logic was inserted, and also the unit test was expanded to include this scenario.

Signed-off-by: Ram Lavi <ralavi@redhat.com>