### PR TITLE
Add placement configuration to ovs-cni

### DIFF
--- a/data/ovs/001-ovs-cni.yaml
+++ b/data/ovs/001-ovs-cni.yaml
@@ -19,12 +19,8 @@ spec:
     spec:
       serviceAccountName: ovs-cni-marker
       hostNetwork: true
-      nodeSelector:
-        beta.kubernetes.io/arch: amd64
-      tolerations:
-        - key: node-role.kubernetes.io/master
-          operator: Exists
-          effect: NoSchedule
+      nodeSelector: {{ toYaml .Placement.NodeSelector | nindent 8 }}
+      tolerations: {{ toYaml .Placement.Tolerations | nindent 8 }}
       initContainers:
         - name: ovs-cni-plugin
           image: {{ .OvsCNIImage }}
@@ -61,6 +57,7 @@ spec:
         - name: ovs-var-run
           hostPath:
             path: /var/run/openvswitch
+      affinity: {{ toYaml .Placement.Affinity | nindent 8 }}
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1beta1

--- a/hack/components/bump-ovs-cni.sh
+++ b/hack/components/bump-ovs-cni.sh
@@ -27,6 +27,9 @@ function __parametize_by_object() {
 				yaml-utils::update_param ${f} spec.template.spec.containers[0].image  '{{ .OvsMarkerImage }}'
 				yaml-utils::update_param ${f} spec.template.spec.containers[0].imagePullPolicy  '{{ .ImagePullPolicy }}'
 				yaml-utils::update_param ${f} spec.template.spec.volumes[0].hostPath.path  '{{ .CNIBinDir }}'
+				yaml-utils::update_param ${f} spec.template.spec.nodeSelector '{{ toYaml .Placement.NodeSelector | nindent 8 }}'
+				yaml-utils::set_param ${f} spec.template.spec.affinity '{{ toYaml .Placement.Affinity | nindent 8 }}'
+				yaml-utils::update_param ${f} spec.template.spec.tolerations '{{ toYaml .Placement.Tolerations | nindent 8 }}'
 				yaml-utils::remove_single_quotes_from_yaml ${f}
 				;;
 		esac

--- a/pkg/network/ovs.go
+++ b/pkg/network/ovs.go
@@ -25,6 +25,7 @@ func renderOvs(conf *cnao.NetworkAddonsConfigSpec, manifestDir string, clusterIn
 	data.Data["OvsMarkerImage"] = os.Getenv("OVS_MARKER_IMAGE")
 	data.Data["OvsImage"] = os.Getenv("OVS_IMAGE")
 	data.Data["ImagePullPolicy"] = conf.ImagePullPolicy
+	data.Data["Placement"] = conf.PlacementConfiguration.Workloads
 	if clusterInfo.OpenShift4 {
 		data.Data["CNIBinDir"] = cni.BinDirOpenShift4
 	} else {


### PR DESCRIPTION
**What this PR does / why we need it**:
Use Infra PlacementConfiguration from NetworkAddonsConfig in ovs-cni
By default, ovs-cni will be scheduled on master nodes.

**Special notes for your reviewer**:
This PR is dependent of PRs: #520

**Release note**:
```release-note
NONE
```
