### PR TITLE
tier1, add ovs-cni e2e-functests script

### DIFF
--- a/automation/check-patch.e2e-ovs-cni-functests.sh
+++ b/automation/check-patch.e2e-ovs-cni-functests.sh
@@ -1,0 +1,33 @@
+#!/bin/bash -xe
+
+# This script should be able to execute KubeMacPool
+# functional tests against Kubernetes cluster with
+# CNAO built with latest changes, on any
+# environment with basic dependencies listed in
+# check-patch.packages installed and docker running.
+#
+# yum -y install automation/check-patch.packages
+# automation/check-patch.e2e-kubemacpool-functests.sh
+
+teardown() {
+    make cluster-down
+    rm -rf "${TMP_COMPONENT_PATH}"
+}
+
+main() {
+    # Setup CNAO and artifacts temp directory
+    source automation/check-patch.setup.sh
+    cd ${TMP_PROJECT_PATH}
+
+    # Spin-up ephemeral cluster with latest CNAO
+    # this script also exports KUBECONFIG, and fetch $COMPONENT repository
+    COMPONENT="ovs-cni" source automation/components-functests.setup.sh
+
+    trap teardown EXIT
+
+    # Run ovs-cni functional tests
+    cd ${TMP_COMPONENT_PATH}
+    KUBECONFIG=${KUBECONFIG} E2E_TEST_ARGS="-ginkgo.v -test.v -ginkgo.noColor --junit-output=$ARTIFACTS/junit.functest.xml" make functest
+}
+
+[[ "${BASH_SOURCE[0]}" == "$0" ]] && main "$@"


### PR DESCRIPTION
**What this PR does / why we need it**:
This script adds ovs-cni e2e functests on a cluster with CNAO latest changes.

This PR can only be merged after:
1. ovs-cni issues a new release with functests [PR](https://github.com/kubevirt/ovs-cni/pull/124) is mereged
2. ovs-cni is bumped
3. lane added in project infra [PR](https://github.com/kubevirt/project-infra/pull/582)

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
