### PR TITLE
Fix missing prefix 'v' for versions v0.41.0 and v0.42.0

### DIFF
--- a/hack/prepare-release.sh
+++ b/hack/prepare-release.sh
@@ -5,15 +5,17 @@ set -ex
 version_type=$1
 previous_version=$(hack/version.sh)
 released_version=$(hack/bump-version.sh $version_type)
-commits=$(git log --pretty=format:"* %s" $previous_version..HEAD)
+prefixed_previous_version="v${previous_version}"
+prefixed_released_version="v${released_version}"
+commits=$(git log --pretty=format:"* %s" $prefixed_previous_version..HEAD)
 
 echo 'Build manifests for the new release'
-VERSION=${released_version} IMAGE_TAG=${released_version} make gen-manifests
+VERSION=${released_version} IMAGE_TAG=${prefixed_released_version} make gen-manifests
 git add manifests/cluster-network-addons/${released_version}
 
 echo 'Upgrade README.md with the released manifests'
-sed -i "s/\(.*kubectl apply.*\)${previous_version}\(.*\)/\1${released_version}\2/g" README.md
-sed -i "s/\(.*startingCSV.*\)${previous_version}\(.*\)/\1${released_version}\2/g" README.md
+sed -i "s/\(.*kubectl apply.*\)${prefixed_previous_version}\(.*\)/\1${prefixed_released_version}\2/g" README.md
+sed -i "s/\(.*startingCSV.*\)${prefixed_previous_version}\(.*\)/\1${prefixed_released_version}\2/g" README.md
 
 echo 'Generating new release for workflow e2e tests'
 cp test/releases/99.0.0.go test/releases/${released_version}.go

--- a/manifests/cluster-network-addons/0.41.0/cluster-network-addons-operator.0.41.0.clusterserviceversion.yaml
+++ b/manifests/cluster-network-addons/0.41.0/cluster-network-addons-operator.0.41.0.clusterserviceversion.yaml
@@ -175,7 +175,7 @@ spec:
                   - name: MACVTAP_CNI_IMAGE
                     value: quay.io/kubevirt/macvtap-cni:v0.2.0
                   - name: OPERATOR_IMAGE
-                    value: quay.io/kubevirt/cluster-network-addons-operator:0.41.0
+                    value: quay.io/kubevirt/cluster-network-addons-operator:v0.41.0
                   - name: OPERATOR_NAME
                     value: cluster-network-addons-operator
                   - name: OPERATOR_VERSION
@@ -193,7 +193,7 @@ spec:
                       fieldRef:
                         fieldPath: metadata.name
                   - name: WATCH_NAMESPACE
-                  image: quay.io/kubevirt/cluster-network-addons-operator:0.41.0
+                  image: quay.io/kubevirt/cluster-network-addons-operator:v0.41.0
                   imagePullPolicy: Always
                   name: cluster-network-addons-operator
                   resources: {}

--- a/manifests/cluster-network-addons/0.42.0/cluster-network-addons-operator.0.42.0.clusterserviceversion.yaml
+++ b/manifests/cluster-network-addons/0.42.0/cluster-network-addons-operator.0.42.0.clusterserviceversion.yaml
@@ -175,7 +175,7 @@ spec:
                   - name: MACVTAP_CNI_IMAGE
                     value: quay.io/kubevirt/macvtap-cni@sha256:407f75760fc096666becfa45d94f51757ebbe8f382e9e7b57ceeded0b8cfb6b8
                   - name: OPERATOR_IMAGE
-                    value: quay.io/kubevirt/cluster-network-addons-operator:0.42.0
+                    value: quay.io/kubevirt/cluster-network-addons-operator:v0.42.0
                   - name: OPERATOR_NAME
                     value: cluster-network-addons-operator
                   - name: OPERATOR_VERSION
@@ -193,7 +193,7 @@ spec:
                       fieldRef:
                         fieldPath: metadata.name
                   - name: WATCH_NAMESPACE
-                  image: quay.io/kubevirt/cluster-network-addons-operator:0.42.0
+                  image: quay.io/kubevirt/cluster-network-addons-operator:v0.42.0
                   imagePullPolicy: Always
                   name: cluster-network-addons-operator
                   resources: {}
@@ -218,7 +218,7 @@ spec:
       name: "ovs-cni-marker"
     - image: "quay.io/kubevirt/macvtap-cni@sha256:407f75760fc096666becfa45d94f51757ebbe8f382e9e7b57ceeded0b8cfb6b8"
       name: "macvtap-cni"
-    - image: "quay.io/kubevirt/cluster-network-addons-operator:0.42.0"
+    - image: "quay.io/kubevirt/cluster-network-addons-operator:v0.42.0"
       name: "cluster-network-addons-operator"
   customresourcedefinitions:
     owned:


### PR DESCRIPTION
1. commit __Fixed__ missing `v` prefix in released manifest container tags in versions v0.41.0 and v0.42.0.

2. commit __Updated__ `prepare-release.sh` to generated manifests with the prefixed CONTAINER_TAG value.

From version v0.41.0 forward, we are using v-prefixed versions in **git tags** and **CONTAINER_TAG**s

Signed-off-by: Radim Hrazdil <rhrazdil@redhat.com>

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**Release note**:

```release-note
Adds missing version prefix 'v' to manifests in released versions v0.41.0 and v0.42.0
```
