### PR TITLE
Check cnao pod restarts in CI tests

### DIFF
--- a/test/e2e/workflow/main_test.go
+++ b/test/e2e/workflow/main_test.go
@@ -2,6 +2,7 @@ package test
 
 import (
 	"context"
+	"time"
 	"testing"
 
 	. "github.com/onsi/ginkgo"
@@ -47,7 +48,12 @@ var _ = BeforeSuite(func() {
 	Expect(err).ToNot(HaveOccurred())
 })
 
+var _ = AfterSuite(func() {
+	CheckOperatorPodStability(time.Minute)
+})
+
 var _ = AfterEach(func() {
+	PrintOperatorPodStability()
 	By("Performing cleanup")
 	if GetConfig() != nil {
 		DeleteConfig()


### PR DESCRIPTION
**What this PR does / why we need it**:
add check if CNAO pod performs unexpected restart during the CI tests.

- **add check that cnao pod has not restarted**
Currently there is no chck in the tests that
the CNAO pod has gone through a restart.
Let add a check to catch those restarts as soon as they occur.

- **add cnao pod stability check ci tests**
We want to make sure that CNAO pod does not perform
unwanted restart.
To do that we add a consistency check at the end of workflow
test suite to make sure no restart have been made
during the tests.
Also , after each test we want to add a print to signal
where the pod started restarting

- **TEMP COMMIT temporarily induce the cnao pod to restart.**
the Exit was added in order to be induced in test It("should remain at Available condition")

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
