### PR TITLE
Add Placement for knmstate

### DIFF
--- a/components.yaml
+++ b/components.yaml
@@ -25,10 +25,10 @@ components:
     metadata: "v0.20.0"
   nmstate:
     url: "https://github.com/nmstate/kubernetes-nmstate"
-    commit: "f1c8aec816f88ac0435c3c8985bc49823fb9d20a"
+    commit: "a0d3d5658390fac730bafcc85506a0a681da98ac"
     branch: "master"
     update-policy: "tagged"
-    metadata: "v0.29.0"
+    metadata: "v0.31.0"
   ovs-cni:
     url: "https://github.com/kubevirt/ovs-cni"
     commit: "edb4754d08f49be54c399c938895fe82aab6aa5a"

--- a/data/nmstate/operator.yaml
+++ b/data/nmstate/operator.yaml
@@ -23,13 +23,9 @@ spec:
         name: {{template "handlerPrefix" .}}nmstate-webhook
     spec:
       serviceAccountName: {{template "handlerPrefix" .}}nmstate-handler
-      nodeSelector:
-        beta.kubernetes.io/arch: amd64
-        node-role.kubernetes.io/master: ""
-      tolerations:
-        - key: node-role.kubernetes.io/master
-          operator: Exists
-          effect: NoSchedule
+      nodeSelector: {{ toYaml .WebhookNodeSelector | nindent 8 }}
+      tolerations: {{ toYaml .WebhookTolerations | nindent 8 }}
+      affinity: {{ toYaml .WebhookAffinity | nindent 8 }}
       containers:
         - name: nmstate-webhook
           args:
@@ -111,15 +107,9 @@ spec:
       # https://github.com/nmstate/nmstate/pull/440
       hostNetwork: true
       serviceAccountName: {{template "handlerPrefix" .}}nmstate-handler
-      nodeSelector:
-        beta.kubernetes.io/arch: amd64
-      {{- range $key, $value := .HandlerNodeSelector }}
-      {{"  "}}{{- $key }}: {{  $value }}
-      {{- end}}
-      tolerations:
-        - key: node-role.kubernetes.io/master
-          operator: Exists
-          effect: NoSchedule
+      nodeSelector: {{ toYaml .HandlerNodeSelector | nindent 8 }}
+      tolerations: {{ toYaml .HandlerTolerations | nindent 8 }}
+      affinity: {{ toYaml .HandlerAffinity | nindent 8 }}
       containers:
         - name: nmstate-handler
           args:

--- a/data/nmstate/operator.yaml
+++ b/data/nmstate/operator.yaml
@@ -23,9 +23,9 @@ spec:
         name: {{template "handlerPrefix" .}}nmstate-webhook
     spec:
       serviceAccountName: {{template "handlerPrefix" .}}nmstate-handler
-      nodeSelector: {{ toYaml .WebhookNodeSelector | nindent 8 }}
-      tolerations: {{ toYaml .WebhookTolerations | nindent 8 }}
-      affinity: {{ toYaml .WebhookAffinity | nindent 8 }}
+      nodeSelector: {{ toYaml .PlacementConfiguration.Infra.NodeSelector | nindent 8 }}
+      tolerations: {{ toYaml .PlacementConfiguration.Infra.Tolerations | nindent 8 }}
+      affinity: {{ toYaml .PlacementConfiguration.Infra.Affinity | nindent 8 }}
       containers:
         - name: nmstate-webhook
           args:
@@ -107,9 +107,9 @@ spec:
       # https://github.com/nmstate/nmstate/pull/440
       hostNetwork: true
       serviceAccountName: {{template "handlerPrefix" .}}nmstate-handler
-      nodeSelector: {{ toYaml .HandlerNodeSelector | nindent 8 }}
-      tolerations: {{ toYaml .HandlerTolerations | nindent 8 }}
-      affinity: {{ toYaml .HandlerAffinity | nindent 8 }}
+      nodeSelector: {{ toYaml .PlacementConfiguration.Workloads.NodeSelector | nindent 8 }}
+      tolerations: {{ toYaml .PlacementConfiguration.Workloads.Tolerations | nindent 8 }}
+      affinity: {{ toYaml .PlacementConfiguration.Workloads.Affinity | nindent 8 }}
       containers:
         - name: nmstate-handler
           args:

