### PR TITLE
Add the relatedImages field to the CSV

### DIFF
--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -2,20 +2,26 @@ package components
 
 import (
 	"fmt"
-	cnav1alpha1 "github.com/kubevirt/cluster-network-addons-operator/pkg/apis/networkaddonsoperator/v1alpha1"
-	opv1alpha1 "github.com/kubevirt/cluster-network-addons-operator/pkg/apis/networkaddonsoperator/v1alpha1"
-	"github.com/kubevirt/cluster-network-addons-operator/pkg/util/k8s"
+	"regexp"
+
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	extv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"strings"
+
+	cnav1alpha1 "github.com/kubevirt/cluster-network-addons-operator/pkg/apis/networkaddonsoperator/v1alpha1"
+	opv1alpha1 "github.com/kubevirt/cluster-network-addons-operator/pkg/apis/networkaddonsoperator/v1alpha1"
+	"github.com/kubevirt/cluster-network-addons-operator/pkg/util/k8s"
 )
 
 const (
 	Name      = "cluster-network-addons-operator"
 	Namespace = "cluster-network-addons"
+)
+
+var (
+	imageSplitRe = regexp.MustCompile(`(?:.+/)*([^/:@]+)(?:[:@]?.*)?`)
 )
 
 const (
@@ -104,18 +110,10 @@ func (ai AddonsImages) ToRelatedImages() RelatedImages {
 
 func NewRelatedImage(image string) RelatedImage {
 	// find the basic image name - with no registry and tag
-	// remove registry prefix if exists (e.g. quay.io/organization/)
-	subStr := image[strings.LastIndex(image, "/")+1:]
-
-	// remove digest tag if exists (e.g. @sha256:79889cb3fd31db8c945021d928e86738654288d451f4cd42c8c07c9690398330)
-	index := strings.LastIndex(subStr, "@")
-	if index == -1 {
-		// remove image tag if exists (e.g. :latest or :v1.2.3)
-		if index = strings.LastIndex(subStr, ":"); index == -1 {
-			index = len(subStr)
-		}
+	name := image
+	if names := imageSplitRe.FindStringSubmatch(image); len(names) > 1 {
+		name = names[1]
 	}
-	name := subStr[:index]
 
 	return RelatedImage{
 		Name: name,

--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -47,8 +47,8 @@ type AddonsImages struct {
 }
 
 type RelatedImage struct {
-	Name string `json:"name"`
-	Ref  string `json:"image"`
+	Name string
+	Ref  string
 }
 
 type RelatedImages []RelatedImage

--- a/pkg/components/components_suite_test.go
+++ b/pkg/components/components_suite_test.go
@@ -1,0 +1,13 @@
+package components_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestNetwork(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Components Suite")
+}

--- a/pkg/components/components_test.go
+++ b/pkg/components/components_test.go
@@ -1,0 +1,90 @@
+package components
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+const imageName = "the-image-name"
+
+var _ = Describe("Components Tests", func() {
+	Context("RelatedImage Test", func() {
+		It("Should extruct a short image name from image name", func() {
+			image := "imageRegistry/organization/" + imageName + ":1.2.3"
+			ri := NewRelatedImage(image)
+			Expect(ri.Ref).To(Equal(image))
+			Expect(ri.Name).To(Equal(imageName))
+		})
+
+		It("Should extruct a short image name from image digest", func() {
+			image := "imageRegistry/organization/" + imageName + "@sha256:76cc13fb4a60943dca6038619599b6a49fe451852aba23ad3046658429a9af30"
+			ri := NewRelatedImage(image)
+			Expect(ri.Ref).To(Equal(image))
+			Expect(ri.Name).To(Equal(imageName))
+		})
+
+		It("Should copy the imaage name if not it not match to the standard", func() {
+			image := "justAstring" + imageName + "anotherString"
+			ri := NewRelatedImage(image)
+			Expect(ri.Ref).To(Equal(image))
+			Expect(ri.Name).To(Equal(image))
+		})
+	})
+
+	Context("RelatedImages Tests", func() {
+		It(`"constructor" should create an empty list when there are no parameters`, func() {
+			ris := NewRelatedImages()
+			Expect(len(ris)).To(Equal(0))
+		})
+
+		It(`"constructor" should create a list of related images if getting image names as parameters`, func() {
+			ris := NewRelatedImages(
+				"nfvpe/multus@sha256:167722b954355361bd69829466f27172b871dbdbf86b85a95816362885dc0aba",
+				"quay.io/kubevirt/cni-default-plugins@sha256:680ac8fd5eeab39c9a3c01479da344bdcaa43aa065d07ae00513b7bafa22fccf",
+				"quay.io/kubevirt/ovs-cni-marker@sha256:0f08d6b1550a90c9f10221f2bb07709d1090e7c675ee1a711981bd429074d620",
+			)
+			Expect(len(ris)).To(Equal(3))
+
+			Expect(ris[0].Name).To(Equal("multus"))
+			Expect(ris[0].Ref).To(Equal("nfvpe/multus@sha256:167722b954355361bd69829466f27172b871dbdbf86b85a95816362885dc0aba"))
+			Expect(ris[1].Name).To(Equal("cni-default-plugins"))
+			Expect(ris[1].Ref).To(Equal("quay.io/kubevirt/cni-default-plugins@sha256:680ac8fd5eeab39c9a3c01479da344bdcaa43aa065d07ae00513b7bafa22fccf"))
+			Expect(ris[2].Name).To(Equal("ovs-cni-marker"))
+			Expect(ris[2].Ref).To(Equal("quay.io/kubevirt/ovs-cni-marker@sha256:0f08d6b1550a90c9f10221f2bb07709d1090e7c675ee1a711981bd429074d620"))
+		})
+
+		It("should add image to an empty list", func() {
+			var ris RelatedImages
+			Expect(len(ris)).To(Equal(0))
+
+			ris.Add("nfvpe/multus@sha256:167722b954355361bd69829466f27172b871dbdbf86b85a95816362885dc0aba")
+			Expect(len(ris)).To(Equal(1))
+			Expect(ris[0].Name).To(Equal("multus"))
+			Expect(ris[0].Ref).To(Equal("nfvpe/multus@sha256:167722b954355361bd69829466f27172b871dbdbf86b85a95816362885dc0aba"))
+		})
+
+		It("should add image to an non-empty list", func() {
+			ris := NewRelatedImages(
+				"nfvpe/multus@sha256:167722b954355361bd69829466f27172b871dbdbf86b85a95816362885dc0aba",
+				"quay.io/kubevirt/cni-default-plugins@sha256:680ac8fd5eeab39c9a3c01479da344bdcaa43aa065d07ae00513b7bafa22fccf",
+			)
+			Expect(len(ris)).To(Equal(2))
+
+			Expect(ris[0].Name).To(Equal("multus"))
+			Expect(ris[0].Ref).To(Equal("nfvpe/multus@sha256:167722b954355361bd69829466f27172b871dbdbf86b85a95816362885dc0aba"))
+			Expect(ris[1].Name).To(Equal("cni-default-plugins"))
+			Expect(ris[1].Ref).To(Equal("quay.io/kubevirt/cni-default-plugins@sha256:680ac8fd5eeab39c9a3c01479da344bdcaa43aa065d07ae00513b7bafa22fccf"))
+
+			ris.Add("quay.io/kubevirt/ovs-cni-marker@sha256:0f08d6b1550a90c9f10221f2bb07709d1090e7c675ee1a711981bd429074d620")
+
+			Expect(len(ris)).To(Equal(3))
+
+			Expect(ris[0].Name).To(Equal("multus"))
+			Expect(ris[0].Ref).To(Equal("nfvpe/multus@sha256:167722b954355361bd69829466f27172b871dbdbf86b85a95816362885dc0aba"))
+			Expect(ris[1].Name).To(Equal("cni-default-plugins"))
+			Expect(ris[1].Ref).To(Equal("quay.io/kubevirt/cni-default-plugins@sha256:680ac8fd5eeab39c9a3c01479da344bdcaa43aa065d07ae00513b7bafa22fccf"))
+			Expect(ris[2].Name).To(Equal("ovs-cni-marker"))
+			Expect(ris[2].Ref).To(Equal("quay.io/kubevirt/ovs-cni-marker@sha256:0f08d6b1550a90c9f10221f2bb07709d1090e7c675ee1a711981bd429074d620"))
+		})
+	})
+})

--- a/pkg/components/components_test.go
+++ b/pkg/components/components_test.go
@@ -8,26 +8,41 @@ import (
 
 const imageName = "the-image-name"
 
-var _ = Describe("Components Tests", func() {
-	Describe("RelatedImage Test", func() {
-		DescribeTable("image name tests", func(fullImageName string){
-			ri := NewRelatedImage(fullImageName)
-			Expect(ri.Ref).To(Equal(fullImageName))
-			Expect(ri.Name).To(Equal(imageName))
-		},
-		Entry("Should extract a short image name from image name", "imageRegistry/organization/" + imageName + ":1.2.3"),
-		Entry("Should extract a short image name from image digest", "imageRegistry/organization/" + imageName + "@sha256:76cc13fb4a60943dca6038619599b6a49fe451852aba23ad3046658429a9af30"),
-		Entry("Should copy the image name if it not match to the standard", imageName),
-		Entry("Should find the right name, even with a registry name with a port number", "registry:5000/" + imageName + "@sha256:76cc13fb4a60943dca6038619599b6a49fe451852aba23ad3046658429a9af30"))
-	})
+var _ = Describe("Components", func() {
+	DescribeTable("When RelatedImage is called", func(fullImageName, expectedShortName string) {
+		ri := NewRelatedImage(fullImageName)
+		Expect(ri.Ref).To(Equal(fullImageName))
+		Expect(ri.Name).To(Equal(expectedShortName))
+	},
+		Entry("Should extract a short image name from image name",
+			"imageRegistry/organization/the-image-name:1.2.3",
+			"the-image-name",
+		),
+		Entry("Should extract a short image name from image digest",
+			"imageRegistry/organization/the-image-name@sha256:76cc13fb4a60943dca6038619599b6a49fe451852aba23ad3046658429a9af30",
+			"the-image-name",
+		),
+		Entry("Should copy the image name if it not match to the standard",
+			"the-image-name",
+			"the-image-name",
+		),
+		Entry("Should find the short name, when the host name is with a port number",
+			"registry:5000/the-image-name@sha256:76cc13fb4a60943dca6038619599b6a49fe451852aba23ad3046658429a9af30",
+			"the-image-name",
+		),
+		Entry("Should find the short name, when the image name is just organization/image",
+			"organization/the-image-name",
+			"the-image-name",
+		),
+	)
 
-	Context("RelatedImages Tests", func() {
-		It(`"constructor" should create an empty list when there are no parameters`, func() {
+	Context("When RelatedImages constructor is called", func() {
+		It("Should create an empty list when there are no parameters", func() {
 			ris := NewRelatedImages()
 			Expect(ris).To(BeEmpty())
 		})
 
-		It(`"constructor" should create a list of related images if getting image names as parameters`, func() {
+		It("Should create a list of related images if getting image names as parameters", func() {
 			ris := NewRelatedImages(
 				"nfvpe/multus@sha256:167722b954355361bd69829466f27172b871dbdbf86b85a95816362885dc0aba",
 				"quay.io/kubevirt/cni-default-plugins@sha256:680ac8fd5eeab39c9a3c01479da344bdcaa43aa065d07ae00513b7bafa22fccf",
@@ -42,7 +57,9 @@ var _ = Describe("Components Tests", func() {
 			Expect(ris[2].Name).To(Equal("ovs-cni-marker"))
 			Expect(ris[2].Ref).To(Equal("quay.io/kubevirt/ovs-cni-marker@sha256:0f08d6b1550a90c9f10221f2bb07709d1090e7c675ee1a711981bd429074d620"))
 		})
+	})
 
+	Context("When adding image to RelatedImages", func() {
 		It("should add image to an empty list", func() {
 			var ris RelatedImages
 			Expect(ris).To(BeEmpty())

--- a/pkg/components/components_test.go
+++ b/pkg/components/components_test.go
@@ -2,39 +2,29 @@ package components
 
 import (
 	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 )
 
 const imageName = "the-image-name"
 
 var _ = Describe("Components Tests", func() {
-	Context("RelatedImage Test", func() {
-		It("Should extruct a short image name from image name", func() {
-			image := "imageRegistry/organization/" + imageName + ":1.2.3"
-			ri := NewRelatedImage(image)
-			Expect(ri.Ref).To(Equal(image))
+	Describe("RelatedImage Test", func() {
+		DescribeTable("image name tests", func(fullImageName string){
+			ri := NewRelatedImage(fullImageName)
+			Expect(ri.Ref).To(Equal(fullImageName))
 			Expect(ri.Name).To(Equal(imageName))
-		})
-
-		It("Should extruct a short image name from image digest", func() {
-			image := "imageRegistry/organization/" + imageName + "@sha256:76cc13fb4a60943dca6038619599b6a49fe451852aba23ad3046658429a9af30"
-			ri := NewRelatedImage(image)
-			Expect(ri.Ref).To(Equal(image))
-			Expect(ri.Name).To(Equal(imageName))
-		})
-
-		It("Should copy the imaage name if not it not match to the standard", func() {
-			image := "justAstring" + imageName + "anotherString"
-			ri := NewRelatedImage(image)
-			Expect(ri.Ref).To(Equal(image))
-			Expect(ri.Name).To(Equal(image))
-		})
+		},
+		Entry("Should extract a short image name from image name", "imageRegistry/organization/" + imageName + ":1.2.3"),
+		Entry("Should extract a short image name from image digest", "imageRegistry/organization/" + imageName + "@sha256:76cc13fb4a60943dca6038619599b6a49fe451852aba23ad3046658429a9af30"),
+		Entry("Should copy the image name if it not match to the standard", imageName),
+		Entry("Should find the right name, even with a registry name with a port number", "registry:5000/" + imageName + "@sha256:76cc13fb4a60943dca6038619599b6a49fe451852aba23ad3046658429a9af30"))
 	})
 
 	Context("RelatedImages Tests", func() {
 		It(`"constructor" should create an empty list when there are no parameters`, func() {
 			ris := NewRelatedImages()
-			Expect(len(ris)).To(Equal(0))
+			Expect(ris).To(BeEmpty())
 		})
 
 		It(`"constructor" should create a list of related images if getting image names as parameters`, func() {
@@ -43,7 +33,7 @@ var _ = Describe("Components Tests", func() {
 				"quay.io/kubevirt/cni-default-plugins@sha256:680ac8fd5eeab39c9a3c01479da344bdcaa43aa065d07ae00513b7bafa22fccf",
 				"quay.io/kubevirt/ovs-cni-marker@sha256:0f08d6b1550a90c9f10221f2bb07709d1090e7c675ee1a711981bd429074d620",
 			)
-			Expect(len(ris)).To(Equal(3))
+			Expect(ris).To(HaveLen(3))
 
 			Expect(ris[0].Name).To(Equal("multus"))
 			Expect(ris[0].Ref).To(Equal("nfvpe/multus@sha256:167722b954355361bd69829466f27172b871dbdbf86b85a95816362885dc0aba"))
@@ -55,10 +45,10 @@ var _ = Describe("Components Tests", func() {
 
 		It("should add image to an empty list", func() {
 			var ris RelatedImages
-			Expect(len(ris)).To(Equal(0))
+			Expect(ris).To(BeEmpty())
 
 			ris.Add("nfvpe/multus@sha256:167722b954355361bd69829466f27172b871dbdbf86b85a95816362885dc0aba")
-			Expect(len(ris)).To(Equal(1))
+			Expect(ris).To(HaveLen(1))
 			Expect(ris[0].Name).To(Equal("multus"))
 			Expect(ris[0].Ref).To(Equal("nfvpe/multus@sha256:167722b954355361bd69829466f27172b871dbdbf86b85a95816362885dc0aba"))
 		})
@@ -68,16 +58,17 @@ var _ = Describe("Components Tests", func() {
 				"nfvpe/multus@sha256:167722b954355361bd69829466f27172b871dbdbf86b85a95816362885dc0aba",
 				"quay.io/kubevirt/cni-default-plugins@sha256:680ac8fd5eeab39c9a3c01479da344bdcaa43aa065d07ae00513b7bafa22fccf",
 			)
-			Expect(len(ris)).To(Equal(2))
+			Expect(ris).To(HaveLen(2))
 
 			Expect(ris[0].Name).To(Equal("multus"))
 			Expect(ris[0].Ref).To(Equal("nfvpe/multus@sha256:167722b954355361bd69829466f27172b871dbdbf86b85a95816362885dc0aba"))
 			Expect(ris[1].Name).To(Equal("cni-default-plugins"))
 			Expect(ris[1].Ref).To(Equal("quay.io/kubevirt/cni-default-plugins@sha256:680ac8fd5eeab39c9a3c01479da344bdcaa43aa065d07ae00513b7bafa22fccf"))
 
+			By("adding a new image to the list")
 			ris.Add("quay.io/kubevirt/ovs-cni-marker@sha256:0f08d6b1550a90c9f10221f2bb07709d1090e7c675ee1a711981bd429074d620")
 
-			Expect(len(ris)).To(Equal(3))
+			Expect(ris).To(HaveLen(3))
 
 			Expect(ris[0].Name).To(Equal("multus"))
 			Expect(ris[0].Ref).To(Equal("nfvpe/multus@sha256:167722b954355361bd69829466f27172b871dbdbf86b85a95816362885dc0aba"))

--- a/templates/cluster-network-addons/VERSION/cluster-network-addons-operator.VERSION.clusterserviceversion.yaml.in
+++ b/templates/cluster-network-addons/VERSION/cluster-network-addons-operator.VERSION.clusterserviceversion.yaml.in
@@ -88,6 +88,11 @@ spec:
         - name: cluster-network-addons-operator
           spec:
 {{.CNA.DeploymentSpec}}
+  relatedImages:
+  {{- range .CNA.RelatedImages }}
+    - image: "{{ .Ref }}"
+      name: "{{ .Name }}"
+  {{- end}}
   customresourcedefinitions:
     owned:
       - name: {{.CNA.CRD.ObjectMeta.Name}}

--- a/tools/manifest-templator/manifest-templator.go
+++ b/tools/manifest-templator/manifest-templator.go
@@ -47,6 +47,7 @@ type operatorData struct {
 	CRD               *extv1beta1.CustomResourceDefinition
 	CRDString         string
 	CRString          string
+	RelatedImages     components.RelatedImages
 }
 
 type templateData struct {
@@ -200,6 +201,11 @@ func getCNA(data *templateData) {
 	marshallObject(cr, &writer)
 	crString := writer.String()
 
+	// Get related images
+	relatedImages := data.AddonsImages.ToRelatedImages()
+	selfImageName := fmt.Sprintf("%s/%s:%s", data.ContainerPrefix, data.ImageName, data.ContainerTag)
+	relatedImages.Add(selfImageName)
+
 	cnaData := operatorData{
 		Deployment:        deployment,
 		DeploymentSpec:    deploymentSpec,
@@ -210,6 +216,7 @@ func getCNA(data *templateData) {
 		CRD:               crd,
 		CRDString:         crdString,
 		CRString:          crString,
+		RelatedImages:     relatedImages,
 	}
 	data.CNA = &cnaData
 }


### PR DESCRIPTION

Signed-off-by: Nahshon Unna-Tsameret <nunnatsa@redhat.com>

**What this PR does / why we need it**:
In order to enable deployment in disconnected environment, all the images in the CSV listed under the `relatedImages` field.

**Release note**:
```release-note
Add the relatedImages field to the CSV
```
