### PR TITLE
Introduce `networkaddonsoperator.network.kubevirt.io/rejectOwner` annotation and drop ownership of KMP secrets

### DIFF
--- a/data/kubemacpool/kubemacpool.yaml
+++ b/data/kubemacpool/kubemacpool.yaml
@@ -6,74 +6,6 @@ metadata:
     mutatepods.kubemacpool.io: ignore
   name: {{ .Namespace }}
 ---
-apiVersion: admissionregistration.k8s.io/v1beta1
-kind: MutatingWebhookConfiguration
-metadata:
-  labels: null
-  name: kubemacpool-mutator
-webhooks:
-- clientConfig:
-    service:
-      name: kubemacpool-service
-      namespace: {{ .Namespace }}
-      path: /mutate-pods
-  failurePolicy: Fail
-  name: mutatepods.kubemacpool.io
-  namespaceSelector:
-    matchExpressions:
-    - key: runlevel
-      operator: NotIn
-      values:
-      - "0"
-      - "1"
-    - key: openshift.io/run-level
-      operator: NotIn
-      values:
-      - "0"
-      - "1"
-    matchLabels:
-      mutatepods.kubemacpool.io: allocate
-  rules:
-  - apiGroups:
-    - ""
-    apiVersions:
-    - v1
-    operations:
-    - CREATE
-    resources:
-    - pods
-- clientConfig:
-    service:
-      name: kubemacpool-service
-      namespace: {{ .Namespace }}
-      path: /mutate-virtualmachines
-  failurePolicy: Fail
-  name: mutatevirtualmachines.kubemacpool.io
-  namespaceSelector:
-    matchExpressions:
-    - key: runlevel
-      operator: NotIn
-      values:
-      - "0"
-      - "1"
-    - key: openshift.io/run-level
-      operator: NotIn
-      values:
-      - "0"
-      - "1"
-    matchLabels:
-      mutatevirtualmachines.kubemacpool.io: allocate
-  rules:
-  - apiGroups:
-    - kubevirt.io
-    apiVersions:
-    - v1alpha3
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - virtualmachines
----
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -206,6 +138,8 @@ data:
   tls.key: YmFkIGtleQo=
 kind: Secret
 metadata:
+  annotations:
+    networkaddonsoperator.network.kubevirt.io/rejectOwner: ""
   name: kubemacpool-service
   namespace: '{{ .Namespace }}'
 type: kubernetes.io/tls
@@ -319,3 +253,71 @@ spec:
       - name: tls-key-pair
         secret:
           secretName: kubemacpool-service
+---
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: MutatingWebhookConfiguration
+metadata:
+  labels: null
+  name: kubemacpool-mutator
+webhooks:
+- clientConfig:
+    service:
+      name: kubemacpool-service
+      namespace: {{ .Namespace }}
+      path: /mutate-pods
+  failurePolicy: Fail
+  name: mutatepods.kubemacpool.io
+  namespaceSelector:
+    matchExpressions:
+    - key: runlevel
+      operator: NotIn
+      values:
+      - "0"
+      - "1"
+    - key: openshift.io/run-level
+      operator: NotIn
+      values:
+      - "0"
+      - "1"
+    matchLabels:
+      mutatepods.kubemacpool.io: allocate
+  rules:
+  - apiGroups:
+    - ""
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    resources:
+    - pods
+- clientConfig:
+    service:
+      name: kubemacpool-service
+      namespace: {{ .Namespace }}
+      path: /mutate-virtualmachines
+  failurePolicy: Fail
+  name: mutatevirtualmachines.kubemacpool.io
+  namespaceSelector:
+    matchExpressions:
+    - key: runlevel
+      operator: NotIn
+      values:
+      - "0"
+      - "1"
+    - key: openshift.io/run-level
+      operator: NotIn
+      values:
+      - "0"
+      - "1"
+    matchLabels:
+      mutatevirtualmachines.kubemacpool.io: allocate
+  rules:
+  - apiGroups:
+    - kubevirt.io
+    apiVersions:
+    - v1alpha3
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - virtualmachines

--- a/data/nmstate/operator.yaml
+++ b/data/nmstate/operator.yaml
@@ -239,6 +239,8 @@ kind: Secret
 metadata:
   name: {{template "handlerPrefix" .}}nmstate-webhook
   namespace: {{ .HandlerNamespace }}
+  annotations:
+    networkaddonsoperator.network.kubevirt.io/rejectOwner: ""
 type: kubernetes.io/tls
 data:
   tls.crt: YmFkIGNlcnRpZmljYXRlCg==

