### PR TITLE
Use image digests instead of tags

### DIFF
--- a/hack/components/bump-bridge-marker.sh
+++ b/hack/components/bump-bridge-marker.sh
@@ -4,6 +4,7 @@ set -xeo pipefail
 
 source hack/components/yaml-utils.sh
 source hack/components/git-utils.sh
+source hack/components/docker-utils.sh
 
 #here we do all the object specific parametizing
 function __parametize_by_object() {
@@ -92,6 +93,7 @@ echo 'Get bridge-marker image name and update it under CNAO'
 BRIDGE_MARKER_TAG=$(git-utils::get_component_tag ${BRIDGE_MARKER_PATH})
 BRIDGE_MARKER_IMAGE=quay.io/kubevirt/bridge-marker
 BRIDGE_MARKER_IMAGE_TAGGED=${BRIDGE_MARKER_IMAGE}:${BRIDGE_MARKER_TAG}
-sed -i "s#\"${BRIDGE_MARKER_IMAGE}:.*\"#\"${BRIDGE_MARKER_IMAGE_TAGGED}\"#" \
+BRIDGE_MARKER_IMAGE_DIGEST="$(docker-utils::get_image_digest "${BRIDGE_MARKER_IMAGE_TAGGED}" "${BRIDGE_MARKER_IMAGE}")"
+sed -i -r "s#\"${BRIDGE_MARKER_IMAGE}(@sha256)?:.*\"#\"${BRIDGE_MARKER_IMAGE_DIGEST}\"#" \
     pkg/components/components.go \
     test/releases/${CNAO_VERSION}.go

--- a/hack/components/bump-bridge-marker.sh
+++ b/hack/components/bump-bridge-marker.sh
@@ -94,6 +94,6 @@ BRIDGE_MARKER_TAG=$(git-utils::get_component_tag ${BRIDGE_MARKER_PATH})
 BRIDGE_MARKER_IMAGE=quay.io/kubevirt/bridge-marker
 BRIDGE_MARKER_IMAGE_TAGGED=${BRIDGE_MARKER_IMAGE}:${BRIDGE_MARKER_TAG}
 BRIDGE_MARKER_IMAGE_DIGEST="$(docker-utils::get_image_digest "${BRIDGE_MARKER_IMAGE_TAGGED}" "${BRIDGE_MARKER_IMAGE}")"
-sed -i -r "s#\"${BRIDGE_MARKER_IMAGE}(@sha256)?:.*\"#\"${BRIDGE_MARKER_IMAGE_DIGEST}\"#" \
-    pkg/components/components.go \
-    test/releases/${CNAO_VERSION}.go
+
+sed -i -r "s#\"${BRIDGE_MARKER_IMAGE}(@sha256)?:.*\"#\"${BRIDGE_MARKER_IMAGE_DIGEST}\"#" pkg/components/components.go
+sed -i -r "s#\"${BRIDGE_MARKER_IMAGE}(@sha256)?:.*\"#\"${BRIDGE_MARKER_IMAGE_DIGEST}\"#" test/releases/${CNAO_VERSION}.go

--- a/hack/components/bump-knmstate.sh
+++ b/hack/components/bump-knmstate.sh
@@ -23,9 +23,9 @@ NMSTATE_TAG=$(git-utils::get_component_tag ${NMSTATE_PATH})
 NMSTATE_IMAGE=quay.io/nmstate/kubernetes-nmstate-handler
 NMSTATE_IMAGE_TAGGED=${NMSTATE_IMAGE}:${NMSTATE_TAG}
 NMSTATE_IMAGE_DIGEST="$(docker-utils::get_image_digest "${NMSTATE_IMAGE_TAGGED}" "${NMSTATE_IMAGE}")"
-sed -i -r "s#\"${NMSTATE_IMAGE}(@sha256)?:.*\"#\"${NMSTATE_IMAGE_DIGEST}\"#" \
-    pkg/components/components.go \
-    "test/releases/${CNAO_VERSION}.go"
+
+sed -i -r "s#\"${NMSTATE_IMAGE}(@sha256)?:.*\"#\"${NMSTATE_IMAGE_DIGEST}\"#" pkg/components/components.go
+sed -i -r "s#\"${NMSTATE_IMAGE}(@sha256)?:.*\"#\"${NMSTATE_IMAGE_DIGEST}\"#" "test/releases/${CNAO_VERSION}.go"
 
 echo 'Copy kubernetes-nmstate manifests'
 rm -rf data/nmstate/*

--- a/hack/components/bump-knmstate.sh
+++ b/hack/components/bump-knmstate.sh
@@ -4,6 +4,7 @@ set -xeo pipefail
 
 source hack/components/yaml-utils.sh
 source hack/components/git-utils.sh
+source hack/components/docker-utils.sh
 
 echo 'Bumping kubernetes-nmstate'
 NMSTATE_URL=$(yaml-utils::get_component_url nmstate)
@@ -21,9 +22,10 @@ echo 'Get kubernetes-nmstate image name and update it under CNAO'
 NMSTATE_TAG=$(git-utils::get_component_tag ${NMSTATE_PATH})
 NMSTATE_IMAGE=quay.io/nmstate/kubernetes-nmstate-handler
 NMSTATE_IMAGE_TAGGED=${NMSTATE_IMAGE}:${NMSTATE_TAG}
-sed -i "s#\"${NMSTATE_IMAGE}:.*\"#\"${NMSTATE_IMAGE_TAGGED}\"#" \
+NMSTATE_IMAGE_DIGEST="$(docker-utils::get_image_digest "${NMSTATE_IMAGE_TAGGED}" "${NMSTATE_IMAGE}")"
+sed -i -r "s#\"${NMSTATE_IMAGE}(@sha256)?:.*\"#\"${NMSTATE_IMAGE_DIGEST}\"#" \
     pkg/components/components.go \
-    test/releases/${CNAO_VERSION}.go
+    "test/releases/${CNAO_VERSION}.go"
 
 echo 'Copy kubernetes-nmstate manifests'
 rm -rf data/nmstate/*

--- a/hack/components/bump-kubemacpool.sh
+++ b/hack/components/bump-kubemacpool.sh
@@ -4,6 +4,7 @@ set -xeo pipefail
 
 source hack/components/yaml-utils.sh
 source hack/components/git-utils.sh
+source hack/components/docker-utils.sh
 
 echo 'Bumping kubemacpool'
 KUBEMACPOOL_URL=$(yaml-utils::get_component_url kubemacpool)
@@ -80,5 +81,7 @@ echo 'Get kubemacpool image name and update it under CNAO'
 KUBEMACPOOL_TAG=$(git-utils::get_component_tag ${KUBEMACPOOL_PATH})
 KUBEMACPOOL_IMAGE=quay.io/kubevirt/kubemacpool
 KUBEMACPOOL_IMAGE_TAGGED=${KUBEMACPOOL_IMAGE}:${KUBEMACPOOL_TAG}
-sed -i "s#\"${KUBEMACPOOL_IMAGE}:.*\"#\"${KUBEMACPOOL_IMAGE_TAGGED}\"#" pkg/components/components.go
-sed -i "s#\"${KUBEMACPOOL_IMAGE}:.*\"#\"${KUBEMACPOOL_IMAGE_TAGGED}\"#" test/releases/${CNAO_VERSION}.go
+KUBEMACPOOL_IMAGE_DIGEST="$(docker-utils::get_image_digest "${KUBEMACPOOL_IMAGE_TAGGED}" "${KUBEMACPOOL_IMAGE}")"
+
+sed -i -r "s#\"${KUBEMACPOOL_IMAGE}(@sha256)?:.*\"#\"${KUBEMACPOOL_IMAGE_DIGEST}\"#" pkg/components/components.go
+sed -i -r "s#\"${KUBEMACPOOL_IMAGE}(@sha256)?:.*\"#\"${KUBEMACPOOL_IMAGE_DIGEST}\"#" test/releases/${CNAO_VERSION}.go

--- a/hack/components/bump-linux-bridge.sh
+++ b/hack/components/bump-linux-bridge.sh
@@ -45,7 +45,7 @@ echo 'Push the image to KubeVirt repo'
     fi
 )
 
-if [[ "$(docker-utils::check_image_exists "${LINUX_BRIDGE_IMAGE}" "${LINUX_BRIDGE_TAG}")" ]]; then
+if [[ -n "$(docker-utils::check_image_exists "${LINUX_BRIDGE_IMAGE}" "${LINUX_BRIDGE_TAG}")" ]]; then
     LINUX_BRIDGE_IMAGE_DIGEST="$(docker-utils::get_image_digest "${LINUX_BRIDGE_IMAGE_TAGGED}" "${LINUX_BRIDGE_IMAGE}")"
 else
     LINUX_BRIDGE_IMAGE_DIGEST=${LINUX_BRIDGE_IMAGE_TAGGED}

--- a/hack/components/bump-macvtap.sh
+++ b/hack/components/bump-macvtap.sh
@@ -45,4 +45,4 @@ MACVTAP_IMAGE_DIGEST="$(docker-utils::get_image_digest "${MACVTAP_IMAGE_TAGGED}"
 
 sed -i -r "s#\"${MACVTAP_IMAGE}(@sha256)?:.*\"#\"${MACVTAP_IMAGE_DIGEST}\"#" pkg/components/components.go
 # TODO: uncomment the following line *once* there is macvtap upgrade is supported
-#sed -i "s#\"${MACVTAP_IMAGE}:.*\"#\"${MACVTAP_IMAGE_TAGGED}\"#" test/releases/${CNAO_VERSION}.go
+#sed -i "s#\"${MACVTAP_IMAGE}(@sha256)?:.*\"#\"${MACVTAP_IMAGE_DIGEST}\"#" test/releases/${CNAO_VERSION}.go

--- a/hack/components/bump-macvtap.sh
+++ b/hack/components/bump-macvtap.sh
@@ -4,6 +4,7 @@ set -xeo pipefail
 
 source hack/components/yaml-utils.sh
 source hack/components/git-utils.sh
+source hack/components/docker-utils.sh
 
 echo 'Bumping macvtap-cni'
 MACVTAP_URL=$(yaml-utils::get_component_url macvtap-cni)
@@ -40,6 +41,8 @@ echo 'Get macvtap-cni image name and update it under CNAO'
 MACVTAP_TAG=$(git-utils::get_component_tag ${MACVTAP_PATH})
 MACVTAP_IMAGE=quay.io/kubevirt/macvtap-cni
 MACVTAP_IMAGE_TAGGED=${MACVTAP_IMAGE}:${MACVTAP_TAG}
-sed -i "s#\"${MACVTAP_IMAGE}:.*\"#\"${MACVTAP_IMAGE_TAGGED}\"#" pkg/components/components.go
+MACVTAP_IMAGE_DIGEST="$(docker-utils::get_image_digest "${MACVTAP_IMAGE_TAGGED}" "${MACVTAP_IMAGE}")"
+
+sed -i -r "s#\"${MACVTAP_IMAGE}(@sha256)?:.*\"#\"${MACVTAP_IMAGE_DIGEST}\"#" pkg/components/components.go
 # TODO: uncomment the following line *once* there is macvtap upgrade is supported
 #sed -i "s#\"${MACVTAP_IMAGE}:.*\"#\"${MACVTAP_IMAGE_TAGGED}\"#" test/releases/${CNAO_VERSION}.go

--- a/hack/components/bump-multus.sh
+++ b/hack/components/bump-multus.sh
@@ -108,6 +108,6 @@ MULTUS_TAG=$(git-utils::get_component_tag ${MULTUS_PATH})
 MULTUS_IMAGE=nfvpe/multus
 MULTUS_IMAGE_TAGGED=${MULTUS_IMAGE}:${MULTUS_TAG}
 MULTUS_IMAGE_DIGEST="$(docker-utils::get_image_digest "${MULTUS_IMAGE_TAGGED}" "${MULTUS_IMAGE}")"
-sed -i -r "s#\"${MULTUS_IMAGE}(@sha256)?:.*\"#\"${MULTUS_IMAGE_DIGEST}\"#" \
-    pkg/components/components.go \
-    test/releases/${CNAO_VERSION}.go
+
+sed -i -r "s#\"${MULTUS_IMAGE}(@sha256)?:.*\"#\"${MULTUS_IMAGE_DIGEST}\"#" pkg/components/components.go
+sed -i -r "s#\"${MULTUS_IMAGE}(@sha256)?:.*\"#\"${MULTUS_IMAGE_DIGEST}\"#" test/releases/${CNAO_VERSION}.go

--- a/hack/components/bump-multus.sh
+++ b/hack/components/bump-multus.sh
@@ -4,6 +4,7 @@ set -xeo pipefail
 
 source hack/components/yaml-utils.sh
 source hack/components/git-utils.sh
+source hack/components/docker-utils.sh
 
 #here we do all the object specific parametizing
 function __parametize_by_object() {
@@ -106,6 +107,7 @@ echo 'Get multus image name and update it under CNAO'
 MULTUS_TAG=$(git-utils::get_component_tag ${MULTUS_PATH})
 MULTUS_IMAGE=nfvpe/multus
 MULTUS_IMAGE_TAGGED=${MULTUS_IMAGE}:${MULTUS_TAG}
-sed -i "s#\"${MULTUS_IMAGE}:.*\"#\"${MULTUS_IMAGE_TAGGED}\"#" \
+MULTUS_IMAGE_DIGEST="$(docker-utils::get_image_digest "${MULTUS_IMAGE_TAGGED}" "${MULTUS_IMAGE}")"
+sed -i -r "s#\"${MULTUS_IMAGE}(@sha256)?:.*\"#\"${MULTUS_IMAGE_DIGEST}\"#" \
     pkg/components/components.go \
     test/releases/${CNAO_VERSION}.go

--- a/hack/components/bump-ovs-cni.sh
+++ b/hack/components/bump-ovs-cni.sh
@@ -4,6 +4,7 @@ set -xeo pipefail
 
 source hack/components/yaml-utils.sh
 source hack/components/git-utils.sh
+source hack/components/docker-utils.sh
 
 #here we do all the object specific parametizing
 function __parametize_by_object() {
@@ -107,13 +108,15 @@ OVS_TAG=$(git-utils::get_component_tag ${OVS_PATH})
 echo 'Get ovs-cni-plugin image name and update it under CNAO'
 OVS_PLUGIN_IMAGE=quay.io/kubevirt/ovs-cni-plugin
 OVS_PLUGIN_IMAGE_TAGGED=${OVS_PLUGIN_IMAGE}:${OVS_TAG}
-sed -i "s#\"${OVS_PLUGIN_IMAGE}:.*\"#\"${OVS_PLUGIN_IMAGE_TAGGED}\"#" \
+OVS_PLUGIN_IMAGE_DIGEST="$(docker-utils::get_image_digest "${OVS_PLUGIN_IMAGE_TAGGED}" "${OVS_PLUGIN_IMAGE}")"
+sed -i -r "s#\"${OVS_PLUGIN_IMAGE}(@sha256)?:.*\"#\"${OVS_PLUGIN_IMAGE_DIGEST}\"#" \
     pkg/components/components.go \
     test/releases/${CNAO_VERSION}.go
 
-echo 'Get ovs-cni-marker image name and update it under CNAO'
+echo -r 'Get ovs-cni-marker image name and update it under CNAO'
 OVS_MARKER_IMAGE=quay.io/kubevirt/ovs-cni-marker
 OVS_MARKER_IMAGE_TAGGED=${OVS_MARKER_IMAGE}:${OVS_TAG}
-sed -i "s#\"${OVS_MARKER_IMAGE}:.*\"#\"${OVS_MARKER_IMAGE_TAGGED}\"#" \
+OVS_MARKER_IMAGE_DIGEST="$(docker-utils::get_image_digest "${OVS_MARKER_IMAGE_TAGGED}" "${OVS_MARKER_IMAGE}")"
+sed -i -r "s#\"${OVS_MARKER_IMAGE}(@sha256)?:.*\"#\"${OVS_MARKER_IMAGE_DIGEST}\"#" \
     pkg/components/components.go \
     test/releases/${CNAO_VERSION}.go

--- a/hack/components/bump-ovs-cni.sh
+++ b/hack/components/bump-ovs-cni.sh
@@ -109,14 +109,14 @@ echo 'Get ovs-cni-plugin image name and update it under CNAO'
 OVS_PLUGIN_IMAGE=quay.io/kubevirt/ovs-cni-plugin
 OVS_PLUGIN_IMAGE_TAGGED=${OVS_PLUGIN_IMAGE}:${OVS_TAG}
 OVS_PLUGIN_IMAGE_DIGEST="$(docker-utils::get_image_digest "${OVS_PLUGIN_IMAGE_TAGGED}" "${OVS_PLUGIN_IMAGE}")"
-sed -i -r "s#\"${OVS_PLUGIN_IMAGE}(@sha256)?:.*\"#\"${OVS_PLUGIN_IMAGE_DIGEST}\"#" \
-    pkg/components/components.go \
-    test/releases/${CNAO_VERSION}.go
 
-echo -r 'Get ovs-cni-marker image name and update it under CNAO'
+sed -i -r "s#\"${OVS_PLUGIN_IMAGE}(@sha256)?:.*\"#\"${OVS_PLUGIN_IMAGE_DIGEST}\"#" pkg/components/components.go
+sed -i -r "s#\"${OVS_PLUGIN_IMAGE}(@sha256)?:.*\"#\"${OVS_PLUGIN_IMAGE_DIGEST}\"#" test/releases/${CNAO_VERSION}.go
+
+echo 'Get ovs-cni-marker image name and update it under CNAO'
 OVS_MARKER_IMAGE=quay.io/kubevirt/ovs-cni-marker
 OVS_MARKER_IMAGE_TAGGED=${OVS_MARKER_IMAGE}:${OVS_TAG}
 OVS_MARKER_IMAGE_DIGEST="$(docker-utils::get_image_digest "${OVS_MARKER_IMAGE_TAGGED}" "${OVS_MARKER_IMAGE}")"
-sed -i -r "s#\"${OVS_MARKER_IMAGE}(@sha256)?:.*\"#\"${OVS_MARKER_IMAGE_DIGEST}\"#" \
-    pkg/components/components.go \
-    test/releases/${CNAO_VERSION}.go
+
+sed -i -r "s#\"${OVS_MARKER_IMAGE}(@sha256)?:.*\"#\"${OVS_MARKER_IMAGE_DIGEST}\"#" pkg/components/components.go
+sed -i -r "s#\"${OVS_MARKER_IMAGE}(@sha256)?:.*\"#\"${OVS_MARKER_IMAGE_DIGEST}\"#" test/releases/${CNAO_VERSION}.go

--- a/hack/components/docker-utils.sh
+++ b/hack/components/docker-utils.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+set -xo pipefail
+
+function docker-utils::get_image_digest() {
+  echo "${2}@$(docker run --rm quay.io/skopeo/stable:latest inspect "docker://${1}" | jq -r '.Digest')"
+}
+
+function docker-utils::check_image_exists() {
+  docker run --rm quay.io/skopeo/stable:latest list-tags "docker://${1}" | grep "\"${2}\""
+}

--- a/hack/components/docker-utils.sh
+++ b/hack/components/docker-utils.sh
@@ -2,10 +2,28 @@
 
 set -xo pipefail
 
+# The get_image_digest function retrieves the image digest from the registry, according to the
+# image name (registry:tag format).
+#
+# Parameters:
+# 1. image name in registry:tag format
+# 2. image name without the tag
+#
+# Returns
+# The image digest
+#
 function docker-utils::get_image_digest() {
   echo "${2}@$(docker run --rm quay.io/skopeo/stable:latest inspect "docker://${1}" | jq -r '.Digest')"
 }
 
+# The check_image_exists function checks if an image already exists in the registry.
+#
+# Parameters:
+# 1. image name in registry:tag format
+# 2. image tag
+#
+# returns the image tag if found; else, returns an empty result
+#
 function docker-utils::check_image_exists() {
   docker run --rm quay.io/skopeo/stable:latest list-tags "docker://${1}" | grep "\"${2}\""
 }

--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -20,14 +20,14 @@ const (
 )
 
 const (
-	MultusImageDefault            = "nfvpe/multus:v3.4.1"
-	LinuxBridgeCniImageDefault    = "quay.io/kubevirt/cni-default-plugins:v0.8.6"
-	LinuxBridgeMarkerImageDefault = "quay.io/kubevirt/bridge-marker:0.3.0"
-	KubeMacPoolImageDefault       = "quay.io/kubevirt/kubemacpool:v0.19.0"
-	NMStateHandlerImageDefault    = "quay.io/nmstate/kubernetes-nmstate-handler:v0.29.0"
-	OvsCniImageDefault            = "quay.io/kubevirt/ovs-cni-plugin:v0.12.0"
-	OvsMarkerImageDefault         = "quay.io/kubevirt/ovs-cni-marker:v0.12.0"
-	MacvtapCniImageDefault        = "quay.io/kubevirt/macvtap-cni:v0.2.0"
+	MultusImageDefault            = "nfvpe/multus@sha256:167722b954355361bd69829466f27172b871dbdbf86b85a95816362885dc0aba"
+	LinuxBridgeCniImageDefault    = "quay.io/kubevirt/cni-default-plugins@sha256:680ac8fd5eeab39c9a3c01479da344bdcaa43aa065d07ae00513b7bafa22fccf"
+	LinuxBridgeMarkerImageDefault = "quay.io/kubevirt/bridge-marker@sha256:e55f73526468fee46a35ae41aa860f492d208b8a7a132832c5b9a76d4a51566a"
+	KubeMacPoolImageDefault       = "quay.io/kubevirt/kubemacpool@sha256:34c470f7654da6d4407cc9bcb79c871cd5c90a3396861dc2ff64ad013ef0aa74"
+	NMStateHandlerImageDefault    = "quay.io/nmstate/kubernetes-nmstate-handler@sha256:76cc13fb4a60943dca6038619599b6a49fe451852aba23ad3046658429a9af30"
+	OvsCniImageDefault            = "quay.io/kubevirt/ovs-cni-plugin@sha256:4101c52617efb54a45181548c257a08e3689f634b79b9dfcff42bffd8b25af53"
+	OvsMarkerImageDefault         = "quay.io/kubevirt/ovs-cni-marker@sha256:0f08d6b1550a90c9f10221f2bb07709d1090e7c675ee1a711981bd429074d620"
+	MacvtapCniImageDefault        = "quay.io/kubevirt/macvtap-cni@sha256:2606ac545cc69af5766d929bd82f86df5098a5e1c8ac26cfd2cdf99c46da8067"
 )
 
 type AddonsImages struct {

--- a/test/releases/99.0.0.go
+++ b/test/releases/99.0.0.go
@@ -8,53 +8,53 @@ func init() {
 	release := Release{
 		Version: "99.0.0",
 		Containers: []opv1alpha1.Container{
-			opv1alpha1.Container{
+			{
 				ParentName: "multus",
 				ParentKind: "DaemonSet",
 				Name:       "kube-multus",
-				Image:      "nfvpe/multus:v3.4.1",
+				Image:      "nfvpe/multus@sha256:167722b954355361bd69829466f27172b871dbdbf86b85a95816362885dc0aba",
 			},
-			opv1alpha1.Container{
+			{
 				ParentName: "bridge-marker",
 				ParentKind: "DaemonSet",
 				Name:       "bridge-marker",
-				Image:      "quay.io/kubevirt/bridge-marker:0.3.0",
+				Image:      "quay.io/kubevirt/bridge-marker@sha256:e55f73526468fee46a35ae41aa860f492d208b8a7a132832c5b9a76d4a51566a",
 			},
-			opv1alpha1.Container{
+			{
 				ParentName: "kube-cni-linux-bridge-plugin",
 				ParentKind: "DaemonSet",
 				Name:       "cni-plugins",
-				Image:      "quay.io/kubevirt/cni-default-plugins:v0.8.6",
+				Image:      "quay.io/kubevirt/cni-default-plugins@sha256:680ac8fd5eeab39c9a3c01479da344bdcaa43aa065d07ae00513b7bafa22fccf",
 			},
-			opv1alpha1.Container{
+			{
 				ParentName: "kubemacpool-mac-controller-manager",
 				ParentKind: "Deployment",
 				Name:       "manager",
-				Image:      "quay.io/kubevirt/kubemacpool:v0.19.0",
+				Image:      "quay.io/kubevirt/kubemacpool@sha256:34c470f7654da6d4407cc9bcb79c871cd5c90a3396861dc2ff64ad013ef0aa74",
 			},
-			opv1alpha1.Container{
+			{
 				ParentName: "nmstate-handler",
 				ParentKind: "DaemonSet",
 				Name:       "nmstate-handler",
-				Image:      "quay.io/nmstate/kubernetes-nmstate-handler:v0.29.0",
+				Image:      "quay.io/nmstate/kubernetes-nmstate-handler@sha256:76cc13fb4a60943dca6038619599b6a49fe451852aba23ad3046658429a9af30",
 			},
-			opv1alpha1.Container{
+			{
 				ParentName: "nmstate-webhook",
 				ParentKind: "Deployment",
 				Name:       "nmstate-webhook",
-				Image:      "quay.io/nmstate/kubernetes-nmstate-handler:v0.29.0",
+				Image:      "quay.io/nmstate/kubernetes-nmstate-handler@sha256:76cc13fb4a60943dca6038619599b6a49fe451852aba23ad3046658429a9af30",
 			},
-			opv1alpha1.Container{
+			{
 				ParentName: "ovs-cni-amd64",
 				ParentKind: "DaemonSet",
 				Name:       "ovs-cni-plugin",
-				Image:      "quay.io/kubevirt/ovs-cni-plugin:v0.12.0",
+				Image:      "quay.io/kubevirt/ovs-cni-plugin@sha256:4101c52617efb54a45181548c257a08e3689f634b79b9dfcff42bffd8b25af53",
 			},
-			opv1alpha1.Container{
+			{
 				ParentName: "ovs-cni-amd64",
 				ParentKind: "DaemonSet",
 				Name:       "ovs-cni-marker",
-				Image:      "quay.io/kubevirt/ovs-cni-marker:v0.12.0",
+				Image:      "quay.io/kubevirt/ovs-cni-marker@sha256:0f08d6b1550a90c9f10221f2bb07709d1090e7c675ee1a711981bd429074d620",
 			},
 		},
 		SupportedSpec: opv1alpha1.NetworkAddonsConfigSpec{


### PR DESCRIPTION
In order to enable deployment in disconnected environment, all the images in the CSV must be with digests instead of tag.

Signed-off-by: Nahshon Unna-Tsameret <nunnatsa@redhat.com>

<!-- Thanks for sending a pull request!

Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the master branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it

If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
Images in CSV are now digest instead of repo:tag
```
