### PR TITLE
Knmstate configure cert env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ The selfSignConfiguration parameters has to be all or none set, setting some of
 them fails at validation, also they have to conform to golang time.Duration
 string format also the following checks are done at validation: caRotateInterval => caOverlapInterval && caRotateInterval => certRotateInterval
 
-This parameters are consumed by kubemacpool component.
+This parameters are consumed by kubemacpool and kubernetes-nmstate components.
 
 # Deployment
 

--- a/pkg/network/nmstate.go
+++ b/pkg/network/nmstate.go
@@ -32,11 +32,9 @@ func renderNMState(conf *opv1alpha1.NetworkAddonsConfigSpec, manifestDir string,
 	data.Data["HandlerPullPolicy"] = conf.ImagePullPolicy
 	data.Data["HandlerNodeSelector"] = map[string]string{}
 	data.Data["EnableSCC"] = clusterInfo.SCCAvailable
-	// TODO: This is just a place holder to make template renderer happy
-	//       proper variable has to be read from selfSignConfiguration
-	data.Data["CARotateInterval"] = ""
-	data.Data["CAOverlapInterval"] = ""
-	data.Data["CertRotateInterval"] = ""
+	data.Data["CARotateInterval"] = conf.SelfSignConfiguration.CARotateInterval
+	data.Data["CAOverlapInterval"] = conf.SelfSignConfiguration.CAOverlapInterval
+	data.Data["CertRotateInterval"] = conf.SelfSignConfiguration.CertRotateInterval
 
 	objs, err := render.RenderDir(filepath.Join(manifestDir, "nmstate"), &data)
 	if err != nil {


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the master branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it

If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**What this PR does / why we need it**:
Configure knmstate cert rotation parameters from the CR
    
It will take the config from the selfSignConfiguration field at the networkaddonsconfig CR.


**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
Use selfSignConfiguration to configure kubernetes-nmstate cert rotation parameters.
```
