### PR TITLE
Fix false positive on the CI and missed bugs

### DIFF
--- a/hack/functest.sh
+++ b/hack/functest.sh
@@ -23,7 +23,7 @@ source ./cluster/kubevirtci.sh
 ${OPERATOR_SDK} test \
     local \
     ./${TEST_SUITE} \
-    --namespace cluster-network-addons \
+    --operator-namespace cluster-network-addons \
     --no-setup \
     --kubeconfig $(kubevirtci::kubeconfig) \
     --go-test-flags "${TEST_ARGS}"

--- a/test/e2e/workflow/validation_test.go
+++ b/test/e2e/workflow/validation_test.go
@@ -44,7 +44,7 @@ var _ = Describe("NetworkAddonsConfig", func() {
 				NMState:     &opv1alpha1.NMState{},
 			}
 			CreateConfig(configSpec)
-			CheckConfigCondition(ConditionAvailable, ConditionTrue, time.Minute, CheckDoNotRepeat)
+			CheckConfigCondition(ConditionAvailable, ConditionTrue, 2*time.Minute, CheckDoNotRepeat)
 		})
 
 		Context("and a component which does support removal is removed from the Spec", func() {


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the master branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it

If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**What this PR does / why we need it**:

Fix operator-sdk test --namespace flag. It has been changed to --operator-namespace. Using --namespace cause operator-sdk to return immediately with false positive.



**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
