### PR TITLE
Fix reset patch version when bumping minor

### DIFF
--- a/hack/bump-version.sh
+++ b/hack/bump-version.sh
@@ -12,15 +12,15 @@ bump() {
 }
 
 bump_major() {
-   bump "s/^\(.*\)[.].*[.].*$/\1/g" "s/^\(.*\)[.]\(.*\)[.]\(.*\)$/version_part.\2.\3/g"
+   bump "s/^\(.*\)[.].*[.].*$/\1/g" "s/^.*$/version_part.0.0/g"
 }
 
 bump_minor() {
-    bump "s/^.*[.]\(.*\)[.].*$/\1/g" "s/^\(.*\)[.]\(.*\)[.]\(.*\)$/\1.version_part.\3/g"
+    bump "s/^.*[.]\(.*\)[.].*$/\1/g" "s/^\(.*\)[.].*[.].*$/\1.version_part.0/g"
 }
 
 bump_patch() {
-    bump "s/^.*[.].*[.]\(.*\)$/\1/g" "s/^\(.*\)[.]\(.*\)[.]\(.*\)$/\1.\2.version_part/g"
+    bump "s/^.*[.].*[.]\(.*\)$/\1/g" "s/^\(.*\)[.]\(.*\)[.].*$/\1.\2.version_part/g"
 }
 
 if [[ ! $current_type =~ $expected_types ]]; then


### PR DESCRIPTION


<!-- Thanks for sending a pull request!

Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the master branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it

If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**What this PR does / why we need it**:

In the current state, when we bump a patch version (e.g. to 0.1.1) and
then call bump of minor version, the patch is not reset (e.g. 0.2.1).

With this patch, we will reset the patch/minor version on bump of
minor/major version respectively.

Signed-off-by: Petr Horacek <phoracek@redhat.com>

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
Fix reset patch version when bumping minor
```
