### PR TITLE
add porcelain to check for uncommitted changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ services:
 
 install: true
 script:
+- make bump-all
 - make check
 - make docker-build
 

--- a/Makefile
+++ b/Makefile
@@ -78,6 +78,7 @@ whitespace: $(all_sources)
 	touch $@
 
 check: whitespace-check vet goimports-check gen-k8s-check test/unit
+	./hack/check.sh
 
 whitespace-check: $(all_sources)
 	./hack/whitespace.sh

--- a/hack/check.sh
+++ b/hack/check.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+set -xe
+
+if [[ -n "$(git status --porcelain)" ]] ; then
+    echo "You have Uncommitted changes. Please commit the changes"
+    git status --porcelain
+    git diff
+    exit 1
+fi


### PR DESCRIPTION
Signed-off-by: Ram Lavi <ralavi@redhat.com>

**What this PR does / why we need it**:
Adds porcelain check, to make sure no generated uncommitted changes are left outside of a commit.
We also add bump-all on travis.yaml to make  sure the manifests weren't changed.

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