--- a/hack/components/bump-knmstate.sh
+++ b/hack/components/bump-knmstate.sh
@@ -29,3 +29,10 @@ echo 'Copy kubernetes-nmstate manifests'
 rm -rf data/nmstate/*
 cp $NMSTATE_PATH/deploy/handler/* data/nmstate/
 cp $NMSTATE_PATH/deploy/crds/*nodenetwork*crd* data/nmstate/
+
+echo 'Apply custom CNAO patches on kubernetes-nmstate manifests'
+echo '
+241a242,243
+>   annotations:
+>     networkaddonsoperator.network.kubevirt.io/rejectOwner: ""
+' | patch data/nmstate/operator.yaml

--- a/hack/components/bump-kubemacpool.sh
+++ b/hack/components/bump-kubemacpool.sh
@@ -30,6 +30,7 @@ bases:
 - ../default
 patchesStrategicMerge:
 - cnao_image_patch.yaml
+- cnao_rejectowner_patch.yaml
 EOF
 
     cat <<EOF > config/cnao/cnao_image_patch.yaml
@@ -46,7 +47,18 @@ spec:
         imagePullPolicy: "{{ .ImagePullPolicy }}"
         name: manager
 EOF
+
+    cat <<EOF > config/cnao/cnao_rejectowner_patch.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: service
+  namespace: system
+  annotations:
+    networkaddonsoperator.network.kubevirt.io/rejectOwner: ""
+EOF
 )
+
 rm -rf data/kubemacpool/*
 (
     cd $KUBEMACPOOL_PATH

--- a/pkg/names/names.go
+++ b/pkg/names/names.go
@@ -7,3 +7,8 @@ const OPERATOR_CONFIG = "cluster"
 // APPLIED_PREFIX is the prefix applied to the config maps
 // where we store previously applied configuration
 const APPLIED_PREFIX = "cluster-networks-addons-operator-applied-"
+
+// REJECT_OWNER_ANNOTATION can be set on objects under data/ that should not be
+// assigned with NetworkAddonsConfig as their owner. This can be used to prevent
+// garbage collection deletion upon NetworkAddonsConfig removal.
+const REJECT_OWNER_ANNOTATION = "networkaddonsoperator.network.kubevirt.io/rejectOwner"

--- a/test/check/components.go
+++ b/test/check/components.go
@@ -17,7 +17,10 @@ var (
 		ClusterRole:        "kubemacpool-manager-role",
 		ClusterRoleBinding: "kubemacpool-manager-rolebinding",
 		Deployments:        []string{"kubemacpool-mac-controller-manager"},
-		// TODO: KubeMacPool secret is not owned by NetworkAddonsConfig and KubeMacPool is currently not cleaning it up upon removal. Therefore we cannot really check for it. Once is the cleanup implemented, we should check it again.
+		// TODO: KubeMacPool secret is not owned by NetworkAddonsConfig and
+		// KubeMacPool is currently not cleaning it up upon removal. Therefore
+		// we cannot really check for it. Once is the cleanup implemented, we
+		// should check it again.
 		// Secret:                       "kubemacpool-service",
 		MutatingWebhookConfiguration: "kubemacpool-mutator",
 	}
@@ -49,7 +52,11 @@ var (
 		Deployments: []string{
 			"nmstate-webhook",
 		},
-		Secret:                       "nmstate-webhook",
+		// TODO: KubeMacPool secret is not owned by NetworkAddonsConfig and
+		// knmstate is currently not cleaning it up upon removal. Therefore we
+		// cannot really check for it. Once is the cleanup implemented, we
+		// should check it again.
+		// Secret:                       "nmstate-webhook",
 		MutatingWebhookConfiguration: "nmstate",
 	}
 	OvsComponent = Component{

--- a/test/check/components.go
+++ b/test/check/components.go
@@ -13,11 +13,12 @@ type Component struct {
 
 var (
 	KubeMacPoolComponent = Component{
-		ComponentName:                "KubeMacPool",
-		ClusterRole:                  "kubemacpool-manager-role",
-		ClusterRoleBinding:           "kubemacpool-manager-rolebinding",
-		Deployments:                  []string{"kubemacpool-mac-controller-manager"},
-		Secret:                       "kubemacpool-service",
+		ComponentName:      "KubeMacPool",
+		ClusterRole:        "kubemacpool-manager-role",
+		ClusterRoleBinding: "kubemacpool-manager-rolebinding",
+		Deployments:        []string{"kubemacpool-mac-controller-manager"},
+		// TODO: KubeMacPool secret is not owned by NetworkAddonsConfig and KubeMacPool is currently not cleaning it up upon removal. Therefore we cannot really check for it. Once is the cleanup implemented, we should check it again.
+		// Secret:                       "kubemacpool-service",
 		MutatingWebhookConfiguration: "kubemacpool-mutator",
 	}
 	LinuxBridgeComponent = Component{


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the master branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it

If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**What this PR does / why we need it**:

# Introduce rejectOwner annotation

In the current code, we mark all objects created by CNAO (those kept
under data/) as owned by us. As a result, they are garbage collected
upon removal of NetworkAddonsConfig.

This cause complications with objects that we do not want to remove or
that we want to be owned by other objects. The recent example of this
were KubeMacPool secrets that need to be precreated in CNAO in order to
avoid chicken-egg issues, but then handled separately.

In order to provide a generic mechanism to avoid ownership, a new
annotation `networkaddonsoperator.network.kubevirt.io/rejectOwner` was
introduced. When an object is annotated with this, we will not set the
reference.

# Don't set owner reference on KMP secret

Currently, we set owner reference of the secret to NetworkAddonsConfig.
That means that it will be removed upon deletion of that CR.

The issue is that there are KMP controllers recreating this Secret, not
knowing whether the whole setup is being deleted or just the specific
Secret.

In order to make this little clearer, we decided not to own the secret
at all and leave its lifecycle on KMP. We still need to pre-create it
with its dummy values in CNAO to prevent chicken-egg issues.


# Don't set owner reference on knmstate secret

Currently, we set owner reference of the secret to NetworkAddonsConfig.
That means that it will be removed upon deletion of that CR.

The issue is that there are knmstate controllers recreating this Secret, not
knowing whether the whole setup is being deleted or just the specific
Secret.

In order to make this little clearer, we decided not to own the secret
at all and leave its lifecycle on knmstate. We still need to pre-create it
with its dummy values in CNAO to prevent chicken-egg issues.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
Introduce `networkaddonsoperator.network.kubevirt.io/rejectOwner` annotation and drop ownership of KMP secrets
```
