### PR TITLE
bump kubemacpool to v0.14.5

### DIFF
--- a/components.yaml
+++ b/components.yaml
@@ -10,7 +10,7 @@ components:
     commit: "049eb6a796b742767a0be838f6ddb7f79c97dd60" # 0.3.0
   kubemacpool:
     url: "https://github.com/k8snetworkplumbingwg/kubemacpool"
-    commit: "aa5edead1c6ca3eba4abb292f4a26768755cb99a" # v0.14.4
+    commit: "3db1d0bf7c6a383fa42376905fe3b18c8429963e" # v0.14.5
   nmstate:
     url: "https://github.com/nmstate/kubernetes-nmstate"
     commit: "a57e1ebf43b797094c39f87274e771633c269e69" # v0.21.0

--- a/data/kubemacpool/kubemacpool.yaml
+++ b/data/kubemacpool/kubemacpool.yaml
@@ -3,78 +3,8 @@ kind: Namespace
 metadata:
   labels:
     control-plane: mac-controller-manager
-    controller-tools.k8s.io: "1.0"
-    openshift.io/run-level: "0"
-    runlevel: "0"
+    mutatepods.kubemacpool.io: ignore
   name: {{ .Namespace }}
----
-apiVersion: admissionregistration.k8s.io/v1beta1
-kind: MutatingWebhookConfiguration
-metadata:
-  labels: null
-  name: kubemacpool-mutator
-webhooks:
-- clientConfig:
-    service:
-      name: kubemacpool-service
-      namespace: {{ .Namespace }}
-      path: /mutate-pods
-  failurePolicy: Fail
-  name: mutatepods.kubemacpool.io
-  namespaceSelector:
-    matchExpressions:
-    - key: runlevel
-      operator: NotIn
-      values:
-      - "0"
-      - "1"
-    - key: openshift.io/run-level
-      operator: NotIn
-      values:
-      - "0"
-      - "1"
-    matchLabels:
-      mutatepods.kubemacpool.io: allocate
-  rules:
-  - apiGroups:
-    - ""
-    apiVersions:
-    - v1
-    operations:
-    - CREATE
-    resources:
-    - pods
-- clientConfig:
-    service:
-      name: kubemacpool-service
-      namespace: {{ .Namespace }}
-      path: /mutate-virtualmachines
-  failurePolicy: Fail
-  name: mutatevirtualmachines.kubemacpool.io
-  namespaceSelector:
-    matchExpressions:
-    - key: runlevel
-      operator: NotIn
-      values:
-      - "0"
-      - "1"
-    - key: openshift.io/run-level
-      operator: NotIn
-      values:
-      - "0"
-      - "1"
-    matchLabels:
-      mutatevirtualmachines.kubemacpool.io: allocate
-  rules:
-  - apiGroups:
-    - kubevirt.io
-    apiVersions:
-    - v1alpha3
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - virtualmachines
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -321,3 +251,71 @@ spec:
       - name: tls-key-pair
         secret:
           secretName: kubemacpool-service
+---
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: MutatingWebhookConfiguration
+metadata:
+  labels: null
+  name: kubemacpool-mutator
+webhooks:
+- clientConfig:
+    service:
+      name: kubemacpool-service
+      namespace: {{ .Namespace }}
+      path: /mutate-pods
+  failurePolicy: Fail
+  name: mutatepods.kubemacpool.io
+  namespaceSelector:
+    matchExpressions:
+    - key: runlevel
+      operator: NotIn
+      values:
+      - "0"
+      - "1"
+    - key: openshift.io/run-level
+      operator: NotIn
+      values:
+      - "0"
+      - "1"
+    matchLabels:
+      mutatepods.kubemacpool.io: allocate
+  rules:
+  - apiGroups:
+    - ""
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    resources:
+    - pods
+- clientConfig:
+    service:
+      name: kubemacpool-service
+      namespace: {{ .Namespace }}
+      path: /mutate-virtualmachines
+  failurePolicy: Fail
+  name: mutatevirtualmachines.kubemacpool.io
+  namespaceSelector:
+    matchExpressions:
+    - key: runlevel
+      operator: NotIn
+      values:
+      - "0"
+      - "1"
+    - key: openshift.io/run-level
+      operator: NotIn
+      values:
+      - "0"
+      - "1"
+    matchLabels:
+      mutatevirtualmachines.kubemacpool.io: allocate
+  rules:
+  - apiGroups:
+    - kubevirt.io
+    apiVersions:
+    - v1alpha3
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - virtualmachines

--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -23,7 +23,7 @@ const (
 	MultusImageDefault            = "nfvpe/multus:v3.4.1"
 	LinuxBridgeCniImageDefault    = "quay.io/kubevirt/cni-default-plugins:v0.8.6"
 	LinuxBridgeMarkerImageDefault = "quay.io/kubevirt/bridge-marker:0.3.0"
-	KubeMacPoolImageDefault       = "quay.io/kubevirt/kubemacpool:v0.14.4"
+	KubeMacPoolImageDefault       = "quay.io/kubevirt/kubemacpool:v0.14.5"
 	NMStateHandlerImageDefault    = "quay.io/nmstate/kubernetes-nmstate-handler:v0.21.0"
 	OvsCniImageDefault            = "quay.io/kubevirt/ovs-cni-plugin:v0.12.0"
 	OvsMarkerImageDefault         = "quay.io/kubevirt/ovs-cni-marker:v0.12.0"

--- a/test/releases/99.0.0.go
+++ b/test/releases/99.0.0.go
@@ -30,7 +30,7 @@ func init() {
 				ParentName: "kubemacpool-mac-controller-manager",
 				ParentKind: "Deployment",
 				Name:       "manager",
-				Image:      "quay.io/kubevirt/kubemacpool:v0.14.4",
+				Image:      "quay.io/kubevirt/kubemacpool:v0.14.5",
 			},
 			opv1alpha1.Container{
 				ParentName: "nmstate-handler",


### PR DESCRIPTION
Signed-off-by: Petr Horacek <phoracek@redhat.com>

<!-- Thanks for sending a pull request!

Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the master branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it

If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**What this PR does / why we need it**:

This version brings fixes to two serious bugs. Inability to select a leader and setting namespace of the operator as run-level: "0".

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
Bump kubemacpool to v0.14.5
```
