### PR TITLE
Do not trim the version exposed in CR

### DIFF
--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -2,7 +2,6 @@ package components
 
 import (
 	"fmt"
-	"strings"
 
 	cnav1alpha1 "github.com/kubevirt/cluster-network-addons-operator/pkg/apis/networkaddonsoperator/v1alpha1"
 	appsv1 "k8s.io/api/apps/v1"
@@ -12,6 +11,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	opv1alpha1 "github.com/kubevirt/cluster-network-addons-operator/pkg/apis/networkaddonsoperator/v1alpha1"
+	"github.com/kubevirt/cluster-network-addons-operator/pkg/util/k8s"
 )
 
 const (
@@ -72,14 +72,6 @@ func (ai *AddonsImages) FillDefaults() *AddonsImages {
 func GetDeployment(version string, operatorVersion string, namespace string, repository string, imageName string, tag string, imagePullPolicy string, addonsImages *AddonsImages) *appsv1.Deployment {
 	image := fmt.Sprintf("%s/%s:%s", repository, imageName, tag)
 
-	// In case SHA is used for the version, we need to trim it to fit into labels
-	if len(operatorVersion) > 63 {
-		operatorVersion = operatorVersion[0:63]
-	}
-
-	// We also need to remove characters that are not allowed, e.g. :
-	operatorVersion = strings.Replace(operatorVersion, ":", "_", -1)
-
 	deployment := &appsv1.Deployment{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "apps/v1",
@@ -89,7 +81,7 @@ func GetDeployment(version string, operatorVersion string, namespace string, rep
 			Name:      Name,
 			Namespace: namespace,
 			Annotations: map[string]string{
-				opv1alpha1.SchemeGroupVersion.Group + "/version": operatorVersion,
+				opv1alpha1.SchemeGroupVersion.Group + "/version": k8s.StringToLabel(operatorVersion),
 			},
 		},
 		Spec: appsv1.DeploymentSpec{

--- a/pkg/controller/networkaddonsconfig/networkaddonsconfig_controller.go
+++ b/pkg/controller/networkaddonsconfig/networkaddonsconfig_controller.go
@@ -36,6 +36,7 @@ import (
 	"github.com/kubevirt/cluster-network-addons-operator/pkg/controller/statusmanager"
 	"github.com/kubevirt/cluster-network-addons-operator/pkg/names"
 	"github.com/kubevirt/cluster-network-addons-operator/pkg/network"
+	"github.com/kubevirt/cluster-network-addons-operator/pkg/util/k8s"
 )
 
 // ManifestPath is the path to the manifest templates
@@ -43,10 +44,12 @@ const ManifestPath = "./data"
 
 var operatorNamespace string
 var operatorVersion string
+var operatorVersionLabel string
 
 func init() {
 	operatorNamespace = os.Getenv("OPERATOR_NAMESPACE")
 	operatorVersion = os.Getenv("OPERATOR_VERSION")
+	operatorVersionLabel = k8s.StringToLabel(operatorVersion)
 }
 
 // Add creates a new NetworkAddonsConfig Controller and adds it to the Manager. The Manager will set fields on the Controller
@@ -305,7 +308,7 @@ func (r *ReconcileNetworkAddonsConfig) renderObjects(networkAddonsConfig *opv1al
 		if labels == nil {
 			labels = map[string]string{}
 		}
-		labels[opv1alpha1.SchemeGroupVersion.Group+"/version"] = operatorVersion
+		labels[opv1alpha1.SchemeGroupVersion.Group+"/version"] = operatorVersionLabel
 		obj.SetLabels(labels)
 	}
 

--- a/pkg/util/k8s/labels.go
+++ b/pkg/util/k8s/labels.go
@@ -1,0 +1,31 @@
+package k8s
+
+import (
+	"log"
+	"regexp"
+)
+
+var labelAntiSelector *regexp.Regexp
+
+func init() {
+	var err error
+
+	// Regex matching all non-allowed label characters
+	labelAntiSelector, err = regexp.Compile("[^a-z0-9A-Z_.-]+")
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+
+// Make given string label-compatible
+func StringToLabel(s string) string {
+	// We need to remove characters that are not allowed
+	s = labelAntiSelector.ReplaceAllString(s, "_")
+
+	// We need to trim the string to allowed length
+	if len(s) > 63 {
+		s = s[0:63]
+	}
+
+	return s
+}

--- a/pkg/util/k8s/labels_test.go
+++ b/pkg/util/k8s/labels_test.go
@@ -1,0 +1,46 @@
+package k8s_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/kubevirt/cluster-network-addons-operator/pkg/util/k8s"
+)
+
+var _ = Describe("StringToLabel", func() {
+	Context("when given a very long string", func() {
+		s := "Avalanches of water in the midst of a calm/And the distances cataracting toward the abyss!"
+
+		It("should trim the text to supported 63 characters", func() {
+			label := k8s.StringToLabel(s)
+			Expect(label).To(HaveLen(63), "The string should be trimmed to 63 characters")
+		})
+	})
+
+	Context("when given a string with special characters", func() {
+		s := "Avalanches&of:water"
+
+		It("should replace special characters with underscore", func() {
+			label := k8s.StringToLabel(s)
+			Expect(label).To(Equal("Avalanches_of_water"), "The string should have special characters replaced")
+		})
+	})
+
+	Context("when given a short string without special characters", func() {
+		s := "Avalanches_of-water."
+
+		It("should leave it intact", func() {
+			label := k8s.StringToLabel(s)
+			Expect(label).To(Equal(s), "The string should be left intact")
+		})
+	})
+
+	Context("when given an empty string", func() {
+		s := ""
+
+		It("should leave it intact", func() {
+			label := k8s.StringToLabel(s)
+			Expect(label).To(Equal(s), "The string should be left intact")
+		})
+	})
+})


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the master branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it

If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**What this PR does / why we need it**:

We started trimming the version so it can fit into labels. We will keep
that but we will stop trimming it for the use in our CRs. That way
whatever was set in CNAO deployment as a version will be exposed in its
CRs. So no unexpected results.

https://bugzilla.redhat.com/show_bug.cgi?id=1856438

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
Do not trim OPERATOR_VERSION in the CR
```
