### PR TITLE
Revert "Fix rbac in CNAO's manifest (#419)"

### DIFF
--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -273,26 +273,13 @@ func GetClusterRole() *rbacv1.ClusterRole {
 				Resources: []string{
 					"securitycontextconstraints",
 				},
-				Verbs: []string{
-					"get",
-					"list",
-					"watch",
-				},
-			},
-			{
-				APIGroups: []string{
-					"security.openshift.io",
-				},
-				Resources: []string{
-					"securitycontextconstraints",
-				},
 				ResourceNames: []string{
 					"privileged",
 				},
 				Verbs: []string{
 					"get",
-					"patch",
-					"update",
+					"list",
+					"watch",
 				},
 			},
 			{
@@ -314,108 +301,19 @@ func GetClusterRole() *rbacv1.ClusterRole {
 				},
 				Resources: []string{
 					"networkaddonsconfigs",
-					"networkaddonsconfigs/status",
 				},
 				Verbs: []string{
 					"get",
 					"list",
 					"watch",
-					"update",
 				},
 			},
 			{
 				APIGroups: []string{
-					"",
-				},
-				Resources: []string{
-					"services",
-					"configmaps",
-					"namespaces",
-					"nodes",
-					"nodes/status",
-					"serviceaccounts",
-					"pods",
-					"pods/status",
-					"events",
-					"secrets",
-				},
-				Verbs: []string{
 					"*",
-				},
-			},
-			{
-				APIGroups: []string{
-					"apps",
 				},
 				Resources: []string{
 					"*",
-				},
-				Verbs: []string{
-					"*",
-				},
-			},
-			{
-				APIGroups: []string{
-					"rbac.authorization.k8s.io",
-				},
-				Resources: []string{
-					"*",
-				},
-				Verbs: []string{
-					"*",
-				},
-			},
-			{
-				APIGroups: []string{
-					"admissionregistration.k8s.io",
-				},
-				Resources: []string{
-					"mutatingwebhookconfigurations",
-					"validatingwebhookconfigurations",
-				},
-				Verbs: []string{
-					"*",
-				},
-			},
-			{
-				APIGroups: []string{
-					"k8s.cni.cncf.io",
-				},
-				Resources: []string{
-					"*",
-				},
-				Verbs: []string{
-					"*",
-				},
-			},
-			{
-				APIGroups: []string{
-					"apiextensions.k8s.io",
-				},
-				Resources: []string{
-					"customresourcedefinitions",
-				},
-				Verbs: []string{
-					"*",
-				},
-			},
-			{
-				APIGroups: []string{
-					"kubevirt.io",
-				},
-				Resources: []string{
-					"virtualmachines",
-				},
-				Verbs: []string{
-					"*",
-				},
-			},
-			{
-				APIGroups: []string{
-					"policy",
-				},
-				Resources: []string{
-					"poddisruptionbudgets",
 				},
 				Verbs: []string{
 					"*",


### PR DESCRIPTION

**What this PR does / why we need it**:
The latest [rbac fix](https://github.com/kubevirt/cluster-network-addons-operator/pull/419) introduced a new problem with [configmap finalizer](https://bugzilla.redhat.com/show_bug.cgi?id=1848004).
This reverts commit 4435752626331963f28cfc71e3dfa9ca4a9aea2e.
Due to this, unfortunately the [anyuid BZ](https://bugzilla.redhat.com/show_bug.cgi?id=1834839) will be reopened

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
