### PR TITLE
Ignore TLS secrets

### DIFF
--- a/data/kubemacpool/kubemacpool.yaml
+++ b/data/kubemacpool/kubemacpool.yaml
@@ -206,8 +206,6 @@ data:
   tls.key: YmFkIGtleQo=
 kind: Secret
 metadata:
-  annotations:
-    networkaddonsoperator.network.kubevirt.io/rejectOwner: ""
   name: kubemacpool-service
   namespace: '{{ .Namespace }}'
 type: kubernetes.io/tls

--- a/data/nmstate/operator.yaml
+++ b/data/nmstate/operator.yaml
@@ -241,8 +241,6 @@ spec:
 apiVersion: v1
 kind: Secret
 metadata:
-  annotations:
-    networkaddonsoperator.network.kubevirt.io/rejectOwner: ""
   name: {{template "handlerPrefix" .}}nmstate-webhook
   namespace: {{ .HandlerNamespace }}
 type: kubernetes.io/tls

--- a/hack/components/bump-knmstate.sh
+++ b/hack/components/bump-knmstate.sh
@@ -32,6 +32,3 @@ cp $NMSTATE_PATH/deploy/crds/*nodenetwork*crd* data/nmstate/
 cp $NMSTATE_PATH/deploy/openshift/scc.yaml data/nmstate/scc.yaml
 sed -i "s/---/{{ if .EnableSCC }}\n---/" data/nmstate/scc.yaml
 echo "{{ end }}" >> data/nmstate/scc.yaml
-
-echo 'Apply custom CNAO patches on kubernetes-nmstate manifests'
-sed -i -z 's#kind: Secret\nmetadata:#kind: Secret\nmetadata:\n  annotations:\n    networkaddonsoperator.network.kubevirt.io\/rejectOwner: ""#' data/nmstate/operator.yaml

--- a/hack/components/bump-kubemacpool.sh
+++ b/hack/components/bump-kubemacpool.sh
@@ -30,7 +30,6 @@ bases:
 - ../default
 patchesStrategicMerge:
 - cnao_image_patch.yaml
-- cnao_rejectowner_patch.yaml
 EOF
 
     cat <<EOF > config/cnao/cnao_image_patch.yaml
@@ -53,16 +52,6 @@ spec:
             value: "{{ .CAOverlapInterval }}"
           - name: CERT_ROTATE_INTERVAL
             value: "{{ .CertRotateInterval }}"
-EOF
-
-    cat <<EOF > config/cnao/cnao_rejectowner_patch.yaml
-apiVersion: v1
-kind: Secret
-metadata:
-  name: service
-  namespace: system
-  annotations:
-    networkaddonsoperator.network.kubevirt.io/rejectOwner: ""
 EOF
 )
 

--- a/pkg/apply/apply.go
+++ b/pkg/apply/apply.go
@@ -49,7 +49,7 @@ func ApplyObject(ctx context.Context, client k8sclient.Client, obj *uns.Unstruct
 		return errors.Wrapf(err, "could not retrieve existing %s", objDesc)
 	}
 
-	if isTLSSecret(obj) {
+	if IsTLSSecret(obj) {
 		log.Printf("Ignoring TLS secret %s at reconcile", obj.GetName())
 		return nil
 	}
@@ -117,7 +117,7 @@ func DeleteObject(ctx context.Context, client k8sclient.Client, obj *uns.Unstruc
 	return nil
 }
 
-func isTLSSecret(obj *uns.Unstructured) bool {
+func IsTLSSecret(obj *uns.Unstructured) bool {
 	if obj.GetKind() != "Secret" {
 		return false
 	}

--- a/pkg/controller/networkaddonsconfig/networkaddonsconfig_controller.go
+++ b/pkg/controller/networkaddonsconfig/networkaddonsconfig_controller.go
@@ -368,10 +368,11 @@ func (r *ReconcileNetworkAddonsConfig) applyObjects(networkAddonsConfig *opv1alp
 		// Don't set owner reference on namespaces if they are used by the operator itself
 		// Don't set owner reference on CRDs, they should survive removal of the operator
 		// Don't set owner reference on objects that explicitly rejected an owner
+		// Don't set owner refernece on TLS secrets
 		isOperatorNamespace := obj.GetKind() == "Namespace" && obj.GetName() == operatorNamespace
 		isCRD := obj.GetKind() == "CustomResourceDefinition"
 		_, isRejectingOwner := obj.GetAnnotations()[names.REJECT_OWNER_ANNOTATION]
-		if !isCRD && !isOperatorNamespace && !isRejectingOwner {
+		if !isCRD && !isOperatorNamespace && !isRejectingOwner && !apply.IsTLSSecret(obj) {
 			if err := controllerutil.SetControllerReference(networkAddonsConfig, obj, r.scheme); err != nil {
 				log.Printf("could not set reference for (%s) %s/%s: %v", obj.GroupVersionKind(), obj.GetNamespace(), obj.GetName(), err)
 				err = errors.Wrapf(err, "could not set reference for (%s) %s/%s", obj.GroupVersionKind(), obj.GetNamespace(), obj.GetName())


### PR DESCRIPTION

Signed-off-by: Quique Llorente <ellorent@redhat.com>

<!-- Thanks for sending a pull request!

Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the master branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it

If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**What this PR does / why we need it**:
Using the ignore ownerhip at kubemacpool and kubernetes-nmstate TLS secrets
is not enough since they are going to recreate them if removed without the label

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
