### PR TITLE
add bumper go executable to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,7 @@ goimports-check
 vet
 whitespace
 whitespace-check
+
+# bumper go exec file
+bumper
+


### PR DESCRIPTION
**What this PR does / why we need it**:
building the bumper.go script creates a bumper executable file.
This may cause a future bumping PR to fail travis (git --porcelain will fail with this unmerged file)
Moreover, we don't want to accidentally commit it.
Hence, we want to add it to .gitignore

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
