### PR TITLE
Add PlacementConfiguration for linux-bridge

### DIFF
--- a/data/linux-bridge/002-linux-bridge.yaml
+++ b/data/linux-bridge/002-linux-bridge.yaml
@@ -21,12 +21,9 @@ spec:
 {{ if .EnableSCC }}
       serviceAccountName: linux-bridge
 {{ end }}
-      nodeSelector:
-        beta.kubernetes.io/arch: amd64
-      tolerations:
-        - key: node-role.kubernetes.io/master
-          operator: Exists
-          effect: NoSchedule
+      affinity: {{ toYaml .Placement.Affinity | nindent 8 }}
+      nodeSelector: {{ toYaml .Placement.NodeSelector | nindent 8 }}
+      tolerations: {{ toYaml .Placement.Tolerations | nindent 8 }}
       containers:
         - name: cni-plugins
           image: {{ .LinuxBridgeImage }}

--- a/pkg/network/linux-bridge.go
+++ b/pkg/network/linux-bridge.go
@@ -30,6 +30,7 @@ func renderLinuxBridge(conf *cnao.NetworkAddonsConfigSpec, manifestDir string, c
 		data.Data["CNIBinDir"] = cni.BinDir
 	}
 	data.Data["EnableSCC"] = clusterInfo.SCCAvailable
+	data.Data["Placement"] = conf.PlacementConfiguration.Workloads
 
 	objs, err := render.RenderDir(filepath.Join(manifestDir, "linux-bridge"), &data)
 	if err != nil {

--- a/pkg/network/network_test.go
+++ b/pkg/network/network_test.go
@@ -88,7 +88,7 @@ var _ = Describe("Testing network", func() {
 
 	Describe("Render", func() {
 		Context("when given valid arguments", func() {
-			conf := &cnao.NetworkAddonsConfigSpec{ImagePullPolicy: v1.PullAlways, Multus: &cnao.Multus{}, LinuxBridge: &cnao.LinuxBridge{}}
+			conf := &cnao.NetworkAddonsConfigSpec{ImagePullPolicy: v1.PullAlways, Multus: &cnao.Multus{}, LinuxBridge: &cnao.LinuxBridge{}, PlacementConfiguration: &cnao.PlacementConfiguration{Workloads: &cnao.Placement{}}}
 			manifestDir := "../../data"
 			openshiftNetworkConf := &osv1.Network{}
 			clusterInfo := &ClusterInfo{SCCAvailable: true, OpenShift4: false}
@@ -101,7 +101,7 @@ var _ = Describe("Testing network", func() {
 		})
 
 		Context("when given manifest directory that does not contain all expected components", func() {
-			conf := &cnao.NetworkAddonsConfigSpec{ImagePullPolicy: v1.PullAlways, Multus: &cnao.Multus{}, LinuxBridge: &cnao.LinuxBridge{}}
+			conf := &cnao.NetworkAddonsConfigSpec{ImagePullPolicy: v1.PullAlways, Multus: &cnao.Multus{}, LinuxBridge: &cnao.LinuxBridge{}, PlacementConfiguration: &cnao.PlacementConfiguration{Workloads: &cnao.Placement{}}}
 			manifestDir := "." // Test directory with this module
 			openshiftNetworkConf := &osv1.Network{}
 			clusterInfo := &ClusterInfo{SCCAvailable: true, OpenShift4: false}


### PR DESCRIPTION
Use Workloads PlacementConfiguration from NetworkAddonsConfig in linux-bridge
By default, linux-bridge pods will be scheduled on all nodes.

**What this PR does / why we need it**:

**Special notes for your reviewer**:
This PR depends on : #520 #526

```release-note
NONE
```
