### PR TITLE
add stdout to git-clone process in bumper script

### DIFF
--- a/tools/bumper/component_commands.go
+++ b/tools/bumper/component_commands.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io/ioutil"
+	"os"
 	"strings"
 
 	"github.com/go-git/go-git/v5"
@@ -100,6 +101,7 @@ func newGitRepo(componentName string, componentParams *component) (*gitRepo, err
 	repo, err := git.PlainClone(repoDir, false, &git.CloneOptions{
 		URL:           componentParams.Url,
 		ReferenceName: plumbing.NewBranchReferenceName(componentParams.Branch),
+		Progress: os.Stdout,
 	})
 	if err != nil {
 		return nil, errors.Wrapf(err, "Failed to clone %s repo", componentName)


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently when running the bumper script,
there is no output to stdout when a component is cloned
to the temporary folder. As this may take a short while,
it could be seen as if the script is stuck.

Let's dump the clone command output to stdout,
thus making it more user-friendly.

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
