### PR TITLE
Bump kubernetes-nmstate to 0.26.0

### DIFF
--- a/components.yaml
+++ b/components.yaml
@@ -13,7 +13,7 @@ components:
     commit: "a47cfcad6dbc249821941cdcb4bd93efb9b15cf7" # v0.17.0
   nmstate:
     url: "https://github.com/nmstate/kubernetes-nmstate"
-    commit: "6f41747788235c3363a314dfae46a4ed90e1846a" # v0.25.0
+    commit: "bdb07fb11f4a5d5cea87f2dec5ab9f6387b4128b" # v0.26.0
   ovs-cni:
     url: "https://github.com/kubevirt/ovs-cni"
     commit: "edb4754d08f49be54c399c938895fe82aab6aa5a" # v0.12.0

--- a/data/nmstate/operator.yaml
+++ b/data/nmstate/operator.yaml
@@ -46,6 +46,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
             - name: RUN_WEBHOOK_SERVER
               value: ""
             - name: OPERATOR_NAME
@@ -237,10 +241,10 @@ spec:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{template "handlerPrefix" .}}nmstate-webhook
-  namespace: {{ .HandlerNamespace }}
   annotations:
     networkaddonsoperator.network.kubevirt.io/rejectOwner: ""
+  name: {{template "handlerPrefix" .}}nmstate-webhook
+  namespace: {{ .HandlerNamespace }}
 type: kubernetes.io/tls
 data:
   tls.crt: YmFkIGNlcnRpZmljYXRlCg==

--- a/hack/components/bump-knmstate.sh
+++ b/hack/components/bump-knmstate.sh
@@ -34,8 +34,4 @@ sed -i "s/---/{{ if .EnableSCC }}\n---/" data/nmstate/scc.yaml
 echo "{{ end }}" >> data/nmstate/scc.yaml
 
 echo 'Apply custom CNAO patches on kubernetes-nmstate manifests'
-echo '
-241a242,243
->   annotations:
->     networkaddonsoperator.network.kubevirt.io/rejectOwner: ""
-' | patch data/nmstate/operator.yaml
+sed -i -z 's#kind: Secret\nmetadata:#kind: Secret\nmetadata:\n  annotations:\n    networkaddonsoperator.network.kubevirt.io\/rejectOwner: ""#' data/nmstate/operator.yaml

--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -24,7 +24,7 @@ const (
 	LinuxBridgeCniImageDefault    = "quay.io/kubevirt/cni-default-plugins:v0.8.6"
 	LinuxBridgeMarkerImageDefault = "quay.io/kubevirt/bridge-marker:0.3.0"
 	KubeMacPoolImageDefault       = "quay.io/kubevirt/kubemacpool:v0.17.0"
-	NMStateHandlerImageDefault    = "quay.io/nmstate/kubernetes-nmstate-handler:v0.25.0"
+	NMStateHandlerImageDefault    = "quay.io/nmstate/kubernetes-nmstate-handler:v0.26.0"
 	OvsCniImageDefault            = "quay.io/kubevirt/ovs-cni-plugin:v0.12.0"
 	OvsMarkerImageDefault         = "quay.io/kubevirt/ovs-cni-marker:v0.12.0"
 	MacvtapCniImageDefault        = "quay.io/kubevirt/macvtap-cni:v0.2.0"

--- a/test/releases/99.0.0.go
+++ b/test/releases/99.0.0.go
@@ -36,13 +36,13 @@ func init() {
 				ParentName: "nmstate-handler",
 				ParentKind: "DaemonSet",
 				Name:       "nmstate-handler",
-				Image:      "quay.io/nmstate/kubernetes-nmstate-handler:v0.25.0",
+				Image:      "quay.io/nmstate/kubernetes-nmstate-handler:v0.26.0",
 			},
 			opv1alpha1.Container{
 				ParentName: "nmstate-webhook",
 				ParentKind: "Deployment",
 				Name:       "nmstate-webhook",
-				Image:      "quay.io/nmstate/kubernetes-nmstate-handler:v0.25.0",
+				Image:      "quay.io/nmstate/kubernetes-nmstate-handler:v0.26.0",
 			},
 			opv1alpha1.Container{
 				ParentName: "ovs-cni-amd64",


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the master branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it

If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**What this PR does / why we need it**:
It uses kube-admission-webhook 0.12.0 that implements the CA overlap interval, although this interval
has the expiration time value so behaviour has to be the same.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
Bump kubernetes-nmstate to v0.26.0
```
