### PR TITLE
allow listing of all SCC

### DIFF
--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -273,9 +273,6 @@ func GetClusterRole() *rbacv1.ClusterRole {
 				Resources: []string{
 					"securitycontextconstraints",
 				},
-				ResourceNames: []string{
-					"privileged",
-				},
 				Verbs: []string{
 					"get",
 					"list",


### PR DESCRIPTION


Signed-off-by: Petr Horacek <phoracek@redhat.com>

<!-- Thanks for sending a pull request!

Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the master branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it

If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**What this PR does / why we need it**:

In 19291e695e6a293ed395bf42ab23aaaa91e68162 we have dropped the
universal ClusterRole allowing us to handle all objects. That introduced
a bug where we were not able to list SCCs, despite we had a rule for it,
it was limited to a single name and resulted in this bug:
https://bugzilla.redhat.com/show_bug.cgi?id=1844057

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
Fix bug caused my missing SCC rule, preventing CNAO from starting on OpenShift
```
