### PR TITLE
Add placement configuration to multus

### DIFF
--- a/data/multus/001-multus.yaml
+++ b/data/multus/001-multus.yaml
@@ -87,11 +87,8 @@ spec:
         name: kube-multus-ds-amd64
     spec:
       hostNetwork: true
-      nodeSelector:
-        kubernetes.io/arch: amd64
-      tolerations:
-        - operator: Exists
-          effect: NoSchedule
+      nodeSelector: {{ toYaml .Placement.NodeSelector | nindent 8 }}
+      tolerations: {{ toYaml .Placement.Tolerations | nindent 8 }}
       serviceAccountName: multus
       containers:
         - name: kube-multus
@@ -122,6 +119,7 @@ spec:
         - name: cnibin
           hostPath:
             path: {{ .CNIBinDir }}
+      affinity: {{ toYaml .Placement.Affinity | nindent 8 }}
 {{ if .EnableSCC }}
 ---
 apiVersion: security.openshift.io/v1

--- a/hack/components/bump-multus.sh
+++ b/hack/components/bump-multus.sh
@@ -29,6 +29,9 @@ function __parametize_by_object() {
 				yaml-utils::update_param ${f} spec.template.spec.volumes[0].hostPath.path '{{ .CNIConfigDir }}'
 				yaml-utils::update_param ${f} spec.template.spec.volumes[1].hostPath.path '{{ .CNIBinDir }}'
 				yaml-utils::delete_param ${f} spec.template.spec.volumes[2]
+				yaml-utils::update_param ${f} spec.template.spec.nodeSelector '{{ toYaml .Placement.NodeSelector | nindent 8 }}'
+				yaml-utils::set_param ${f} spec.template.spec.affinity '{{ toYaml .Placement.Affinity | nindent 8 }}'
+				yaml-utils::update_param ${f} spec.template.spec.tolerations '{{ toYaml .Placement.Tolerations | nindent 8 }}'
 				yaml-utils::remove_single_quotes_from_yaml ${f}
 				;;
 		esac

--- a/pkg/network/multus.go
+++ b/pkg/network/multus.go
@@ -90,6 +90,7 @@ func renderMultus(conf *cnao.NetworkAddonsConfigSpec, manifestDir string, opensh
 	data.Data["Namespace"] = os.Getenv("OPERAND_NAMESPACE")
 	data.Data["MultusImage"] = os.Getenv("MULTUS_IMAGE")
 	data.Data["ImagePullPolicy"] = conf.ImagePullPolicy
+	data.Data["Placement"] = conf.PlacementConfiguration.Workloads
 	if clusterInfo.OpenShift4 {
 		data.Data["CNIConfigDir"] = cni.ConfigDirOpenShift4
 		data.Data["CNIBinDir"] = cni.BinDirOpenShift4


### PR DESCRIPTION
Use Infra PlacementConfiguration from NetworkAddonsConfig in multus
By default, multus will be scheduled on master nodes.

**What this PR does / why we need it**:

**Special notes for your reviewer**:
This PR is dependent of PRs: #520
**Release note**:

```release-note
NONE
```
