### PR TITLE
Change config for both cnao v1alpha1 and v1

### DIFF
--- a/test/e2e/lifecycle/deployment_test.go
+++ b/test/e2e/lifecycle/deployment_test.go
@@ -22,13 +22,15 @@ var _ = Context("Cluster Network Addons Operator", func() {
 		})
 
 		Context("and when NodeNetworkConfig with supported spec is created", func() {
+			releaseConfigApi := ConfigV1{}
 			BeforeEach(func() {
-				CreateConfig(masterRelease.SupportedSpec)
+				releaseConfigApi.CreateConfig(masterRelease.SupportedSpec)
 			})
 
 			It("reaches Available condition with all containers using expected images", func() {
 				CheckConfigCondition(ConditionAvailable, ConditionTrue, 15*time.Minute, CheckDoNotRepeat)
-				CheckReleaseUsesExpectedContainerImages(masterRelease)
+				status := releaseConfigApi.GetStatus()
+				CheckReleaseUsesExpectedContainerImages(masterRelease, status.Containers)
 			})
 
 			It("stays in Available condition while the operator is being removed and redeployed", func() {

--- a/test/e2e/lifecycle/main_test.go
+++ b/test/e2e/lifecycle/main_test.go
@@ -12,6 +12,7 @@ import (
 	framework "github.com/operator-framework/operator-sdk/pkg/test"
 
 	"github.com/kubevirt/cluster-network-addons-operator/pkg/apis"
+	cnaov1alpha1 "github.com/kubevirt/cluster-network-addons-operator/pkg/apis/networkaddonsoperator/v1alpha1"
 	cnaov1 "github.com/kubevirt/cluster-network-addons-operator/pkg/apis/networkaddonsoperator/v1"
 	. "github.com/kubevirt/cluster-network-addons-operator/test/check"
 	. "github.com/kubevirt/cluster-network-addons-operator/test/operations"
@@ -33,14 +34,17 @@ func TestE2E(t *testing.T) {
 
 var _ = BeforeSuite(func() {
 	By("Adding custom resource scheme to framework")
-	err := framework.AddToFrameworkScheme(apis.AddToScheme, &cnaov1.NetworkAddonsConfigList{})
-	Expect(err).ToNot(HaveOccurred())
+	err := framework.AddToFrameworkScheme(apis.AddToScheme, &cnaov1alpha1.NetworkAddonsConfigList{})
+	Expect(err).ToNot(HaveOccurred(), "Should succeed adding cnaov1alpha1.NetworkAddonsConfigList to FrameworkScheme")
+	err = framework.AddToFrameworkScheme(apis.AddToScheme, &cnaov1.NetworkAddonsConfigList{})
+	Expect(err).ToNot(HaveOccurred(), "Should succeed adding cnaov1.NetworkAddonsConfigList to FrameworkScheme")
 })
 
 var _ = AfterEach(func() {
 	By("Performing cleanup")
-	if GetConfig() != nil {
-		DeleteConfig()
+	releaseConfigApi := ConfigV1{}
+	if releaseConfigApi.GetConfig() != nil {
+		releaseConfigApi.DeleteConfig()
 	}
 	CheckComponentsRemoval(AllComponents)
 	for _, release := range Releases() {

--- a/test/e2e/workflow/containers_test.go
+++ b/test/e2e/workflow/containers_test.go
@@ -16,15 +16,14 @@ var _ = Describe("NetworkAddonsConfig", func() {
 		configSpec := cnao.NetworkAddonsConfigSpec{
 			LinuxBridge: &cnao.LinuxBridge{},
 		}
-
+		releaseConfigApi := ConfigV1{}
 		BeforeEach(func() {
-			CreateConfig(configSpec)
+			releaseConfigApi.CreateConfig(configSpec)
 			CheckConfigCondition(ConditionAvailable, ConditionTrue, 15*time.Minute, CheckDoNotRepeat)
 		})
 
 		It("should report non-empty list of deployed containers", func() {
-			config := GetConfig()
-			Expect(config.Status.Containers).NotTo(BeEmpty())
+			Expect(releaseConfigApi.GetStatus().Containers).NotTo(BeEmpty())
 		})
 	})
 })

--- a/test/e2e/workflow/main_test.go
+++ b/test/e2e/workflow/main_test.go
@@ -16,6 +16,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/kubevirt/cluster-network-addons-operator/pkg/apis"
+	cnaov1alpha1 "github.com/kubevirt/cluster-network-addons-operator/pkg/apis/networkaddonsoperator/v1alpha1"
 	cnaov1 "github.com/kubevirt/cluster-network-addons-operator/pkg/apis/networkaddonsoperator/v1"
 	"github.com/kubevirt/cluster-network-addons-operator/pkg/components"
 	. "github.com/kubevirt/cluster-network-addons-operator/test/check"
@@ -40,8 +41,10 @@ func TestE2E(t *testing.T) {
 
 var _ = BeforeSuite(func() {
 	By("Adding custom resource scheme to framework")
-	err := framework.AddToFrameworkScheme(apis.AddToScheme, &cnaov1.NetworkAddonsConfigList{})
-	Expect(err).ToNot(HaveOccurred())
+	err := framework.AddToFrameworkScheme(apis.AddToScheme, &cnaov1alpha1.NetworkAddonsConfigList{})
+	Expect(err).ToNot(HaveOccurred(), "Should succeed adding cnaov1alpha1.NetworkAddonsConfigList to FrameworkScheme")
+	err = framework.AddToFrameworkScheme(apis.AddToScheme, &cnaov1.NetworkAddonsConfigList{})
+	Expect(err).ToNot(HaveOccurred(), "Should succeed adding cnaov1.NetworkAddonsConfigList to FrameworkScheme")
 
 	By("Detecting operator version")
 	operatorVersion, err = getRunningOperatorVersion()
@@ -55,8 +58,9 @@ var _ = AfterSuite(func() {
 var _ = AfterEach(func() {
 	PrintOperatorPodStability()
 	By("Performing cleanup")
-	if GetConfig() != nil {
-		DeleteConfig()
+	releaseConfigApi := ConfigV1{}
+	if releaseConfigApi.GetConfig() != nil {
+		releaseConfigApi.DeleteConfig()
 	}
 	CheckComponentsRemoval(AllComponents)
 })

--- a/test/e2e/workflow/recovery_test.go
+++ b/test/e2e/workflow/recovery_test.go
@@ -13,13 +13,14 @@ import (
 //2297
 var _ = Describe("NetworkAddonsConfig", func() {
 	Context("when invalid config is applied", func() {
+		releaseConfigApi := ConfigV1{}
 		BeforeEach(func() {
 			configSpec := cnao.NetworkAddonsConfigSpec{
 				KubeMacPool: &cnao.KubeMacPool{
 					RangeStart: "this:aint:right",
 				},
 			}
-			CreateConfig(configSpec)
+			releaseConfigApi.CreateConfig(configSpec)
 			CheckConfigCondition(ConditionDegraded, ConditionTrue, 5*time.Second, CheckDoNotRepeat)
 			CheckFailedEvent("FailedToValidate")
 		})
@@ -27,7 +28,7 @@ var _ = Describe("NetworkAddonsConfig", func() {
 		Context("and it is updated with a valid config", func() {
 			BeforeEach(func() {
 				configSpec := cnao.NetworkAddonsConfigSpec{}
-				UpdateConfig(configSpec)
+				releaseConfigApi.UpdateConfig(configSpec)
 			})
 
 			It("should turn from Failing to Available", func() {

--- a/test/e2e/workflow/validation_test.go
+++ b/test/e2e/workflow/validation_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 var _ = Describe("NetworkAddonsConfig", func() {
+	releaseConfigApi := ConfigV1{}
 	Context("when there is no running config", func() {
 		Context("and an invalid config is created", func() {
 			BeforeEach(func() {
@@ -26,7 +27,7 @@ var _ = Describe("NetworkAddonsConfig", func() {
 					NMState:     &cnao.NMState{},
 					MacvtapCni:  &cnao.MacvtapCni{},
 				}
-				CreateConfig(configSpec)
+				releaseConfigApi.CreateConfig(configSpec)
 			})
 
 			It("should report Failing condition and Available must be set to False", func() {
@@ -42,7 +43,7 @@ var _ = Describe("NetworkAddonsConfig", func() {
 				LinuxBridge: &cnao.LinuxBridge{},
 				NMState:     &cnao.NMState{},
 			}
-			CreateConfig(configSpec)
+			releaseConfigApi.CreateConfig(configSpec)
 			CheckConfigCondition(ConditionAvailable, ConditionTrue, 2*time.Minute, CheckDoNotRepeat)
 		})
 
@@ -51,7 +52,7 @@ var _ = Describe("NetworkAddonsConfig", func() {
 				configSpec := cnao.NetworkAddonsConfigSpec{
 					LinuxBridge: &cnao.LinuxBridge{},
 				}
-				UpdateConfig(configSpec)
+				releaseConfigApi.UpdateConfig(configSpec)
 			})
 
 			It("should remain at Available condition", func() {

--- a/test/e2e/workflow/version_test.go
+++ b/test/e2e/workflow/version_test.go
@@ -11,12 +11,13 @@ import (
 )
 
 var _ = Describe("NetworkAddonsConfig", func() {
+	releaseConfigApi := ConfigV1{}
 	Context("when a config is created", func() {
 		BeforeEach(func() {
 			configSpec := cnao.NetworkAddonsConfigSpec{
 				LinuxBridge: &cnao.LinuxBridge{},
 			}
-			CreateConfig(configSpec)
+			releaseConfigApi.CreateConfig(configSpec)
 		})
 
 		It("should set targetVersion and operatorVersion immediately after it turns Progressing", func() {
@@ -35,7 +36,7 @@ var _ = Describe("NetworkAddonsConfig", func() {
 			configSpec := cnao.NetworkAddonsConfigSpec{
 				Multus: &cnao.Multus{},
 			}
-			CreateConfig(configSpec)
+			releaseConfigApi.CreateConfig(configSpec)
 			CheckConfigCondition(ConditionAvailable, ConditionTrue, 15*time.Minute, CheckDoNotRepeat)
 		})
 
@@ -53,7 +54,7 @@ var _ = Describe("NetworkAddonsConfig", func() {
 				// Give validator some time to verify original state
 				time.Sleep(3 * time.Second)
 
-				UpdateConfig(configSpec)
+				releaseConfigApi.UpdateConfig(configSpec)
 				CheckConfigCondition(ConditionAvailable, ConditionTrue, 15*time.Minute, CheckDoNotRepeat)
 
 				// Give validator some time to verify versions while we stay in updated config

--- a/test/operations/operations.go
+++ b/test/operations/operations.go
@@ -1,81 +1,19 @@
 package operations
 
 import (
-	"context"
-	"fmt"
 	"strings"
-	"time"
 
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
-	framework "github.com/operator-framework/operator-sdk/pkg/test"
 	"gopkg.in/yaml.v2"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 
 	cnao "github.com/kubevirt/cluster-network-addons-operator/pkg/apis/networkaddonsoperator/shared"
-	cnaov1 "github.com/kubevirt/cluster-network-addons-operator/pkg/apis/networkaddonsoperator/v1"
-	"github.com/kubevirt/cluster-network-addons-operator/pkg/names"
 )
 
-func GetConfig() *cnaov1.NetworkAddonsConfig {
-	By("Getting the current config")
-
-	config := &cnaov1.NetworkAddonsConfig{}
-
-	err := framework.Global.Client.Get(context.TODO(), types.NamespacedName{Name: names.OPERATOR_CONFIG}, config)
-	if apierrors.IsNotFound(err) {
-		return nil
-	}
-	Expect(err).NotTo(HaveOccurred(), "Failed to fetch Config")
-
-	return config
-}
-
-func CreateConfig(configSpec cnao.NetworkAddonsConfigSpec) {
-	By(fmt.Sprintf("Applying NetworkAddonsConfig:\n%s", configSpecToYaml(configSpec)))
-
-	config := &cnaov1.NetworkAddonsConfig{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: names.OPERATOR_CONFIG,
-		},
-		Spec: configSpec,
-	}
-
-	err := framework.Global.Client.Create(context.TODO(), config, &framework.CleanupOptions{})
-	Expect(err).NotTo(HaveOccurred(), "Failed to create the Config")
-}
-
-func UpdateConfig(configSpec cnao.NetworkAddonsConfigSpec) {
-	By(fmt.Sprintf("Updating NetworkAddonsConfig:\n%s", configSpecToYaml(configSpec)))
-
-	// Get current Config
-	config := GetConfig()
-
-	// Update the Config with the desired Spec
-	config.Spec = configSpec
-	err := framework.Global.Client.Update(context.TODO(), config)
-	Expect(err).NotTo(HaveOccurred(), "Failed to update the Config")
-}
-
-func DeleteConfig() {
-	By("Removing NetworkAddonsConfig")
-
-	config := &cnaov1.NetworkAddonsConfig{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: names.OPERATOR_CONFIG,
-		},
-	}
-
-	err := framework.Global.Client.Delete(context.TODO(), config)
-	ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to remove the Config")
-
-	// Wait until the config is deleted
-	EventuallyWithOffset(1, func() error {
-		return framework.Global.Client.Get(context.TODO(), types.NamespacedName{Name: names.OPERATOR_CONFIG}, &cnaov1.NetworkAddonsConfig{})
-	}, 60*time.Second, 1*time.Second).Should(SatisfyAll(HaveOccurred(), WithTransform(apierrors.IsNotFound, BeTrue())), fmt.Sprintf("should successfuly delete config '%s'", config.Name))
-
+type ConfigInterface interface {
+	GetConfig() map[string]interface{}
+	CreateConfig(configSpec cnao.NetworkAddonsConfigSpec)
+	UpdateConfig(configSpec cnao.NetworkAddonsConfigSpec)
+	DeleteConfig()
+	GetStatus() cnao.NetworkAddonsConfigStatus
 }
 
 // Convert NetworkAddonsConfig specification to a yaml format we would expect in a manifest

--- a/test/operations/operationsV1.go
+++ b/test/operations/operationsV1.go
@@ -1,0 +1,96 @@
+package operations
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"k8s.io/apimachinery/pkg/runtime"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	framework "github.com/operator-framework/operator-sdk/pkg/test"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	cnao "github.com/kubevirt/cluster-network-addons-operator/pkg/apis/networkaddonsoperator/shared"
+	cnaov1 "github.com/kubevirt/cluster-network-addons-operator/pkg/apis/networkaddonsoperator/v1"
+	"github.com/kubevirt/cluster-network-addons-operator/pkg/names"
+)
+
+type ConfigV1 struct {}
+
+func (c *ConfigV1) GetConfig() map[string]interface{} {
+	By("Getting the current config")
+	configV1 := &cnaov1.NetworkAddonsConfig{}
+	err := framework.Global.Client.Get(context.TODO(), types.NamespacedName{Name: names.OPERATOR_CONFIG}, configV1)
+	if apierrors.IsNotFound(err) {
+		return nil
+	}
+	Expect(err).NotTo(HaveOccurred(), "Failed to fetch Config")
+
+	unstructuredConfig, err := runtime.DefaultUnstructuredConverter.ToUnstructured(configV1)
+	Expect(err).NotTo(HaveOccurred(), "Failed to convert config to unstructured")
+
+	return unstructuredConfig
+}
+
+func (c *ConfigV1) CreateConfig(configSpec cnao.NetworkAddonsConfigSpec) {
+	By(fmt.Sprintf("Applying NetworkAddonsConfig:\n%s", configSpecToYaml(configSpec)))
+
+	config := &cnaov1.NetworkAddonsConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: names.OPERATOR_CONFIG,
+		},
+		Spec: configSpec,
+	}
+
+	err := framework.Global.Client.Create(context.TODO(), config, &framework.CleanupOptions{})
+	Expect(err).NotTo(HaveOccurred(), "Failed to create the Config")
+}
+
+func (c *ConfigV1) UpdateConfig(configSpec cnao.NetworkAddonsConfigSpec) {
+	By(fmt.Sprintf("Updating NetworkAddonsConfig:\n%s", configSpecToYaml(configSpec)))
+
+	// Get current Config
+	unstructuredConfig := c.GetConfig()
+	configV1 := &cnaov1.NetworkAddonsConfig{}
+	err := runtime.DefaultUnstructuredConverter.FromUnstructured(unstructuredConfig, configV1)
+	Expect(err).NotTo(HaveOccurred(), "Failed to convert unstructured config to cnaov1 Config")
+
+	// Update the Config with the desired Spec
+	configV1.Spec = configSpec
+	err = framework.Global.Client.Update(context.TODO(), configV1)
+	Expect(err).NotTo(HaveOccurred(), "Failed to update the Config")
+}
+
+func (c *ConfigV1) DeleteConfig() {
+	By("Removing NetworkAddonsConfig")
+
+	config := &cnaov1.NetworkAddonsConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: names.OPERATOR_CONFIG,
+		},
+	}
+
+	err := framework.Global.Client.Delete(context.TODO(), config)
+	ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to remove the Config")
+
+	// Wait until the config is deleted
+	EventuallyWithOffset(1, func() error {
+		return framework.Global.Client.Get(context.TODO(), types.NamespacedName{Name: names.OPERATOR_CONFIG}, &cnaov1.NetworkAddonsConfig{})
+	}, 60*time.Second, 1*time.Second).Should(SatisfyAll(HaveOccurred(), WithTransform(apierrors.IsNotFound, BeTrue())), fmt.Sprintf("should successfuly delete config '%s'", config.Name))
+
+}
+
+func (c *ConfigV1) GetStatus() cnao.NetworkAddonsConfigStatus {
+	// Get current Config
+	unstructuredConfig := c.GetConfig()
+	configV1 := &cnaov1.NetworkAddonsConfig{}
+	err := runtime.DefaultUnstructuredConverter.FromUnstructured(unstructuredConfig, configV1)
+	Expect(err).NotTo(HaveOccurred(), "Failed to convert unstructured config to cnaov1 Config")
+
+	return configV1.Status
+}

--- a/test/operations/operationsV1Alpha1.go
+++ b/test/operations/operationsV1Alpha1.go
@@ -1,0 +1,95 @@
+package operations
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	framework "github.com/operator-framework/operator-sdk/pkg/test"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+
+	cnao "github.com/kubevirt/cluster-network-addons-operator/pkg/apis/networkaddonsoperator/shared"
+	cnaov1alpha1 "github.com/kubevirt/cluster-network-addons-operator/pkg/apis/networkaddonsoperator/v1alpha1"
+	"github.com/kubevirt/cluster-network-addons-operator/pkg/names"
+)
+
+type ConfigV1alpha1 struct {}
+
+func (c *ConfigV1alpha1) GetConfig() map[string]interface{} {
+	By("Getting the current config")
+	configV1alpha1 := &cnaov1alpha1.NetworkAddonsConfig{}
+	err := framework.Global.Client.Get(context.TODO(), types.NamespacedName{Name: names.OPERATOR_CONFIG}, configV1alpha1)
+	if apierrors.IsNotFound(err) {
+		return nil
+	}
+	Expect(err).NotTo(HaveOccurred(), "Failed to fetch Config")
+
+	unstructuredConfig, err := runtime.DefaultUnstructuredConverter.ToUnstructured(configV1alpha1)
+	Expect(err).NotTo(HaveOccurred(), "Failed to convert config to unstructured")
+
+	return unstructuredConfig
+}
+
+func (c *ConfigV1alpha1) CreateConfig(configSpec cnao.NetworkAddonsConfigSpec) {
+	By(fmt.Sprintf("Applying NetworkAddonsConfig:\n%s", configSpecToYaml(configSpec)))
+
+	config := &cnaov1alpha1.NetworkAddonsConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: names.OPERATOR_CONFIG,
+		},
+		Spec: configSpec,
+	}
+
+	err := framework.Global.Client.Create(context.TODO(), config, &framework.CleanupOptions{})
+	Expect(err).NotTo(HaveOccurred(), "Failed to create the Config")
+}
+
+func (c *ConfigV1alpha1) UpdateConfig(configSpec cnao.NetworkAddonsConfigSpec) {
+	By(fmt.Sprintf("Updating NetworkAddonsConfig:\n%s", configSpecToYaml(configSpec)))
+
+	// Get current Config
+	unstructuredConfig := c.GetConfig()
+	configV1alpha1 := &cnaov1alpha1.NetworkAddonsConfig{}
+	err := runtime.DefaultUnstructuredConverter.FromUnstructured(unstructuredConfig, configV1alpha1)
+	Expect(err).NotTo(HaveOccurred(), "Failed to convert unstructured config to cnaov1alpha1 Config")
+
+	// Update the Config with the desired Spec
+	configV1alpha1.Spec = configSpec
+	err = framework.Global.Client.Update(context.TODO(), configV1alpha1)
+	Expect(err).NotTo(HaveOccurred(), "Failed to update the Config")
+}
+
+func (c *ConfigV1alpha1) DeleteConfig() {
+	By("Removing NetworkAddonsConfig")
+
+	config := &cnaov1alpha1.NetworkAddonsConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: names.OPERATOR_CONFIG,
+		},
+	}
+
+	err := framework.Global.Client.Delete(context.TODO(), config)
+	ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to remove the Config")
+
+	// Wait until the config is deleted
+	EventuallyWithOffset(1, func() error {
+		return framework.Global.Client.Get(context.TODO(), types.NamespacedName{Name: names.OPERATOR_CONFIG}, &cnaov1alpha1.NetworkAddonsConfig{})
+	}, 60*time.Second, 1*time.Second).Should(SatisfyAll(HaveOccurred(), WithTransform(apierrors.IsNotFound, BeTrue())), fmt.Sprintf("should successfuly delete config '%s'", config.Name))
+
+}
+
+func (c *ConfigV1alpha1) GetStatus() cnao.NetworkAddonsConfigStatus {
+	// Get current Config
+	unstructuredConfig := c.GetConfig()
+	configV1alpha1 := &cnaov1alpha1.NetworkAddonsConfig{}
+	err := runtime.DefaultUnstructuredConverter.FromUnstructured(unstructuredConfig, configV1alpha1)
+	Expect(err).NotTo(HaveOccurred(), "Failed to convert unstructured config to cnaov1alpha1 Config")
+
+	return configV1alpha1.Status
+}

--- a/test/releases/releases.go
+++ b/test/releases/releases.go
@@ -14,7 +14,6 @@ import (
 	cnao "github.com/kubevirt/cluster-network-addons-operator/pkg/apis/networkaddonsoperator/shared"
 	. "github.com/kubevirt/cluster-network-addons-operator/test/kubectl"
 	. "github.com/kubevirt/cluster-network-addons-operator/test/okd"
-	. "github.com/kubevirt/cluster-network-addons-operator/test/operations"
 )
 
 type Release struct {
@@ -112,7 +111,7 @@ func UninstallRelease(release Release) {
 
 // Make sure that container images currently used (reported in NetworkAddonsConfig)
 // are matching images expected for given release
-func CheckReleaseUsesExpectedContainerImages(release Release) {
+func CheckReleaseUsesExpectedContainerImages(release Release, containers []cnao.Container) {
 	By(fmt.Sprintf("Checking that all deployed images match release %s", release.Version))
 
 	expectedContainers := sortContainers(release.Containers)
@@ -121,9 +120,7 @@ func CheckReleaseUsesExpectedContainerImages(release Release) {
 		expectedContainers = dropMultusContainers(expectedContainers)
 	}
 
-	config := GetConfig()
-	deployedContainers := sortContainers(config.Status.Containers)
-
+	deployedContainers := sortContainers(containers)
 	Expect(deployedContainers).To(Equal(expectedContainers))
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR is changes config operations to support both v1, v1alpha1 NetworkAddonsConfig

- **duplicate config api for v1alpha1 and v1**
Currently, functions that create/update/remove NetworkAddonsConfig type
only use the currently stored NetworkAddonsConfig version:v1
This is not an issue during upgrade tests since we're not upgrading
the crd itself, so we always support v1.
Let's support both APIs by introducing version based config interface.

- **update e2e tests to use new config interface**
this commit introduces the change in config API to
all the relevant e2e tests.

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
