### PR TITLE
add 'runAsNonRoot: true' to deployment's securityContext.

### DIFF
--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -71,6 +71,7 @@ func (ai *AddonsImages) FillDefaults() *AddonsImages {
 
 func GetDeployment(version string, operatorVersion string, namespace string, repository string, imageName string, tag string, imagePullPolicy string, addonsImages *AddonsImages) *appsv1.Deployment {
 	image := fmt.Sprintf("%s/%s:%s", repository, imageName, tag)
+	runAsNonRoot := true
 
 	deployment := &appsv1.Deployment{
 		TypeMeta: metav1.TypeMeta{
@@ -102,6 +103,9 @@ func GetDeployment(version string, operatorVersion string, namespace string, rep
 				},
 				Spec: corev1.PodSpec{
 					ServiceAccountName: Name,
+					SecurityContext: &corev1.PodSecurityContext{
+						RunAsNonRoot: &runAsNonRoot,
+					},
 					Containers: []corev1.Container{
 						{
 							Name:            Name,


### PR DESCRIPTION
**What this PR does / why we need it**:
In order to comply with operator [CFC Best practice](https://docs.engineering.redhat.com/display/CFC/Best_Practices),
we set the CNAO operator deployment to 'runAsNonRoot: true'
in the cnao manifest.

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
