### PR TITLE
use kustomize version used on kmp

### DIFF
--- a/data/kubemacpool/kubemacpool.yaml
+++ b/data/kubemacpool/kubemacpool.yaml
@@ -6,6 +6,74 @@ metadata:
     mutatepods.kubemacpool.io: ignore
   name: {{ .Namespace }}
 ---
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: MutatingWebhookConfiguration
+metadata:
+  labels: null
+  name: kubemacpool-mutator
+webhooks:
+- clientConfig:
+    service:
+      name: kubemacpool-service
+      namespace: {{ .Namespace }}
+      path: /mutate-pods
+  failurePolicy: Fail
+  name: mutatepods.kubemacpool.io
+  namespaceSelector:
+    matchExpressions:
+    - key: runlevel
+      operator: NotIn
+      values:
+      - "0"
+      - "1"
+    - key: openshift.io/run-level
+      operator: NotIn
+      values:
+      - "0"
+      - "1"
+    matchLabels:
+      mutatepods.kubemacpool.io: allocate
+  rules:
+  - apiGroups:
+    - ""
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    resources:
+    - pods
+- clientConfig:
+    service:
+      name: kubemacpool-service
+      namespace: {{ .Namespace }}
+      path: /mutate-virtualmachines
+  failurePolicy: Fail
+  name: mutatevirtualmachines.kubemacpool.io
+  namespaceSelector:
+    matchExpressions:
+    - key: runlevel
+      operator: NotIn
+      values:
+      - "0"
+      - "1"
+    - key: openshift.io/run-level
+      operator: NotIn
+      values:
+      - "0"
+      - "1"
+    matchLabels:
+      mutatevirtualmachines.kubemacpool.io: allocate
+  rules:
+  - apiGroups:
+    - kubevirt.io
+    apiVersions:
+    - v1alpha3
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - virtualmachines
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -253,71 +321,3 @@ spec:
       - name: tls-key-pair
         secret:
           secretName: kubemacpool-service
----
-apiVersion: admissionregistration.k8s.io/v1beta1
-kind: MutatingWebhookConfiguration
-metadata:
-  labels: null
-  name: kubemacpool-mutator
-webhooks:
-- clientConfig:
-    service:
-      name: kubemacpool-service
-      namespace: {{ .Namespace }}
-      path: /mutate-pods
-  failurePolicy: Fail
-  name: mutatepods.kubemacpool.io
-  namespaceSelector:
-    matchExpressions:
-    - key: runlevel
-      operator: NotIn
-      values:
-      - "0"
-      - "1"
-    - key: openshift.io/run-level
-      operator: NotIn
-      values:
-      - "0"
-      - "1"
-    matchLabels:
-      mutatepods.kubemacpool.io: allocate
-  rules:
-  - apiGroups:
-    - ""
-    apiVersions:
-    - v1
-    operations:
-    - CREATE
-    resources:
-    - pods
-- clientConfig:
-    service:
-      name: kubemacpool-service
-      namespace: {{ .Namespace }}
-      path: /mutate-virtualmachines
-  failurePolicy: Fail
-  name: mutatevirtualmachines.kubemacpool.io
-  namespaceSelector:
-    matchExpressions:
-    - key: runlevel
-      operator: NotIn
-      values:
-      - "0"
-      - "1"
-    - key: openshift.io/run-level
-      operator: NotIn
-      values:
-      - "0"
-      - "1"
-    matchLabels:
-      mutatevirtualmachines.kubemacpool.io: allocate
-  rules:
-  - apiGroups:
-    - kubevirt.io
-    apiVersions:
-    - v1alpha3
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - virtualmachines

--- a/hack/components/bump-kubemacpool.sh
+++ b/hack/components/bump-kubemacpool.sh
@@ -62,7 +62,8 @@ EOF
 rm -rf data/kubemacpool/*
 (
     cd $KUBEMACPOOL_PATH
-    kustomize build config/cnao | \
+    make tools 1>/dev/null
+    ./build/_output/bin/go/bin/kustomize build config/cnao | \
         sed 's/kubemacpool-system/{{ .Namespace }}/' | \
         sed 's/RANGE_START: .*/RANGE_START: {{ .RangeStart }}/' | \
         sed 's/RANGE_END: .*/RANGE_END: {{ .RangeEnd }}/'


### PR DESCRIPTION

**What this PR does / why we need it**:
Currently, during CNAO bump we use whatever kustomize is intalled.
Lets use the same vendored kustomize version that kubemacpool is using.

Signed-off-by: Ram Lavi <ralavi@redhat.com>
**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
