### PR TITLE
remove over privileged rbac from cnao manifest

### DIFF
--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -308,17 +308,6 @@ func GetClusterRole() *rbacv1.ClusterRole {
 					"watch",
 				},
 			},
-			{
-				APIGroups: []string{
-					"*",
-				},
-				Resources: []string{
-					"*",
-				},
-				Verbs: []string{
-					"*",
-				},
-			},
 		},
 	}
 	return role


### PR DESCRIPTION
Signed-off-by: Ram Lavi <ralavi@redhat.com>

**What this PR does / why we need it**:
Currently the cnao rbac Policy has a segment that elevates the container privileges to all resources, and all verbs.
This is too much for the cnao's needs, and also in turn changes scc to anyuid in cnv/okd clusters.
Hence, the rbac segment is removed in this commit.

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
