### PR TITLE
bumper, Add githubApi functions to open PR

### DIFF
--- a/tools/bumper/bumper.go
+++ b/tools/bumper/bumper.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"log"
 	"os"
-	"strings"
 
 	"github.com/pkg/errors"
 )
@@ -98,9 +97,6 @@ func handleBump(cnaoRepo *gitCnaoRepo, component component, componentName, compo
 		}
 	}()
 
-	// Create PR
-	exitWithError(fmt.Errorf("create PR not implemented yet"))
-
 	// update components yaml in the bumping repo instance
 	componentsConfig, err := cnaoRepo.getComponentsConfig(componentsConfigPath)
 	if err != nil {
@@ -131,12 +127,12 @@ func handleBump(cnaoRepo *gitCnaoRepo, component component, componentName, compo
 		return nil
 	}
 
-	// create a new branch name
-	branchName := strings.Replace(strings.ToLower(proposedPrTitle), " ", "_", -1)
-	logger.Printf("Opening new Branch %s", branchName)
+	logger.Printf("Generate Bump PR using GithubAPI")
+	_, err = cnaoRepo.generateBumpPr(proposedPrTitle, bumpFilesList)
+	if err != nil {
+		exitWithError(errors.Wrap(err, "Failed to generate Bump PR"))
+	}
 
-	// push branch to PR
-	exitWithError(fmt.Errorf("push branch to PR not implemented yet"))
 	return nil
 }
 

