### PR TITLE
merge some upgrade tests

### DIFF
--- a/test/e2e/lifecycle/upgrade_test.go
+++ b/test/e2e/lifecycle/upgrade_test.go
@@ -42,11 +42,11 @@ var _ = Context("Cluster Network Addons Operator", func() {
 					CheckConfigVersions(expectedOperatorVersion, expectedObservedVersion, expectedTargetVersion, podsDeploymentTimeout, CheckDoNotRepeat)
 				})
 
-				It("it should report expected deployed container images", func() {
+				It("it should report expected deployed container images and leave no leftovers from the previous version", func() {
+					By("Checking reported container images")
 					CheckReleaseUsesExpectedContainerImages(newRelease)
-				})
 
-				It("should run with no leftovers from the original version", func() {
+					By("Checking for leftover objects from the previous version")
 					CheckForLeftoverObjects(newRelease.Version)
 				})
 			})


### PR DESCRIPTION


Signed-off-by: Petr Horacek <phoracek@redhat.com>

<!-- Thanks for sending a pull request!

Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the master branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it

If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**What this PR does / why we need it**:

For each release, we test upgrades from every previous release to the
newly created one. That takes a lot of time and is obviously getting
only worse.

This patch merges two of the three upgrade tests into a single one. They
are both just checking the state of the cluster, so we are not risking
too much by merging them.

This should save us 30 % of the time on the suite.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
