### PR TITLE
Add kubernetes-nmstate openshift scc manifests from knmstate 0.25.0

### DIFF
--- a/components.yaml
+++ b/components.yaml
@@ -13,7 +13,7 @@ components:
     commit: "7728339b6c8dcfc9d53cc18ce8e06a910094ed47" # v0.16.0
   nmstate:
     url: "https://github.com/nmstate/kubernetes-nmstate"
-    commit: "ce634344aeda497dc6a51b20a9ac39984312038e" # v0.23.0
+    commit: "6f41747788235c3363a314dfae46a4ed90e1846a" # v0.25.0
   ovs-cni:
     url: "https://github.com/kubevirt/ovs-cni"
     commit: "edb4754d08f49be54c399c938895fe82aab6aa5a" # v0.12.0

--- a/data/nmstate/scc.yaml
+++ b/data/nmstate/scc.yaml
@@ -1,0 +1,21 @@
+{{define "handlerPrefix"}}{{with $prefix := .HandlerPrefix}}{{$prefix | printf "%s-"}}{{end -}}{{end}}
+{{ if .EnableSCC }}
+---
+apiVersion: security.openshift.io/v1
+kind: SecurityContextConstraints
+metadata:
+  name: nmstate
+allowPrivilegedContainer: true
+allowHostDirVolumePlugin: true
+allowHostNetwork: true
+allowHostIPC: false
+allowHostPID: false
+allowHostPorts: false
+readOnlyRootFilesystem: false
+runAsUser:
+  type: RunAsAny
+seLinuxContext:
+  type: RunAsAny
+users:
+- system:serviceaccount:{{ .HandlerNamespace }}:{{template "handlerPrefix" .}}nmstate-handler
+{{ end }}

--- a/hack/components/bump-knmstate.sh
+++ b/hack/components/bump-knmstate.sh
@@ -29,6 +29,9 @@ echo 'Copy kubernetes-nmstate manifests'
 rm -rf data/nmstate/*
 cp $NMSTATE_PATH/deploy/handler/* data/nmstate/
 cp $NMSTATE_PATH/deploy/crds/*nodenetwork*crd* data/nmstate/
+cp $NMSTATE_PATH/deploy/openshift/scc.yaml data/nmstate/scc.yaml
+sed -i "s/---/{{ if .EnableSCC }}\n---/" data/nmstate/scc.yaml
+echo "{{ end }}" >> data/nmstate/scc.yaml
 
 echo 'Apply custom CNAO patches on kubernetes-nmstate manifests'
 echo '

--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -24,7 +24,7 @@ const (
 	LinuxBridgeCniImageDefault    = "quay.io/kubevirt/cni-default-plugins:v0.8.6"
 	LinuxBridgeMarkerImageDefault = "quay.io/kubevirt/bridge-marker:0.3.0"
 	KubeMacPoolImageDefault       = "quay.io/kubevirt/kubemacpool:v0.16.0"
-	NMStateHandlerImageDefault    = "quay.io/nmstate/kubernetes-nmstate-handler:v0.23.0"
+	NMStateHandlerImageDefault    = "quay.io/nmstate/kubernetes-nmstate-handler:v0.25.0"
 	OvsCniImageDefault            = "quay.io/kubevirt/ovs-cni-plugin:v0.12.0"
 	OvsMarkerImageDefault         = "quay.io/kubevirt/ovs-cni-marker:v0.12.0"
 	MacvtapCniImageDefault        = "quay.io/kubevirt/macvtap-cni:v0.2.0"

--- a/test/releases/99.0.0.go
+++ b/test/releases/99.0.0.go
@@ -36,13 +36,13 @@ func init() {
 				ParentName: "nmstate-handler",
 				ParentKind: "DaemonSet",
 				Name:       "nmstate-handler",
-				Image:      "quay.io/nmstate/kubernetes-nmstate-handler:v0.23.0",
+				Image:      "quay.io/nmstate/kubernetes-nmstate-handler:v0.25.0",
 			},
 			opv1alpha1.Container{
 				ParentName: "nmstate-webhook",
 				ParentKind: "Deployment",
 				Name:       "nmstate-webhook",
-				Image:      "quay.io/nmstate/kubernetes-nmstate-handler:v0.23.0",
+				Image:      "quay.io/nmstate/kubernetes-nmstate-handler:v0.25.0",
 			},
 			opv1alpha1.Container{
 				ParentName: "ovs-cni-amd64",


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the master branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it

If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**What this PR does / why we need it**:
The openshift SCC was missing at the kubernetes-nmstate bumping manifests this
commit add it using the expected golang template flags to deactivate it on k8s and
activate it on openshift.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
Add SCC to kubernetes-nmstate
Bump kubernetes-nmstate to 0.25.0
```
