### PR TITLE
Revert "remove over privileged rbac from cnao manifest"

### DIFF
--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -308,6 +308,17 @@ func GetClusterRole() *rbacv1.ClusterRole {
 					"watch",
 				},
 			},
+			{
+				APIGroups: []string{
+					"*",
+				},
+				Resources: []string{
+					"*",
+				},
+				Verbs: []string{
+					"*",
+				},
+			},
 		},
 	}
 	return role


### PR DESCRIPTION
Reverts kubevirt/cluster-network-addons-operator#413

We have to rework this and allow CNAO to edit more resources. By dropping of the global role, we blocked us from creating anything on OpenShift.