### PR TITLE
bump CustomResourceDefinition to v1

### DIFF
--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -7,7 +7,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
-	extv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	cnao "github.com/kubevirt/cluster-network-addons-operator/pkg/apis/networkaddonsoperator/shared"
@@ -372,63 +372,64 @@ func GetClusterRole() *rbacv1.ClusterRole {
 	return role
 }
 
-func GetCrd() *extv1beta1.CustomResourceDefinition {
-	crd := &extv1beta1.CustomResourceDefinition{
+func GetCrd() *extv1.CustomResourceDefinition {
+	subResouceSchema := &extv1.CustomResourceSubresources{Status: &extv1.CustomResourceSubresourceStatus{}}
+	validationSchema := &extv1.CustomResourceValidation{
+		OpenAPIV3Schema: &extv1.JSONSchemaProps{
+			Type: "object",
+			Properties: map[string]extv1.JSONSchemaProps{
+				"apiVersion": extv1.JSONSchemaProps{
+					Type: "string",
+				},
+				"kind": extv1.JSONSchemaProps{
+					Type: "string",
+				},
+				"metadata": extv1.JSONSchemaProps{
+					Type: "object",
+				},
+				"spec": extv1.JSONSchemaProps{
+					Type: "object",
+				},
+				"status": extv1.JSONSchemaProps{
+					Type: "object",
+				},
+			},
+		},
+	}
+
+	crd := &extv1.CustomResourceDefinition{
 		TypeMeta: metav1.TypeMeta{
-			APIVersion: "apiextensions.k8s.io/v1beta1",
+			APIVersion: "apiextensions.k8s.io/v1",
 			Kind:       "CustomResourceDefinition",
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "networkaddonsconfigs.networkaddonsoperator.network.kubevirt.io",
 		},
-		Spec: extv1beta1.CustomResourceDefinitionSpec{
+		Spec: extv1.CustomResourceDefinitionSpec{
 			Group: "networkaddonsoperator.network.kubevirt.io",
 			Scope: "Cluster",
 
-			Subresources: &extv1beta1.CustomResourceSubresources{
-				Status: &extv1beta1.CustomResourceSubresourceStatus{},
-			},
-
-			Names: extv1beta1.CustomResourceDefinitionNames{
+			Names: extv1.CustomResourceDefinitionNames{
 				Plural:   "networkaddonsconfigs",
 				Singular: "networkaddonsconfig",
 				Kind:     "NetworkAddonsConfig",
 				ListKind: "NetworkAddonsConfigList",
 			},
 
-			Versions: []extv1beta1.CustomResourceDefinitionVersion{
+			Versions: []extv1.CustomResourceDefinitionVersion{
 				{
 					Name:    "v1",
 					Served:  true,
 					Storage: true,
+					Schema:  validationSchema,
+					Subresources: subResouceSchema,
 				},
 				{
 					Name:    "v1alpha1",
 					Served:  true,
 					Storage: false,
-				},
-			},
-
-			Validation: &extv1beta1.CustomResourceValidation{
-				OpenAPIV3Schema: &extv1beta1.JSONSchemaProps{
-					Type: "object",
-					Properties: map[string]extv1beta1.JSONSchemaProps{
-						"apiVersion": extv1beta1.JSONSchemaProps{
-							Type: "string",
-						},
-						"kind": extv1beta1.JSONSchemaProps{
-							Type: "string",
-						},
-						"metadata": extv1beta1.JSONSchemaProps{
-							Type: "object",
-						},
-						"spec": extv1beta1.JSONSchemaProps{
-							Type: "object",
-						},
-						"status": extv1beta1.JSONSchemaProps{
-							Type: "object",
-						},
-					},
+					Schema:  validationSchema,
+					Subresources: subResouceSchema,
 				},
 			},
 		},

--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -376,22 +376,134 @@ func GetCrd() *extv1.CustomResourceDefinition {
 	subResouceSchema := &extv1.CustomResourceSubresources{Status: &extv1.CustomResourceSubresourceStatus{}}
 	validationSchema := &extv1.CustomResourceValidation{
 		OpenAPIV3Schema: &extv1.JSONSchemaProps{
-			Type: "object",
+			Description: "NetworkAddonsConfig is the Schema for the networkaddonsconfigs API",
+			Type:        "object",
 			Properties: map[string]extv1.JSONSchemaProps{
 				"apiVersion": extv1.JSONSchemaProps{
-					Type: "string",
+					Description: "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+					Type:        "string",
 				},
 				"kind": extv1.JSONSchemaProps{
-					Type: "string",
+					Description: "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+					Type:        "string",
 				},
 				"metadata": extv1.JSONSchemaProps{
 					Type: "object",
 				},
 				"spec": extv1.JSONSchemaProps{
 					Type: "object",
+					Properties: map[string]extv1.JSONSchemaProps{
+						"imagePullPolicy": extv1.JSONSchemaProps{
+							Description: "PullPolicy describes a policy for if/when to pull a container image",
+							Type:        "string",
+						},
+						"kubeMacPool": extv1.JSONSchemaProps{
+							Type: "object",
+							Properties: map[string]extv1.JSONSchemaProps{
+								"rangeEnd": extv1.JSONSchemaProps{
+									Type: "string",
+								},
+								"rangeStart": extv1.JSONSchemaProps{
+									Type: "string",
+								},
+							},
+						},
+						"linuxBridge": extv1.JSONSchemaProps{
+							Type: "object",
+						},
+						"macvtap": extv1.JSONSchemaProps{
+							Type: "object",
+						},
+						"multus": extv1.JSONSchemaProps{
+							Type: "object",
+						},
+						"nmstate": extv1.JSONSchemaProps{
+							Type: "object",
+						},
+						"ovs": extv1.JSONSchemaProps{
+							Type: "object",
+						},
+					},
 				},
 				"status": extv1.JSONSchemaProps{
-					Type: "object",
+					Description: "NetworkAddonsConfigStatus defines the observed state of NetworkAddonsConfig",
+					Type:        "object",
+					Properties: map[string]extv1.JSONSchemaProps{
+						"conditions": extv1.JSONSchemaProps{
+							Type: "array",
+							Items: &extv1.JSONSchemaPropsOrArray{
+								Schema: &extv1.JSONSchemaProps{
+									Type: "object",
+									Properties: map[string]extv1.JSONSchemaProps{
+										"lastHeartbeatTime": extv1.JSONSchemaProps{
+											Format: "date-time",
+											Type:   "object",
+											Nullable: true,
+										},
+										"lastTransitionTime": extv1.JSONSchemaProps{
+											Format: "date-time",
+											Type:   "object",
+											Nullable: true,
+										},
+										"message": extv1.JSONSchemaProps{
+											Type: "string",
+										},
+										"reason": extv1.JSONSchemaProps{
+											Type: "string",
+										},
+										"status": extv1.JSONSchemaProps{
+											Type: "string",
+										},
+										"type": extv1.JSONSchemaProps{
+											Description: "ConditionType is the state of the operator's reconciliation functionality.",
+											Type:        "string",
+										},
+									},
+									Required: []string{
+										"status",
+										"type",
+									},
+								},
+							},
+						},
+						"containers": extv1.JSONSchemaProps{
+							Type: "array",
+							Items: &extv1.JSONSchemaPropsOrArray{
+								Schema: &extv1.JSONSchemaProps{
+									Properties: map[string]extv1.JSONSchemaProps{
+										"image": extv1.JSONSchemaProps{
+											Type: "string",
+										},
+										"name": extv1.JSONSchemaProps{
+											Type: "string",
+										},
+										"parentKind": extv1.JSONSchemaProps{
+											Type: "string",
+										},
+										"parentName": extv1.JSONSchemaProps{
+											Type: "string",
+										},
+									},
+									Required: []string{
+										"image",
+										"name",
+										"parentKind",
+										"parentName",
+									},
+									Type: "object",
+								},
+							},
+						},
+						"observedVersion": extv1.JSONSchemaProps{
+							Type: "string",
+						},
+						"operatorVersion": extv1.JSONSchemaProps{
+							Type: "string",
+						},
+						"targetVersion": extv1.JSONSchemaProps{
+							Type: "string",
+						},
+					},
 				},
 			},
 		},
@@ -418,17 +530,17 @@ func GetCrd() *extv1.CustomResourceDefinition {
 
 			Versions: []extv1.CustomResourceDefinitionVersion{
 				{
-					Name:    "v1",
-					Served:  true,
-					Storage: true,
-					Schema:  validationSchema,
+					Name:         "v1",
+					Served:       true,
+					Storage:      true,
+					Schema:       validationSchema,
 					Subresources: subResouceSchema,
 				},
 				{
-					Name:    "v1alpha1",
-					Served:  true,
-					Storage: false,
-					Schema:  validationSchema,
+					Name:         "v1alpha1",
+					Served:       true,
+					Storage:      false,
+					Schema:       validationSchema,
 					Subresources: subResouceSchema,
 				},
 			},

--- a/tools/manifest-templator/manifest-templator.go
+++ b/tools/manifest-templator/manifest-templator.go
@@ -34,7 +34,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	components "github.com/kubevirt/cluster-network-addons-operator/pkg/components"
-	extv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 )
 
 type operatorData struct {
@@ -44,7 +44,7 @@ type operatorData struct {
 	Rules             string
 	ClusterRoleString string
 	ClusterRules      string
-	CRD               *extv1beta1.CustomResourceDefinition
+	CRD               *extv1.CustomResourceDefinition
 	CRDString         string
 	CRDVersion        string
 	CRString          string


### PR DESCRIPTION
**What this PR does / why we need it**:
this PR bumps apiextensions.k8s.io to v1.
v1beta1 will be [deprecated](https://github.com/kubernetes/kubernetes/issues/82022) in k8s v1.19, and remove by 1.22
Also, it's needed for #524 to work

- **bump CustomResourceDefinition to v1**
in order to run "kubectl explain crd"
we need to bump CustomResourceDefinition to v1.
Part of this change is to move the deprecated spec.validation and Subresources.status fields
to be per version in spec.versions[].schema

- **Add minimal crd validation schema**
In order for the crd to be validated,
we need to add the minimal schema, including
the cnao components.

**Special notes for your reviewer**:

**Release note**:
This PR  depends on #566, #570 to be merged
```release-note
bump CustomResourceDefinition to v1
```
