### PR TITLE
fix ClusterServiceVersion manifest to not use deprecated version

### DIFF
--- a/templates/cluster-network-addons/VERSION/cluster-network-addons-operator.VERSION.clusterserviceversion.yaml.in
+++ b/templates/cluster-network-addons/VERSION/cluster-network-addons-operator.VERSION.clusterserviceversion.yaml.in
@@ -96,7 +96,7 @@ spec:
   customresourcedefinitions:
     owned:
       - name: {{.CNA.CRD.ObjectMeta.Name}}
-        version: {{.CNA.CRD.Spec.Version}}
+        version: {{.CNA.CRDVersion}}
         group: {{.CNA.CRD.Spec.Group}}
         kind: {{.CNA.CRD.Spec.Names.Kind}}
         displayName: Cluster Network Addons

--- a/tools/manifest-templator/manifest-templator.go
+++ b/tools/manifest-templator/manifest-templator.go
@@ -46,6 +46,7 @@ type operatorData struct {
 	ClusterRules      string
 	CRD               *extv1beta1.CustomResourceDefinition
 	CRDString         string
+	CRDVersion        string
 	CRString          string
 	RelatedImages     components.RelatedImages
 }
@@ -194,6 +195,7 @@ func getCNA(data *templateData) {
 	crd := components.GetCrd()
 	marshallObject(crd, &writer)
 	crdString := writer.String()
+	crdVersion := crd.Spec.Versions[0].Name
 
 	// Get CNA CR
 	writer = strings.Builder{}
@@ -215,6 +217,7 @@ func getCNA(data *templateData) {
 		ClusterRules:      clusterRules,
 		CRD:               crd,
 		CRDString:         crdString,
+		CRDVersion:        crdVersion,
 		CRString:          crString,
 		RelatedImages:     relatedImages,
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently manifest templator created the field customresourcedefinitions.owned[0].version
using the [deprecated](https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definition-versioning/#specify-multiple-versions) crd `version` field.
Lets move to updated `versions` field.

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
