### PR TITLE
Revert "status_manager: only require single ready pod for deployment"

### DIFF
--- a/pkg/controller/statusmanager/status_manager.go
+++ b/pkg/controller/statusmanager/status_manager.go
@@ -300,7 +300,9 @@ func (status *StatusManager) SetFromPods() {
 
 		// Finally check whether Pods belonging to this Deployments are being started or they
 		// are being scheduled.
-		if dep.Status.AvailableReplicas == 0 {
+		if dep.Status.UnavailableReplicas > 0 {
+			progressing = append(progressing, fmt.Sprintf("Deployment %q is not available (awaiting %d nodes)", depName.String(), dep.Status.UnavailableReplicas))
+		} else if dep.Status.AvailableReplicas == 0 {
 			progressing = append(progressing, fmt.Sprintf("Deployment %q is not yet scheduled on any nodes", depName.String()))
 		} else if dep.Status.ObservedGeneration < dep.Generation {
 			progressing = append(progressing, fmt.Sprintf("Deployment %q update is being processed (generation %d, observed generation %d)", depName.String(), dep.Generation, dep.Status.ObservedGeneration))

--- a/test/check/check.go
+++ b/test/check/check.go
@@ -339,7 +339,7 @@ func checkForDeployment(name string) error {
 		}
 	}
 
-	if deployment.Status.AvailableReplicas == 0 {
+	if deployment.Status.UnavailableReplicas > 0 || deployment.Status.AvailableReplicas == 0 {
 		manifest, err := yaml.Marshal(deployment)
 		if err != nil {
 			panic(err)


### PR DESCRIPTION
Signed-off-by: Ram Lavi <ralavi@redhat.com>

**What this PR does / why we need it**:
Currently, kubemacpool deployment is ready when at least 1 pod is ready.
Due to changes braught up in kubemacpool v0.14.3, both kubemapool pods should be in status ready.
Due to this, This commit reverts commit 2a053e585cfa430c8d1828a68ff25ef3aa446a6e.

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
