### PR TITLE
Prefix version tag with "v"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -173,7 +173,7 @@ prepare-major:
 release: $(GITHUB_RELEASE)
 	DESCRIPTION=version/description \
 	GITHUB_RELEASE=$(GITHUB_RELEASE) \
-	TAG=$(shell hack/version.sh) \
+	TAG=v$(shell hack/version.sh) \
 	  hack/release.sh \
 	    manifests/cluster-network-addons/cluster-network-addons.package.yaml \
 	    $(shell find manifests/cluster-network-addons/$(shell hack/version.sh) -type f)


### PR DESCRIPTION


<!-- Thanks for sending a pull request!

Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the master branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it

If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**What this PR does / why we need it**:

Go mod expects versions to start with "v". Without that, go mod is able
to fetch the tag, but it interprets it as:
v0.3.1-0.20200811082954-d0b735298e44

With this change, we prefix release tags with "v" while keeping the
version in our CSVs with a naked version to satisfy OLM's expectations.

Signed-off-by: Petr Horacek <phoracek@redhat.com>

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
Prefix version tags with "v"
```
