### PR TITLE
events, event-emitter: change emitter to emit only for config

### DIFF
--- a/pkg/eventemitter/eventemitter.go
+++ b/pkg/eventemitter/eventemitter.go
@@ -6,7 +6,6 @@ import (
 	"log"
 
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -32,7 +31,7 @@ const (
 
 type EventEmitter interface {
 	Init(mgr manager.Manager)
-	EmitEvent(object runtime.Object, eventType, reason, msg string)
+	EmitEventForConfig(config *cnaov1.NetworkAddonsConfig, eventType, reason, msg string)
 	EmitModifiedForConfig()
 	EmitProgressingForConfig()
 	EmitFailingForConfig(reason, message string)
@@ -58,30 +57,30 @@ func (ee *eventEmitter) Init(mgr manager.Manager) {
 	ee.recorder = mgr.GetEventRecorderFor(names.OPERATOR_CONFIG)
 }
 
-func (ee eventEmitter) EmitEvent(object runtime.Object, eventType, reason, msg string) {
-	if object != nil {
-		ee.recorder.Event(object, eventType, reason, msg)
+func (ee eventEmitter) EmitEventForConfig(config *cnaov1.NetworkAddonsConfig, eventType, reason, msg string) {
+	if config != nil {
+		ee.recorder.Event(config, eventType, reason, msg)
 	}
 }
 
 func (ee eventEmitter) EmitProgressingForConfig() {
 	config := ee.getConfigForEmitter()
-	ee.EmitEvent(config, corev1.EventTypeNormal, ProgressingReason, ProgressingMessage)
+	ee.EmitEventForConfig(config, corev1.EventTypeNormal, ProgressingReason, ProgressingMessage)
 }
 
 func (ee eventEmitter) EmitFailingForConfig(reason, message string) {
 	config := ee.getConfigForEmitter()
-	ee.EmitEvent(config, corev1.EventTypeWarning, fmt.Sprintf("%s: %s", FailedReason, reason), fmt.Sprintf("%s: %s", FailedMessage, message))
+	ee.EmitEventForConfig(config, corev1.EventTypeWarning, fmt.Sprintf("%s: %s", FailedReason, reason), fmt.Sprintf("%s: %s", FailedMessage, message))
 }
 
 func (ee eventEmitter) EmitAvailableForConfig() {
 	config := ee.getConfigForEmitter()
-	ee.EmitEvent(config, corev1.EventTypeNormal, AvailableReason, AvailableMessage)
+	ee.EmitEventForConfig(config, corev1.EventTypeNormal, AvailableReason, AvailableMessage)
 }
 
 func (ee eventEmitter) EmitModifiedForConfig() {
 	config := ee.getConfigForEmitter()
-	ee.EmitEvent(config, corev1.EventTypeNormal, ModifiedReason, ModifiedMessage)
+	ee.EmitEventForConfig(config, corev1.EventTypeNormal, ModifiedReason, ModifiedMessage)
 }
 
 func (ee eventEmitter) getConfigForEmitter() *cnaov1.NetworkAddonsConfig {


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the master branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it

If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**What this PR does / why we need it**:
- Right now events are only emitted for the networkaddonsConfig, and
  asserting nil on a runtime.Object could be dangerous, so there
  is no point of taking a runtime.Object as an argument to emitEvent.

  This commit changes the EmitEvent method to take networkAddonsConfig
  as an argument, and emits events only for it. the name of the method
  was changed accordingly

Signed-off-by: alonSadan <asadan@redhat.com>

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
