### PR TITLE
Add PlacementConfiguration for macvtap

### DIFF
--- a/components.yaml
+++ b/components.yaml
@@ -37,7 +37,7 @@ components:
     metadata: "v0.12.0"
   macvtap-cni:
     url: "https://github.com/kubevirt/macvtap-cni"
-    commit: "14e5a3c7bf516bd4542366a78b7af02f04230ac5"
+    commit: "ced0fb4ce9ae9719b21269c7636b7d8ac14a6e6b"
     branch: "master"
     update-policy: "tagged"
-    metadata: "v0.2.0"
+    metadata: "v0.3.1"

--- a/data/macvtap/002-macvtap-daemonset.yaml
+++ b/data/macvtap/002-macvtap-daemonset.yaml
@@ -7,11 +7,12 @@ metadata:
 data:
   DP_MACVTAP_CONF: "[]"
 ---
+---
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: macvtap-cni
-  namespace: '{{ .Namespace }}'
+  namespace: {{ .Namespace }}
 spec:
   selector:
     matchLabels:
@@ -24,37 +25,40 @@ spec:
       hostNetwork: true
       hostPID: true
       containers:
-      - name: macvtap-cni
-        command: ["/macvtap-deviceplugin", "-v", "3", "-logtostderr"]
-        envFrom:
-          - configMapRef:
-              name: macvtap-deviceplugin-config
-        image: '{{ .MacvtapImage }}'
-        imagePullPolicy: '{{ .ImagePullPolicy }}'
-        resources:
-          requests:
-            cpu: "60m"
-            memory: "30Mi"
-        securityContext:
-          privileged: true
-        volumeMounts:
-          - name: deviceplugin
-            mountPath: /var/lib/kubelet/device-plugins
+        - name: macvtap-cni
+          command: ["/macvtap-deviceplugin", "-v", "3", "-logtostderr"]
+          envFrom:
+            - configMapRef:
+                name: macvtap-deviceplugin-config
+          image: {{ .MacvtapImage }}
+          imagePullPolicy: {{ .ImagePullPolicy }}
+          resources:
+            requests:
+              cpu: "60m"
+              memory: "30Mi"
+          securityContext:
+            privileged: true
+          volumeMounts:
+            - name: deviceplugin
+              mountPath: /var/lib/kubelet/device-plugins
       initContainers:
-      - name: install-cni
-        command: ["cp", "/macvtap-cni", "/host/opt/cni/bin/macvtap"]
-        image: '{{ .MacvtapImage }}'
-        imagePullPolicy: '{{ .ImagePullPolicy }}'
-        securityContext:
-          privileged: true
-        volumeMounts:
-          - name: cni
-            mountPath: /host/opt/cni/bin
-            mountPropagation: Bidirectional
+        - name: install-cni
+          command: ["cp", "/macvtap-cni", "/host/opt/cni/bin/macvtap"]
+          image: {{ .MacvtapImage }}
+          imagePullPolicy: {{ .ImagePullPolicy }}
+          securityContext:
+            privileged: true
+          volumeMounts:
+            - name: cni
+              mountPath: /host/opt/cni/bin
+              mountPropagation: Bidirectional
       volumes:
         - name: deviceplugin
           hostPath:
             path: /var/lib/kubelet/device-plugins
         - name: cni
           hostPath:
-            path: '{{ .CniMountPath }}'
+            path: {{ .CniMountPath }}
+      affinity: {{ toYaml .Placement.Affinity | nindent 8 }}
+      nodeSelector: {{ toYaml .Placement.NodeSelector | nindent 8 }}
+      tolerations: {{ toYaml .Placement.Tolerations | nindent 8 }}

--- a/data/macvtap/002-macvtap-daemonset.yaml
+++ b/data/macvtap/002-macvtap-daemonset.yaml
@@ -11,7 +11,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: macvtap-cni
-  namespace: {{ .Namespace }}
+  namespace: '{{ .Namespace }}'
 spec:
   selector:
     matchLabels:
@@ -25,12 +25,12 @@ spec:
       hostPID: true
       containers:
       - name: macvtap-cni
