### PR TITLE
Fix test NetworkAddonsConfig shouldn't be empty when config deployed

### DIFF
--- a/pkg/controller/networkaddonsconfig/networkaddonsconfig_controller.go
+++ b/pkg/controller/networkaddonsconfig/networkaddonsconfig_controller.go
@@ -437,9 +437,7 @@ func (r *ReconcileNetworkAddonsConfig) trackDeployedObjects(objs []*unstructured
 		}
 	}
 
-	r.statusManager.SetDaemonSets(daemonSets)
-	r.statusManager.SetDeployments(deployments)
-	r.statusManager.SetContainers(containers)
+	r.statusManager.SetAttributes(daemonSets, deployments, containers)
 
 	allResources := []types.NamespacedName{}
 	allResources = append(allResources, daemonSets...)


### PR DESCRIPTION
The StatusManager `SetFromPods` function is accesed from both the `pod_controller` and `networkaddonsconfig_controller`.
This PR adds mutex and locks sections that read/write shared variables: containers, deployments, daemonSets.
Also, writing and reading these shared variables is done together atomicallly in single locked sections (`GetAttribures` and `SetAttributes`)

Signed-off-by: Radim Hrazdil <rhrazdil@redhat.com>

<!-- Thanks for sending a pull request!

Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the master branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it

If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**What this PR does / why we need it**:
Fix flaky test  https://github.com/kubevirt/cluster-network-addons-operator/issues/451

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
none
```
