### PR TITLE
bump bridge marker to 0.3.0

### DIFF
--- a/components.yaml
+++ b/components.yaml
@@ -7,7 +7,7 @@ components:
     commit: "ad10b6fa91aacd720f1f9ab94341a97a82a24965" # v0.8.6
   bridge-marker:
     url: "https://github.com/kubevirt/bridge-marker"
-    commit: "2c01b100bcae0061a622d8b82e2c4db4ac092b4c" # 0.2.0
+    commit: "049eb6a796b742767a0be838f6ddb7f79c97dd60" # 0.3.0
   kubemacpool:
     url: "https://github.com/k8snetworkplumbingwg/kubemacpool"
     commit: "8b525e2df0ecf1bddd3417b6bf0d9e8516ee3ed1" # v0.14.2

--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -22,7 +22,7 @@ const (
 const (
 	MultusImageDefault            = "nfvpe/multus:v3.4.1"
 	LinuxBridgeCniImageDefault    = "quay.io/kubevirt/cni-default-plugins:v0.8.6"
-	LinuxBridgeMarkerImageDefault = "quay.io/kubevirt/bridge-marker:0.2.0"
+	LinuxBridgeMarkerImageDefault = "quay.io/kubevirt/bridge-marker:0.3.0"
 	KubeMacPoolImageDefault       = "quay.io/kubevirt/kubemacpool:v0.14.2"
 	NMStateHandlerImageDefault    = "quay.io/nmstate/kubernetes-nmstate-handler:v0.21.0"
 	OvsCniImageDefault            = "quay.io/kubevirt/ovs-cni-plugin:v0.12.0"

--- a/test/releases/99.0.0.go
+++ b/test/releases/99.0.0.go
@@ -18,7 +18,7 @@ func init() {
 				ParentName: "bridge-marker",
 				ParentKind: "DaemonSet",
 				Name:       "bridge-marker",
-				Image:      "quay.io/kubevirt/bridge-marker:0.2.0",
+				Image:      "quay.io/kubevirt/bridge-marker:0.3.0",
 			},
 			opv1alpha1.Container{
 				ParentName: "kube-cni-linux-bridge-plugin",


### PR DESCRIPTION


Signed-off-by: Petr Horacek <phoracek@redhat.com>

<!-- Thanks for sending a pull request!

Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the master branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it

If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**What this PR does / why we need it**:

The major difference is that this new release is built on Go 1.13 and
Kubernetes 1.18.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
bridge-marker was updated to 0.3.0
```
