### PR TITLE
add describe logs when components has failed to be fully removed

### DIFF
--- a/test/check/check.go
+++ b/test/check/check.go
@@ -64,7 +64,7 @@ func CheckComponentsRemoval(components []Component) {
 		By(fmt.Sprintf("Checking that component %s has been removed", component.ComponentName))
 		Eventually(func() error {
 			return checkForComponentRemoval(&component)
-		}, 5*time.Minute, time.Second).ShouldNot(HaveOccurred(), "Component has not been fully removed within the given timeout")
+		}, 5*time.Minute, time.Second).ShouldNot(HaveOccurred(), fmt.Sprintf("%s component has not been fully removed within the given timeout\ndescribe all:\n%v", component.ComponentName, describeAll()))
 	}
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently CheckComponentsRemoval doesn't give enough info to debug failures.
Let's add describe all to the error to see what went wrong.

Signed-off-by: Ram Lavi <ralavi@redhat.com>

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
