### PR TITLE
make it possible to run `kubectl explain crd`

### DIFF
--- a/pkg/apis/networkaddonsoperator/shared/networkaddonsconfig_types.go
+++ b/pkg/apis/networkaddonsoperator/shared/networkaddonsconfig_types.go
@@ -21,15 +21,22 @@ type NetworkAddonsConfigSpec struct {
 }
 
 // +k8s:openapi-gen=true
+// SelfSignConfiguration defines self sign configuration
 type SelfSignConfiguration struct {
+	// CARotateInterval defines duration for CA and certificate
 	CARotateInterval   string `json:"caRotateInterval,omitempty"`
+	// CAOverlapInterval defines the duration of CA Certificates at CABundle if not set it will default to CARotateInterval
 	CAOverlapInterval  string `json:"caOverlapInterval,omitempty"`
+	// CertRotateInterval defines duration for of service certificate
 	CertRotateInterval string `json:"certRotateInterval,omitempty"`
 }
 
 // +k8s:openapi-gen=true
+// PlacementConfiguration defines node placement configuration
 type PlacementConfiguration struct {
+	// Infra defines placement configuration for master nodes
 	Infra     *Placement `json:"infra,omitempty"`
+	// Workloads defines placement configuration for worker nodes
 	Workloads *Placement `json:"workloads,omitempty"`
 }
 
@@ -40,24 +47,32 @@ type Placement struct {
 	Tolerations  []corev1.Toleration `json:"tolerations,omitempty"`
 }
 
+// Multus plugin enables attaching multiple network interfaces to Pods in Kubernetes
 // +k8s:openapi-gen=true
 type Multus struct{}
 
+// LinuxBridge plugin allows users to create a bridge and add the host and the container to it
 // +k8s:openapi-gen=true
 type LinuxBridge struct{}
 
+// Ovs plugin allows users to define Kubernetes networks on top of Open vSwitch bridges available on nodes
 // +k8s:openapi-gen=true
 type Ovs struct{}
 
+// NMState is a declarative node network configuration driven through Kubernetes API
 // +k8s:openapi-gen=true
 type NMState struct{}
 
+// KubeMacPool plugin manages MAC allocation to Pods and VMs in Kubernetes
 // +k8s:openapi-gen=true
 type KubeMacPool struct {
+	// RangeStart defines the first mac in range
 	RangeStart string `json:"rangeStart,omitempty"`
+	// RangeEnd defines the last mac in range
 	RangeEnd   string `json:"rangeEnd,omitempty"`
 }
 
+// MacvtapCni plugin allows users to define Kubernetes networks on top of existing host interfaces
 // +k8s:openapi-gen=true
 type MacvtapCni struct{}
 
@@ -79,8 +94,7 @@ type Container struct {
 }
 
 // NetworkAddonsConfig is the Schema for the networkaddonsconfigs API
-// This struct is no exposed/registered as part of the CRD, but is used
-// by the v1alpha1 and v1 as kind of inside-helper struct
+// This struct is no exposed/registered as part of the CRD, but is used by the v1alpha1 and v1 as kind of inside-helper struct
 type NetworkAddonsConfig struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/pkg/apis/networkaddonsoperator/v1/networkaddonsconfig_types.go
