### PR TITLE
add make tools

### DIFF
--- a/hack/functest.sh
+++ b/hack/functest.sh
@@ -23,7 +23,7 @@ source ./cluster/kubevirtci.sh
 ${OPERATOR_SDK} test \
     local \
     ./${TEST_SUITE} \
-    --namespace cluster-network-addons \
+    --operator-namespace cluster-network-addons \
     --no-setup \
     --kubeconfig $(kubevirtci::kubeconfig) \
     --go-test-flags "${TEST_ARGS}"

--- a/hack/install-tools.sh
+++ b/hack/install-tools.sh
@@ -1,0 +1,6 @@
+#!/bin/bash -xe
+tools_file=$1
+tools=$(grep "_" $tools_file |  sed 's/.*_ *"//' | sed 's/"//g')
+for tool in $tools; do
+    $GO install ./vendor/$tool
+done


### PR DESCRIPTION
Signed-off-by: Ram Lavi <ralavi@redhat.com>

**What this PR does / why we need it**:
Currently the tools in tools.go can be updated separetly using the appropriate 'make dep'
In order to simplify the infra and make updating tools as simple as updating another golang dep in go.mod -
we added to possibility to do 'make tools'.

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
