### PR TITLE
Fix test should set targetVersion and operatorVersion 

### DIFF
--- a/test/e2e/workflow/version_test.go
+++ b/test/e2e/workflow/version_test.go
@@ -22,7 +22,7 @@ var _ = Describe("NetworkAddonsConfig", func() {
 
 		It("should set targetVersion and operatorVersion immediately after it turns Progressing", func() {
 			CheckConfigCondition(ConditionProgressing, ConditionTrue, time.Minute, CheckDoNotRepeat)
-			CheckConfigVersions(operatorVersion, "", operatorVersion, CheckImmediately, CheckDoNotRepeat)
+			CheckConfigVersions(operatorVersion, CheckIgnoreVersion, operatorVersion, CheckImmediately, CheckDoNotRepeat)
 		})
 
 		It("should set observedVersion once turns it Available", func() {


### PR DESCRIPTION
Fixing by ignoring the observedVersion in the test in question, because after ConditionProgressing
is set to true, we cannot expect observedVersion to be empty, becasue it is possible that the
ConditionAvailable is reached in the meantime which as a result populates the observedVersion.

https://prow.apps.ovirt.org/view/gcs/kubevirt-prow/pr-logs/pull/kubevirt_cluster-network-addons-operator/424/pull-e2e-cluster-network-addons-operator-workflow-k8s/1273247663738851328#1:build-log.txt%3A792

Signed-off-by: Radim Hrazdil <rhrazdil@redhat.com>

**What this PR does / why we need it**:
fixes test
**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
