### PR TITLE
Disable ginkgo colors at CI run

### DIFF
--- a/automation/check-patch.e2e-lifecycle-k8s.sh
+++ b/automation/check-patch.e2e-lifecycle-k8s.sh
@@ -34,7 +34,7 @@ main() {
     make cluster-up
     trap teardown EXIT SIGINT SIGTERM SIGSTOP
     make cluster-operator-push
-    make test/e2e/lifecycle
+    make E2E_TEST_EXTRA_ARGS="-ginkgo.noColor" test/e2e/lifecycle
 }
 
 [[ "${BASH_SOURCE[0]}" == "$0" ]] && main "$@"

--- a/automation/check-patch.e2e-workflow-k8s.sh
+++ b/automation/check-patch.e2e-workflow-k8s.sh
@@ -22,7 +22,7 @@ main() {
     trap teardown EXIT SIGINT SIGTERM SIGSTOP
     make cluster-operator-push
     make cluster-operator-install
-    make test/e2e/workflow
+    make E2E_TEST_EXTRA_ARGS="-ginkgo.noColor" test/e2e/workflow
 }
 
 [[ "${BASH_SOURCE[0]}" == "$0" ]] && main "$@"


### PR DESCRIPTION


Signed-off-by: Quique Llorente <ellorent@redhat.com>

<!-- Thanks for sending a pull request!

Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the master branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it

If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**What this PR does / why we need it**:
Disable ginkgo colors at CI run, It add garbage to prow output.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