--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -29,7 +29,7 @@ const (
 	LinuxBridgeCniImageDefault    = "quay.io/kubevirt/cni-default-plugins@sha256:3dd438117076016d6d2acd508b93f106ca80a28c0af6e2e914d812f9a1d55142"
 	LinuxBridgeMarkerImageDefault = "quay.io/kubevirt/bridge-marker@sha256:e55f73526468fee46a35ae41aa860f492d208b8a7a132832c5b9a76d4a51566a"
 	KubeMacPoolImageDefault       = "quay.io/kubevirt/kubemacpool@sha256:ad8ca6d379d495804969ba4d03da9a6936ff8f413f6f6c7bd20e0138dc0303c4"
-	NMStateHandlerImageDefault    = "quay.io/nmstate/kubernetes-nmstate-handler@sha256:76cc13fb4a60943dca6038619599b6a49fe451852aba23ad3046658429a9af30"
+	NMStateHandlerImageDefault    = "quay.io/nmstate/kubernetes-nmstate-handler@sha256:444ab3349882ac58f594396529708146993b831c2e3e1d524eaa12e17e09f150"
 	OvsCniImageDefault            = "quay.io/kubevirt/ovs-cni-plugin@sha256:4101c52617efb54a45181548c257a08e3689f634b79b9dfcff42bffd8b25af53"
 	OvsMarkerImageDefault         = "quay.io/kubevirt/ovs-cni-marker@sha256:0f08d6b1550a90c9f10221f2bb07709d1090e7c675ee1a711981bd429074d620"
 	MacvtapCniImageDefault        = "quay.io/kubevirt/macvtap-cni@sha256:2606ac545cc69af5766d929bd82f86df5098a5e1c8ac26cfd2cdf99c46da8067"

--- a/pkg/network/nmstate.go
+++ b/pkg/network/nmstate.go
@@ -35,6 +35,7 @@ func renderNMState(conf *cnao.NetworkAddonsConfigSpec, manifestDir string, clust
 	data.Data["CARotateInterval"] = conf.SelfSignConfiguration.CARotateInterval
 	data.Data["CAOverlapInterval"] = conf.SelfSignConfiguration.CAOverlapInterval
 	data.Data["CertRotateInterval"] = conf.SelfSignConfiguration.CertRotateInterval
+	data.Data["PlacementConfiguration"] = conf.PlacementConfiguration
 
 	objs, err := render.RenderDir(filepath.Join(manifestDir, "nmstate"), &data)
 	if err != nil {

--- a/test/releases/99.0.0.go
+++ b/test/releases/99.0.0.go
@@ -36,13 +36,13 @@ func init() {
 				ParentName: "nmstate-handler",
 				ParentKind: "DaemonSet",
 				Name:       "nmstate-handler",
-				Image:      "quay.io/nmstate/kubernetes-nmstate-handler@sha256:76cc13fb4a60943dca6038619599b6a49fe451852aba23ad3046658429a9af30",
+				Image:      "quay.io/nmstate/kubernetes-nmstate-handler@sha256:444ab3349882ac58f594396529708146993b831c2e3e1d524eaa12e17e09f150",
 			},
 			{
 				ParentName: "nmstate-webhook",
 				ParentKind: "Deployment",
 				Name:       "nmstate-webhook",
-				Image:      "quay.io/nmstate/kubernetes-nmstate-handler@sha256:76cc13fb4a60943dca6038619599b6a49fe451852aba23ad3046658429a9af30",
+				Image:      "quay.io/nmstate/kubernetes-nmstate-handler@sha256:444ab3349882ac58f594396529708146993b831c2e3e1d524eaa12e17e09f150",
 			},
 			{
 				ParentName: "ovs-cni-amd64",


### PR DESCRIPTION
__Bumping__ nmstate release version v0.31.0, to include https://github.com/nmstate/kubernetes-nmstate/pull/595
that PlacementConfiguration to be easily introduced to CNAO for nmstate-webhook and nmstate-handler pods.

__Changed__ bump-knmstate to update the template variables.

Using Infra PlacementConfiguration for nmstate-webhook and
Workloads PlacementConfiguration for nmstate-handler.

By default, nmstate-webhook will be scheduled on master nodes and nmstate-handler on all cluster nodes.

Signed-off-by: Radim Hrazdil <rhrazdil@redhat.com>

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