-        command: [ "/macvtap-deviceplugin", "-v", "3", "-logtostderr"]
+        command: ["/macvtap-deviceplugin", "-v", "3", "-logtostderr"]
         envFrom:
           - configMapRef:
               name: macvtap-deviceplugin-config
-        image: {{ .MacvtapImage }}
-        imagePullPolicy: {{ .ImagePullPolicy }}
+        image: '{{ .MacvtapImage }}'
+        imagePullPolicy: '{{ .ImagePullPolicy }}'
         resources:
           requests:
             cpu: "60m"
@@ -42,9 +42,9 @@ spec:
             mountPath: /var/lib/kubelet/device-plugins
       initContainers:
       - name: install-cni
-        command: ['cp', '/macvtap-cni', '/host/opt/cni/bin/macvtap']
-        image: {{ .MacvtapImage }}
-        imagePullPolicy: {{ .ImagePullPolicy }}
+        command: ["cp", "/macvtap-cni", "/host/opt/cni/bin/macvtap"]
+        image: '{{ .MacvtapImage }}'
+        imagePullPolicy: '{{ .ImagePullPolicy }}'
         securityContext:
           privileged: true
         volumeMounts:
@@ -57,4 +57,4 @@ spec:
             path: /var/lib/kubelet/device-plugins
         - name: cni
           hostPath:
-            path: {{ .CniMountPath }}
+            path: '{{ .CniMountPath }}'

--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -32,7 +32,7 @@ const (
 	NMStateHandlerImageDefault    = "quay.io/nmstate/kubernetes-nmstate-handler@sha256:444ab3349882ac58f594396529708146993b831c2e3e1d524eaa12e17e09f150"
 	OvsCniImageDefault            = "quay.io/kubevirt/ovs-cni-plugin@sha256:4101c52617efb54a45181548c257a08e3689f634b79b9dfcff42bffd8b25af53"
 	OvsMarkerImageDefault         = "quay.io/kubevirt/ovs-cni-marker@sha256:0f08d6b1550a90c9f10221f2bb07709d1090e7c675ee1a711981bd429074d620"
-	MacvtapCniImageDefault        = "quay.io/kubevirt/macvtap-cni@sha256:2606ac545cc69af5766d929bd82f86df5098a5e1c8ac26cfd2cdf99c46da8067"
+	MacvtapCniImageDefault        = "quay.io/kubevirt/macvtap-cni@sha256:407f75760fc096666becfa45d94f51757ebbe8f382e9e7b57ceeded0b8cfb6b8"
 )
 
 type AddonsImages struct {

--- a/pkg/network/macvtap.go
+++ b/pkg/network/macvtap.go
@@ -29,6 +29,7 @@ func renderMacvtapCni(conf *cnao.NetworkAddonsConfigSpec, manifestDir string, cl
 	} else {
 		data.Data["CniMountPath"] = cni.BinDir
 	}
+	data.Data["Placement"] = conf.PlacementConfiguration.Workloads
 	objs, err := render.RenderDir(filepath.Join(manifestDir, "macvtap"), &data)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to render macvtap-cni state handler manifests")


### PR DESCRIPTION
Bump macvtap dep to v0.3.1

It contains the following PRs:
- Change vbom.ml/util dependency with github.com/fvbommel/util [0]
    Fixes vbom dependency
- Adding quotes in macvtap.yaml.in [1]
    Allows using yq to edit macvtap.yaml.in
- Fix container command quotes in macvtap.yaml.in [2]
    Fixes single quotes in command list

[0] https://github.com/kubevirt/macvtap-cni/pull/25
[1] https://github.com/kubevirt/macvtap-cni/pull/24
[2] https://github.com/kubevirt/macvtap-cni/pull/27

Use Workloads PlacementConfiguration from NetworkAddonsConfig for macvtap pods.
By default, macvtap pods will are scheduled on all nodes.

**What this PR does / why we need it**:

**Special notes for your reviewer**:
This PR depends on : #520 #526

**Release note**:
```release-note
NONE
```
