### PR TITLE
Add placement configuration to bridge-marker

### DIFF
--- a/data/linux-bridge/003-bridge-marker.yaml
+++ b/data/linux-bridge/003-bridge-marker.yaml
@@ -20,12 +20,8 @@ spec:
     spec:
       serviceAccountName: bridge-marker
       hostNetwork: true
-      nodeSelector:
-        beta.kubernetes.io/arch: amd64
-      tolerations:
-        - key: node-role.kubernetes.io/master
-          operator: Exists
-          effect: NoSchedule
+      nodeSelector: {{ toYaml .Placement.NodeSelector | nindent 8 }}
+      tolerations: {{ toYaml .Placement.Tolerations | nindent 8 }}
       containers:
         - name: bridge-marker
           image: {{ .LinuxBridgeMarkerImage }}
@@ -38,6 +34,7 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+      affinity: {{ toYaml .Placement.Affinity | nindent 8 }}
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1beta1

--- a/hack/components/bump-bridge-marker.sh
+++ b/hack/components/bump-bridge-marker.sh
@@ -22,6 +22,9 @@ function __parametize_by_object() {
 				yaml-utils::update_param ${f} metadata.namespace  '{{ .Namespace }}'
 				yaml-utils::update_param ${f} spec.template.spec.containers[0].image  '{{ .LinuxBridgeMarkerImage }}'
 				yaml-utils::update_param ${f} spec.template.spec.containers[0].imagePullPolicy  '{{ .ImagePullPolicy }}'
+				yaml-utils::update_param ${f} spec.template.spec.nodeSelector '{{ toYaml .Placement.NodeSelector | nindent 8 }}'
+				yaml-utils::set_param ${f} spec.template.spec.affinity '{{ toYaml .Placement.Affinity | nindent 8 }}'
+				yaml-utils::update_param ${f} spec.template.spec.tolerations '{{ toYaml .Placement.Tolerations | nindent 8 }}'
 				yaml-utils::remove_single_quotes_from_yaml ${f}
 				;;
 		esac


### PR DESCRIPTION
**What this PR does / why we need it**:
Use Infra PlacementConfiguration from NetworkAddonsConfig in bridge-marker
By default, bridge-marker will be scheduled on master nodes.

**Special notes for your reviewer**:
This PR is dependent of PRs: #520 #532

**Release note**:

```release-note
NONE
```