+++ b/pkg/apis/networkaddonsoperator/v1/networkaddonsconfig_types.go
@@ -10,7 +10,7 @@ import (
 
 // NetworkAddonsConfig is the Schema for the networkaddonsconfigs API
 // +kubebuilder:subresource:status
-// +kubebuilder:resource:path=networkaddonsconfigs,scope=Namespaced
+// +kubebuilder:resource:path=networkaddonsconfigs,scope=Cluster
 // +k8s:openapi-gen=true
 type NetworkAddonsConfig struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/pkg/apis/networkaddonsoperator/v1alpha1/networkaddonsconfig_types.go
+++ b/pkg/apis/networkaddonsoperator/v1alpha1/networkaddonsconfig_types.go
@@ -10,7 +10,7 @@ import (
 
 // NetworkAddonsConfig is the Schema for the networkaddonsconfigs API
 // +kubebuilder:subresource:status
-// +kubebuilder:resource:path=networkaddonsconfigs,scope=Namespaced
+// +kubebuilder:resource:path=networkaddonsconfigs,scope=Cluster
 // +k8s:openapi-gen=true
 type NetworkAddonsConfig struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -374,6 +374,20 @@ func GetClusterRole() *rbacv1.ClusterRole {
 
 func GetCrd() *extv1.CustomResourceDefinition {
 	subResouceSchema := &extv1.CustomResourceSubresources{Status: &extv1.CustomResourceSubresourceStatus{}}
+	placementProps := map[string]extv1.JSONSchemaProps{
+		"NodeSelector" : extv1.JSONSchemaProps{
+			Type:        "object",
+		},
+		"Affinity" : extv1.JSONSchemaProps{
+			Description: "Affinity is a group of affinity scheduling rules.",
+			Type:        "object",
+		},
+		"Tolerations" : extv1.JSONSchemaProps{
+			Description: "The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.",
+			Type:        "object",
+		},
+	}
+
 	validationSchema := &extv1.CustomResourceValidation{
 		OpenAPIV3Schema: &extv1.JSONSchemaProps{
 			Description: "NetworkAddonsConfig is the Schema for the networkaddonsconfigs API",
@@ -391,37 +405,80 @@ func GetCrd() *extv1.CustomResourceDefinition {
 					Type: "object",
 				},
 				"spec": extv1.JSONSchemaProps{
-					Type: "object",
+					Description: "NetworkAddonsConfigSpec defines the desired state of NetworkAddonsConfig",
+					Type:        "object",
 					Properties: map[string]extv1.JSONSchemaProps{
 						"imagePullPolicy": extv1.JSONSchemaProps{
 							Description: "PullPolicy describes a policy for if/when to pull a container image",
 							Type:        "string",
 						},
 						"kubeMacPool": extv1.JSONSchemaProps{
-							Type: "object",
+							Description: "KubeMacPool plugin manages MAC allocation to Pods and VMs in Kubernetes",
+							Type:        "object",
 							Properties: map[string]extv1.JSONSchemaProps{
 								"rangeEnd": extv1.JSONSchemaProps{
-									Type: "string",
+									Description: "RangeEnd defines the first mac in range",
+									Type:        "string",
 								},
 								"rangeStart": extv1.JSONSchemaProps{
-									Type: "string",
+									Description: "RangeStart defines the first mac in range",
+									Type:        "string",
 								},
 							},
 						},
 						"linuxBridge": extv1.JSONSchemaProps{
-							Type: "object",
+							Description: "LinuxBridge plugin allows users to create a bridge and add the host and the container to it",
+							Type:        "object",
 						},
 						"macvtap": extv1.JSONSchemaProps{
-							Type: "object",
+							Description: "MacvtapCni plugin allows users to define Kubernetes networks on top of existing host interfaces",
+							Type:        "object",
 						},
 						"multus": extv1.JSONSchemaProps{
-							Type: "object",
+							Description: "Multus plugin enables attaching multiple network interfaces to Pods in Kubernetes",
+							Type:        "object",
 						},
 						"nmstate": extv1.JSONSchemaProps{
-							Type: "object",
+							Description: "NMState is a declarative node network configuration driven through Kubernetes API",
+							Type:        "object",
 						},
 						"ovs": extv1.JSONSchemaProps{
+							Description: "Ovs plugin allows users to define Kubernetes networks on top of Open vSwitch bridges available on nodes",
+							Type:        "object",
+						},
+						"selfSignConfiguration": extv1.JSONSchemaProps{
+							Description: "SelfSignConfiguration defines self sign configuration",
 							Type: "object",
+							Properties: map[string]extv1.JSONSchemaProps{
+								"caRotateInterval": extv1.JSONSchemaProps{
+									Description: "CARotateInterval defines duration for CA and certificate",
+									Type:        "string",
+								},
+								"certRotateInterval": extv1.JSONSchemaProps{
+									Description: "CertRotateInterval defines duration for of service certificate",
+									Type:        "string",
+								},
+								"caOverlapInterval": extv1.JSONSchemaProps{
+									Description: "CAOverlapInterval defines the duration of CA Certificates at CABundle if not set it will default to CARotateInterval",
+									Type:        "string",
+								},
+							},
+						},
+						"PlacementConfiguration": extv1.JSONSchemaProps{
+							Description: "PlacementConfiguration defines node placement configuration",
+							Type: "object",
+							Properties: map[string]extv1.JSONSchemaProps{
+								"Infra": extv1.JSONSchemaProps{
+									Description: "Infra defines placement configuration for master nodes",
+									Type:        "object",
+									Properties: placementProps,
+								},
+								"Workloads": extv1.JSONSchemaProps{
+									Description: "Workloads defines placement configuration for worker nodes",
+									Type:        "object",
+									Properties: placementProps,
+								},
+							},
 						},
 					},
 				},
@@ -430,19 +487,20 @@ func GetCrd() *extv1.CustomResourceDefinition {
 					Type:        "object",
 					Properties: map[string]extv1.JSONSchemaProps{
 						"conditions": extv1.JSONSchemaProps{
+							//Description: "Condition represents the state of the operator's reconciliation functionality.",
 							Type: "array",
 							Items: &extv1.JSONSchemaPropsOrArray{
 								Schema: &extv1.JSONSchemaProps{
 									Type: "object",
 									Properties: map[string]extv1.JSONSchemaProps{
 										"lastHeartbeatTime": extv1.JSONSchemaProps{
-											Format:   "date-time",
-											Type:     "object",
+											Format: "date-time",
+											Type:   "string",
 											Nullable: true,
 										},
 										"lastTransitionTime": extv1.JSONSchemaProps{
-											Format:   "date-time",
-											Type:     "object",
+											Format: "date-time",
+											Type:   "string",
 											Nullable: true,
 										},
 										"message": extv1.JSONSchemaProps{

--- a/test/check/check.go
+++ b/test/check/check.go
@@ -56,6 +56,15 @@ func CheckComponentsDeployment(components []Component) {
 	}
 }
 
+func CheckCrdExplainable() {
+	By("Checking crd is explainable")
+	explain, err := Kubectl("explain", "networkaddonsconfigs")
+	Expect(err).NotTo(HaveOccurred(), "explain should not return error")
+
+	Expect(explain).ToNot(BeEmpty(), "explain output should not be empty")
+	Expect(explain).ToNot(ContainSubstring("<empty>"), "explain output should not contain <empty> fields")
+}
+
 func CheckComponentsRemoval(components []Component) {
 	for _, component := range components {
 		if component.ComponentName == MultusComponent.ComponentName && IsOnOKDCluster() {

--- a/test/e2e/lifecycle/upgrade_test.go
+++ b/test/e2e/lifecycle/upgrade_test.go
@@ -44,6 +44,10 @@ var _ = Context("Cluster Network Addons Operator", func() {
 					CheckConfigVersions(newReleaseGvk, expectedOperatorVersion, expectedObservedVersion, expectedTargetVersion, podsDeploymentTimeout, CheckDoNotRepeat)
 				})
 
+				It("Should be able to explain the crd object", func() {
+					CheckCrdExplainable()
+				})
+
 				It("it should report expected deployed container images and leave no leftovers from the previous version", func() {
 					By("Checking reported container images")
 					CheckReleaseUsesExpectedContainerImages(newReleaseGvk, newRelease)

--- a/tools/manifest-templator/manifest-templator.go
+++ b/tools/manifest-templator/manifest-templator.go
@@ -195,6 +195,7 @@ func getCNA(data *templateData) {
 	crd := components.GetCrd()
 	marshallObject(crd, &writer)
 	crdString := writer.String()
+	crdString = addPreserveUnknownFields(crdString)
 	crdVersion := crd.Spec.Versions[0].Name
 
 	// Get CNA CR
@@ -222,6 +223,12 @@ func getCNA(data *templateData) {
 		RelatedImages:     relatedImages,
 	}
 	data.CNA = &cnaData
+}
+
+func addPreserveUnknownFields(crdString string) string {
+	// TODO replace this solution with a better one once this issue get resolved:
+	// https://github.com/kubernetes/kubernetes/issues/95702
+	return crdString + "  preserveUnknownFields: false"
 }
 
 func main() {


### PR DESCRIPTION
**What this PR does / why we need it**:
Let's make make it possible to run `kubectl explain networkaddonsconfigs`

- **add components annotations to types**
`operator-sdk generate crds` generates descriptions from the annotations added to `networkaddonsconfig_types.go`
This commit adds these annotations.

- **fix NetworkAddonsConfig scope to Cluster in api types**
Currently there is a inconsistency between the manifest templator
outputed crd manifest and the type annotations in scope field.
Altough the manifests are controlled by the manifest generator
lets fix the annotation avoid future confusion.

- **add openAPIV3Schema validation parameters**
Let's add openAPIV3Schema detail for "kubectl explain crd"
Since operator-sdk crd cannot run. this commit manually creates the openAPIV3Schema
that should've been generated by operator-sdk crd API.

- **adding test to make sure crd is explainable**

**Special notes for your reviewer**:
PR depends on #537, #593 to be merged

**Release note**:

```release-note
NONE
```
