### PR TITLE
change kubemacpool vms to opt-in

### DIFF
--- a/data/kubemacpool/kubemacpool.yaml
+++ b/data/kubemacpool/kubemacpool.yaml
@@ -63,9 +63,9 @@ webhooks:
       - "0"
       - "1"
     - key: mutatevirtualmachines.kubemacpool.io
-      operator: NotIn
+      operator: In
       values:
-      - ignore
+      - allocate
   rules:
   - apiGroups:
     - kubevirt.io

--- a/hack/components/bump-kubemacpool.sh
+++ b/hack/components/bump-kubemacpool.sh
@@ -85,8 +85,11 @@ EOF
 
     (
         cd config/cnao
-        cp ../release/mutatepods_opt_mode_patch.yaml .
-        cp ../release/mutatevirtualmachines_opt_mode_patch.yaml .
+
+        echo setting pods to opt-in mode
+        cp ../default/mutatepods_opt_in_patch.yaml mutatepods_opt_mode_patch.yaml
+        echo setting vms to opt-in mode
+        cp ../default/mutatevirtualmachines_opt_in_patch.yaml mutatevirtualmachines_opt_mode_patch.yaml
     )
 
 )


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently we are using the default opt-mode
for vms and pods in release configuration of kubemacpool repo.
Specifically, vms was set to opt-out.

Since we didn't have the chance to test this
configuration enough, we want to return the vms to opt-in

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
