### PR TITLE
Bump NetworkManager to 1.22 so we can test knmstate

### DIFF
--- a/cluster/up.sh
+++ b/cluster/up.sh
@@ -32,7 +32,7 @@ if [[ "$KUBEVIRT_PROVIDER" =~ k8s- ]]; then
     echo 'Install NetworkManager on nodes'
     for node in $(./cluster/kubectl.sh get nodes --no-headers | awk '{print $1}'); do
         ./cluster/cli.sh ssh ${node} sudo -- yum install -y yum-plugin-copr
-        ./cluster/cli.sh ssh ${node} sudo -- yum copr enable -y networkmanager/NetworkManager-1.20
+        ./cluster/cli.sh ssh ${node} sudo -- yum copr enable -y networkmanager/NetworkManager-1.22
         ./cluster/cli.sh ssh ${node} sudo -- yum install -y NetworkManager NetworkManager-ovs
         ./cluster/cli.sh ssh ${node} sudo -- systemctl daemon-reload
         ./cluster/cli.sh ssh ${node} sudo -- systemctl restart NetworkManager


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the master branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it

If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**What this PR does / why we need it**:
If we want to run tier1 tests at CNAO u/s we need the same NetworkManager versions installed at kubernetes-nmstate master, for now that's is 1.22.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