--- a/tools/bumper/cnao_repo_commands_test.go
+++ b/tools/bumper/cnao_repo_commands_test.go
@@ -42,15 +42,15 @@ var _ = Describe("Testing internal git CNAO Repo", func() {
 		BeforeEach(func() {
 
 			newPr := getFakePrWithTitle("CNAO test-component to 0.0.2")
-			_, _, err := gitCnaoRepo.githubInterface.CreatePullRequest(dummyOwner, dummyRepo, newPr)
+			_, _, err := gitCnaoRepo.githubInterface.createPullRequest(dummyOwner, dummyRepo, newPr)
 			Expect(err).ToNot(HaveOccurred(), "should succeed creating fake PR")
 
 			newPr = getFakePrWithTitle("CNAO test-component to 1.0.0")
-			_, _, err = gitCnaoRepo.githubInterface.CreatePullRequest(dummyOwner, dummyRepo, newPr)
+			_, _, err = gitCnaoRepo.githubInterface.createPullRequest(dummyOwner, dummyRepo, newPr)
 			Expect(err).ToNot(HaveOccurred(), "should succeed creating fake PR")
 
 			newPr = getFakePrWithTitle("CNAO test-component to 1.0.1")
-			_, _, err = gitCnaoRepo.githubInterface.CreatePullRequest(dummyOwner, dummyRepo, newPr)
+			_, _, err = gitCnaoRepo.githubInterface.createPullRequest(dummyOwner, dummyRepo, newPr)
 			Expect(err).ToNot(HaveOccurred(), "should succeed creating fake PR")
 		})
 

--- a/tools/bumper/component_commands.go
+++ b/tools/bumper/component_commands.go
@@ -31,55 +31,55 @@ type githubApi struct {
 }
 
 type githubInterface interface {
-	ListMatchingRefs(owner, repo string, opts *github.ReferenceListOptions) ([]*github.Reference, *github.Response, error)
-	ListCommits(owner, repo string, opts *github.CommitsListOptions) ([]*github.RepositoryCommit, *github.Response, error)
-	GetBranchRef(owner string, repo string, ref string) (*github.Reference, *github.Response, error)
-	CreateBranchRef(owner string, repo string, ref *github.Reference) (*github.Reference, *github.Response, error)
-	CreateTree(owner string, repo string, baseTree string, entries []*github.TreeEntry) (*github.Tree, *github.Response, error)
-	GetCommit(owner string, repo string, sha string) (*github.Commit, *github.Response, error)
-	CreateCommit(owner string, repo string, commit *github.Commit) (*github.Commit, *github.Response, error)
-	UpdateRef(owner string, repo string, ref *github.Reference, force bool) (*github.Reference, *github.Response, error)
-	ListPullRequests(owner string, repo string) ([]*github.PullRequest, *github.Response, error)
-	CreatePullRequest(owner string, repo string, pull *github.NewPullRequest) (*github.PullRequest, *github.Response, error)
+	listMatchingRefs(owner, repo string, opts *github.ReferenceListOptions) ([]*github.Reference, *github.Response, error)
+	listCommits(owner, repo string, opts *github.CommitsListOptions) ([]*github.RepositoryCommit, *github.Response, error)
+	getBranchRef(owner string, repo string, ref string) (*github.Reference, *github.Response, error)
+	createBranchRef(owner string, repo string, ref *github.Reference) (*github.Reference, *github.Response, error)
+	createTree(owner string, repo string, baseTree string, entries []*github.TreeEntry) (*github.Tree, *github.Response, error)
+	getCommit(owner string, repo string, sha string) (*github.Commit, *github.Response, error)
+	createCommit(owner string, repo string, commit *github.Commit) (*github.Commit, *github.Response, error)
+	updateRef(owner string, repo string, ref *github.Reference, force bool) (*github.Reference, *github.Response, error)
+	listPullRequests(owner string, repo string) ([]*github.PullRequest, *github.Response, error)
+	createPullRequest(owner string, repo string, pull *github.NewPullRequest) (*github.PullRequest, *github.Response, error)
 }
 
-func (g githubApi) ListMatchingRefs(owner, repo string, opts *github.ReferenceListOptions) ([]*github.Reference, *github.Response, error) {
+func (g githubApi) listMatchingRefs(owner, repo string, opts *github.ReferenceListOptions) ([]*github.Reference, *github.Response, error) {
 	return g.client.Git.ListMatchingRefs(g.ctx, owner, repo, opts)
 }
 
-func (g githubApi) ListCommits(owner, repo string, opts *github.CommitsListOptions) ([]*github.RepositoryCommit, *github.Response, error) {
+func (g githubApi) listCommits(owner, repo string, opts *github.CommitsListOptions) ([]*github.RepositoryCommit, *github.Response, error) {
 	return g.client.Repositories.ListCommits(g.ctx, owner, repo, opts)
 }
 
-func (g githubApi) GetBranchRef(owner string, repo string, ref string) (*github.Reference, *github.Response, error) {
+func (g githubApi) getBranchRef(owner string, repo string, ref string) (*github.Reference, *github.Response, error) {
 	return g.client.Git.GetRef(g.ctx, owner, repo, ref)
 }
 
-func (g githubApi) CreateBranchRef(owner string, repo string, newRef *github.Reference) (*github.Reference, *github.Response, error) {
+func (g githubApi) createBranchRef(owner string, repo string, newRef *github.Reference) (*github.Reference, *github.Response, error) {
 	return g.client.Git.CreateRef(g.ctx, owner, repo, newRef)
 }
 
-func (g githubApi) CreateTree(owner string, repo string, baseTree string, entries []*github.TreeEntry) (*github.Tree, *github.Response, error) {
+func (g githubApi) createTree(owner string, repo string, baseTree string, entries []*github.TreeEntry) (*github.Tree, *github.Response, error) {
 	return g.client.Git.CreateTree(g.ctx, owner, repo, baseTree, entries)
 }
 
-func (g githubApi) GetCommit(owner string, repo string, sha string) (*github.Commit, *github.Response, error) {
+func (g githubApi) getCommit(owner string, repo string, sha string) (*github.Commit, *github.Response, error) {
 	return g.client.Git.GetCommit(g.ctx, owner, repo, sha)
 }
 
-func (g githubApi) CreateCommit(owner string, repo string, commit *github.Commit) (*github.Commit, *github.Response, error) {
+func (g githubApi) createCommit(owner string, repo string, commit *github.Commit) (*github.Commit, *github.Response, error) {
 	return g.client.Git.CreateCommit(g.ctx, owner, repo, commit)
 }
 
-func (g githubApi) UpdateRef(owner string, repo string, ref *github.Reference, force bool) (*github.Reference, *github.Response, error) {
+func (g githubApi) updateRef(owner string, repo string, ref *github.Reference, force bool) (*github.Reference, *github.Response, error) {
 	return g.client.Git.UpdateRef(g.ctx, owner, repo, ref, force)
 }
 
-func (g githubApi) ListPullRequests(owner string, repo string) ([]*github.PullRequest, *github.Response, error) {
+func (g githubApi) listPullRequests(owner string, repo string) ([]*github.PullRequest, *github.Response, error) {
 	return g.client.PullRequests.List(g.ctx, owner, repo, &github.PullRequestListOptions{State: "open", Base: "master"})
 }
 
-func (g githubApi) CreatePullRequest(owner string, repo string, pull *github.NewPullRequest) (*github.PullRequest, *github.Response, error) {
+func (g githubApi) createPullRequest(owner string, repo string, pull *github.NewPullRequest) (*github.PullRequest, *github.Response, error) {
 	return g.client.PullRequests.Create(g.ctx, owner, repo, pull)
 }
 
@@ -155,7 +155,7 @@ func (componentOps *gitComponent) getCurrentReleaseTag() (string, error) {
 	owner := componentOps.getComponentOwnerFromUrl()
 	logger.Printf("Getting current tag in repo %s sha %s", repo, componentOps.configParams.Commit)
 
-	tagRefs, _, err := componentOps.githubInterface.ListMatchingRefs(owner, repo, &github.ReferenceListOptions{Ref: "refs/tags"})
+	tagRefs, _, err := componentOps.githubInterface.listMatchingRefs(owner, repo, &github.ReferenceListOptions{Ref: "refs/tags"})
 	if err != nil {
 		return "", errors.Wrap(err, "Failed to get release tag refs from github client API")
 	}
@@ -202,12 +202,12 @@ func (componentOps *gitComponent) getUpdatedReleaseInfo() (string, string, error
 // since some tags are represented by the tag sha and not the commit sha, we also need to convert it to commit sha.
 func (componentOps *gitComponent) getLatestTaggedFromBranch(repo, owner, branch, repoDir string) (string, string, error) {
 	logger.Printf("Getting latest tagged from branch %s in repo %s", branch, repo)
-	tagRefs, _, err := componentOps.githubInterface.ListMatchingRefs(owner, repo, &github.ReferenceListOptions{Ref: "refs/tags"})
+	tagRefs, _, err := componentOps.githubInterface.listMatchingRefs(owner, repo, &github.ReferenceListOptions{Ref: "refs/tags"})
 	if err != nil {
 		return "", "", errors.Wrap(err, "Failed to get release tag refs from github client API")
 	}
 
-	branchCommits, _, err := componentOps.githubInterface.ListCommits(owner, repo, &github.CommitsListOptions{SHA: branch})
+	branchCommits, _, err := componentOps.githubInterface.listCommits(owner, repo, &github.CommitsListOptions{SHA: branch})
 	if err != nil {
 		return "", "", errors.Wrap(err, "Failed to get release tag refs from github client API")
 	}
@@ -235,7 +235,7 @@ func (componentOps *gitComponent) getLatestTaggedFromBranch(repo, owner, branch,
 // since a this commit-sha is not necessarily tagged, we use the v-tag format in case needed.
 func (componentOps *gitComponent) getLatestFromBranch(repo, owner, branch, repoDir string) (string, string, error) {
 	logger.Printf("Getting Latest HEAD from branch %s in repo %s", branch, repo)
-	branchRef, _, err := componentOps.githubInterface.GetBranchRef(owner, repo, "refs/heads/"+branch)
+	branchRef, _, err := componentOps.githubInterface.getBranchRef(owner, repo, "refs/heads/"+branch)
 	if err != nil {
 		return "", "", errors.Wrapf(err, "Failed to get latest HEAD ref of branch %s from github client API", branch)
 	}

--- a/tools/bumper/component_commands.go
+++ b/tools/bumper/component_commands.go
@@ -33,7 +33,12 @@ type githubApi struct {
 type githubInterface interface {
 	ListMatchingRefs(owner, repo string, opts *github.ReferenceListOptions) ([]*github.Reference, *github.Response, error)
 	ListCommits(owner, repo string, opts *github.CommitsListOptions) ([]*github.RepositoryCommit, *github.Response, error)
-	GetRef(owner string, repo string, ref string) (*github.Reference, *github.Response, error)
+	GetBranchRef(owner string, repo string, ref string) (*github.Reference, *github.Response, error)
+	CreateBranchRef(owner string, repo string, ref *github.Reference) (*github.Reference, *github.Response, error)
+	CreateTree(owner string, repo string, baseTree string, entries []*github.TreeEntry) (*github.Tree, *github.Response, error)
+	GetCommit(owner string, repo string, sha string) (*github.Commit, *github.Response, error)
+	CreateCommit(owner string, repo string, commit *github.Commit) (*github.Commit, *github.Response, error)
+	UpdateRef(owner string, repo string, ref *github.Reference, force bool) (*github.Reference, *github.Response, error)
 	ListPullRequests(owner string, repo string) ([]*github.PullRequest, *github.Response, error)
 	CreatePullRequest(owner string, repo string, pull *github.NewPullRequest) (*github.PullRequest, *github.Response, error)
 }
@@ -46,8 +51,28 @@ func (g githubApi) ListCommits(owner, repo string, opts *github.CommitsListOptio
 	return g.client.Repositories.ListCommits(g.ctx, owner, repo, opts)
 }
 
-func (g githubApi) GetRef(owner string, repo string, ref string) (*github.Reference, *github.Response, error) {
+func (g githubApi) GetBranchRef(owner string, repo string, ref string) (*github.Reference, *github.Response, error) {
 	return g.client.Git.GetRef(g.ctx, owner, repo, ref)
+}
+
+func (g githubApi) CreateBranchRef(owner string, repo string, newRef *github.Reference) (*github.Reference, *github.Response, error) {
+	return g.client.Git.CreateRef(g.ctx, owner, repo, newRef)
+}
+
+func (g githubApi) CreateTree(owner string, repo string, baseTree string, entries []*github.TreeEntry) (*github.Tree, *github.Response, error) {
+	return g.client.Git.CreateTree(g.ctx, owner, repo, baseTree, entries)
+}
+
+func (g githubApi) GetCommit(owner string, repo string, sha string) (*github.Commit, *github.Response, error) {
+	return g.client.Git.GetCommit(g.ctx, owner, repo, sha)
+}
+
+func (g githubApi) CreateCommit(owner string, repo string, commit *github.Commit) (*github.Commit, *github.Response, error) {
+	return g.client.Git.CreateCommit(g.ctx, owner, repo, commit)
+}
+
+func (g githubApi) UpdateRef(owner string, repo string, ref *github.Reference, force bool) (*github.Reference, *github.Response, error) {
+	return g.client.Git.UpdateRef(g.ctx, owner, repo, ref, force)
 }
 
 func (g githubApi) ListPullRequests(owner string, repo string) ([]*github.PullRequest, *github.Response, error) {
@@ -210,7 +235,7 @@ func (componentOps *gitComponent) getLatestTaggedFromBranch(repo, owner, branch,
 // since a this commit-sha is not necessarily tagged, we use the v-tag format in case needed.
 func (componentOps *gitComponent) getLatestFromBranch(repo, owner, branch, repoDir string) (string, string, error) {
 	logger.Printf("Getting Latest HEAD from branch %s in repo %s", branch, repo)
-	branchRef, _, err := componentOps.githubInterface.GetRef(owner, repo, "refs/heads/"+branch)
+	branchRef, _, err := componentOps.githubInterface.GetBranchRef(owner, repo, "refs/heads/"+branch)
 	if err != nil {
 		return "", "", errors.Wrapf(err, "Failed to get latest HEAD ref of branch %s from github client API", branch)
 	}

--- a/tools/bumper/git_fakes.go
+++ b/tools/bumper/git_fakes.go
@@ -27,7 +27,7 @@ type mockGithubApi struct {
 	fakePRList []*github.PullRequest
 }
 
-func (g mockGithubApi) ListMatchingRefs(owner, repo string, opts *github.ReferenceListOptions) ([]*github.Reference, *github.Response, error) {
+func (g mockGithubApi) listMatchingRefs(owner, repo string, opts *github.ReferenceListOptions) ([]*github.Reference, *github.Response, error) {
 	gitCommitObjList, err := gitLogJson(g.repoDir, "")
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "failed performing mock git log")
@@ -36,7 +36,7 @@ func (g mockGithubApi) ListMatchingRefs(owner, repo string, opts *github.Referen
 	return convertLogToReferenceList(gitCommitObjList, opts.Ref), nil, nil
 }
 
-func (g mockGithubApi) ListCommits(owner, repo string, opts *github.CommitsListOptions) ([]*github.RepositoryCommit, *github.Response, error) {
+func (g mockGithubApi) listCommits(owner, repo string, opts *github.CommitsListOptions) ([]*github.RepositoryCommit, *github.Response, error) {
 	gitCommitObjList, err := gitLogJson(g.repoDir, opts.SHA)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "failed performing mock git log")
@@ -45,7 +45,7 @@ func (g mockGithubApi) ListCommits(owner, repo string, opts *github.CommitsListO
 	return convertLogToRepositoryCommitList(gitCommitObjList), nil, nil
 }
 
-func (g mockGithubApi) GetBranchRef(owner string, repo string, ref string) (*github.Reference, *github.Response, error) {
+func (g mockGithubApi) getBranchRef(owner string, repo string, ref string) (*github.Reference, *github.Response, error) {
 	gitCommitObjList, err := gitLogJson(g.repoDir, "")
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "failed performing mock git log")
@@ -55,31 +55,31 @@ func (g mockGithubApi) GetBranchRef(owner string, repo string, ref string) (*git
 	return githubRef, nil, err
 }
 
-func (g mockGithubApi) CreateBranchRef(owner string, repo string, newRef *github.Reference) (*github.Reference, *github.Response, error) {
+func (g mockGithubApi) createBranchRef(owner string, repo string, newRef *github.Reference) (*github.Reference, *github.Response, error) {
 	return nil, nil, nil
 }
 
-func (g mockGithubApi) CreateTree(owner string, repo string, baseTree string, entries []*github.TreeEntry) (*github.Tree, *github.Response, error) {
+func (g mockGithubApi) createTree(owner string, repo string, baseTree string, entries []*github.TreeEntry) (*github.Tree, *github.Response, error) {
 	return nil, nil, nil
 }
 
-func (g mockGithubApi) GetCommit(owner string, repo string, sha string) (*github.Commit, *github.Response, error) {
+func (g mockGithubApi) getCommit(owner string, repo string, sha string) (*github.Commit, *github.Response, error) {
 	return nil, nil, nil
 }
 
-func (g mockGithubApi) CreateCommit(owner string, repo string, commit *github.Commit) (*github.Commit, *github.Response, error) {
+func (g mockGithubApi) createCommit(owner string, repo string, commit *github.Commit) (*github.Commit, *github.Response, error) {
 	return nil, nil, nil
 }
 
-func (g mockGithubApi) UpdateRef(owner string, repo string, ref *github.Reference, force bool) (*github.Reference, *github.Response, error) {
+func (g mockGithubApi) updateRef(owner string, repo string, ref *github.Reference, force bool) (*github.Reference, *github.Response, error) {
 	return nil, nil, nil
 }
 
-func (g *mockGithubApi) ListPullRequests(owner string, repo string) ([]*github.PullRequest, *github.Response, error) {
+func (g *mockGithubApi) listPullRequests(owner string, repo string) ([]*github.PullRequest, *github.Response, error) {
 	return g.fakePRList, nil, nil
 }
 
-func (g *mockGithubApi) CreatePullRequest(owner string, repo string, pull *github.NewPullRequest) (*github.PullRequest, *github.Response, error) {
+func (g *mockGithubApi) createPullRequest(owner string, repo string, pull *github.NewPullRequest) (*github.PullRequest, *github.Response, error) {
 	pullRequest := &github.PullRequest{Title: pull.Title}
 	g.fakePRList = append(g.fakePRList, pullRequest)
 
@@ -329,7 +329,7 @@ func createCommitWithoutTag(w *git.Worktree, tagCommitMap map[string]string, rep
 }
 
 // createCommitWithAnnotatedTag created commit and tags it in the repo.
-// In order to simulate output of githubApi methods like ListMatchingRefs
+// In order to simulate output of githubApi methods like listMatchingRefs
 // that return the tags list in chronological order, we should set the tag key
 // to be sorted by alphabetically+chronologically order. we do this by setting
 // tag keys to be the semver version tagged (which is alphabetically+chronologically

--- a/tools/bumper/git_fakes.go
+++ b/tools/bumper/git_fakes.go
@@ -45,7 +45,7 @@ func (g mockGithubApi) ListCommits(owner, repo string, opts *github.CommitsListO
 	return convertLogToRepositoryCommitList(gitCommitObjList), nil, nil
 }
 
-func (g mockGithubApi) GetRef(owner string, repo string, ref string) (*github.Reference, *github.Response, error) {
+func (g mockGithubApi) GetBranchRef(owner string, repo string, ref string) (*github.Reference, *github.Response, error) {
 	gitCommitObjList, err := gitLogJson(g.repoDir, "")
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "failed performing mock git log")
@@ -55,15 +55,35 @@ func (g mockGithubApi) GetRef(owner string, repo string, ref string) (*github.Re
 	return githubRef, nil, err
 }
 
+func (g mockGithubApi) CreateBranchRef(owner string, repo string, newRef *github.Reference) (*github.Reference, *github.Response, error) {
+	return nil, nil, nil
+}
+
+func (g mockGithubApi) CreateTree(owner string, repo string, baseTree string, entries []*github.TreeEntry) (*github.Tree, *github.Response, error) {
+	return nil, nil, nil
+}
+
+func (g mockGithubApi) GetCommit(owner string, repo string, sha string) (*github.Commit, *github.Response, error) {
+	return nil, nil, nil
+}
+
+func (g mockGithubApi) CreateCommit(owner string, repo string, commit *github.Commit) (*github.Commit, *github.Response, error) {
+	return nil, nil, nil
+}
+
+func (g mockGithubApi) UpdateRef(owner string, repo string, ref *github.Reference, force bool) (*github.Reference, *github.Response, error) {
+	return nil, nil, nil
+}
+
+func (g *mockGithubApi) ListPullRequests(owner string, repo string) ([]*github.PullRequest, *github.Response, error) {
+	return g.fakePRList, nil, nil
+}
+
 func (g *mockGithubApi) CreatePullRequest(owner string, repo string, pull *github.NewPullRequest) (*github.PullRequest, *github.Response, error) {
 	pullRequest := &github.PullRequest{Title: pull.Title}
 	g.fakePRList = append(g.fakePRList, pullRequest)
 
 	return pullRequest, nil, nil
-}
-
-func (g *mockGithubApi) ListPullRequests(owner string, repo string) ([]*github.PullRequest, *github.Response, error) {
-	return g.fakePRList, nil, nil
 }
 
 type gitCommitMock struct {


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR implements PR creation in the bumper script.

- **bumper, Add githubApi functions to open PR**
This commit implements the functions that create
a proper PR using githubApi.

**Special notes for your reviewer**:
depends on #619 to be merged, relevant commit is the last one

**Release note**:

```release-note
NONE
```
