### PR TITLE
Fix rbac in CNAO's manifest

### DIFF
--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -273,13 +273,26 @@ func GetClusterRole() *rbacv1.ClusterRole {
 				Resources: []string{
 					"securitycontextconstraints",
 				},
+				Verbs: []string{
+					"get",
+					"list",
+					"watch",
+				},
+			},
+			{
+				APIGroups: []string{
+					"security.openshift.io",
+				},
+				Resources: []string{
+					"securitycontextconstraints",
+				},
 				ResourceNames: []string{
 					"privileged",
 				},
 				Verbs: []string{
 					"get",
-					"list",
-					"watch",
+					"patch",
+					"update",
 				},
 			},
 			{
@@ -301,11 +314,111 @@ func GetClusterRole() *rbacv1.ClusterRole {
 				},
 				Resources: []string{
 					"networkaddonsconfigs",
+					"networkaddonsconfigs/status",
 				},
 				Verbs: []string{
 					"get",
 					"list",
 					"watch",
+					"update",
+				},
+			},
+			{
+				APIGroups: []string{
+					"",
+				},
+				Resources: []string{
+					"services",
+					"configmaps",
+					"namespaces",
+					"nodes",
+					"nodes/status",
+					"serviceaccounts",
+					"pods",
+					"pods/status",
+					"events",
+					"secrets",
+				},
+				Verbs: []string{
+					"*",
+				},
+			},
+			{
+				APIGroups: []string{
+					"apps",
+				},
+				Resources: []string{
+					"*",
+				},
+				Verbs: []string{
+					"*",
+				},
+			},
+			{
+				APIGroups: []string{
+					"rbac.authorization.k8s.io",
+				},
+				Resources: []string{
+					"*",
+				},
+				Verbs: []string{
+					"*",
+				},
+			},
+			{
+				APIGroups: []string{
+					"admissionregistration.k8s.io",
+				},
+				Resources: []string{
+					"mutatingwebhookconfigurations",
+					"validatingwebhookconfigurations",
+				},
+				Verbs: []string{
+					"*",
+				},
+			},
+			{
+				APIGroups: []string{
+					"k8s.cni.cncf.io",
+				},
+				Resources: []string{
+					"*",
+				},
+				Verbs: []string{
+					"*",
+				},
+			},
+			{
+				APIGroups: []string{
+					"apiextensions.k8s.io",
+				},
+				Resources: []string{
+					"customresourcedefinitions",
+				},
+				Verbs: []string{
+					"*",
+				},
+			},
+			{
+				APIGroups: []string{
+					"kubevirt.io",
+				},
+				Resources: []string{
+					"virtualmachines",
+				},
+				Verbs: []string{
+					"*",
+				},
+			},
+			{
+				APIGroups: []string{
+					"policy",
+				},
+				Resources: []string{
+					"poddisruptionbudgets",
+				},
+				Verbs: []string{
+					"*",
 				},
 			},
 		},

--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -308,17 +308,6 @@ func GetClusterRole() *rbacv1.ClusterRole {
 					"watch",
 				},
 			},
-			{
-				APIGroups: []string{
-					"*",
-				},
-				Resources: []string{
-					"*",
-				},
-				Verbs: []string{
-					"*",
-				},
-			},
 		},
 	}
 	return role


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently the cnao rbac Policy has a segment that elevates the container privileges to all resources, and all verbs.
This is too much for the cnao's needs, and also in turn changes scc to anyuid in cnv/okd clusters.
Hence, the rbac segment is replaced with more refined rbac rules.

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
