### PR TITLE
Fix release v0.42.0 operator manifest

### DIFF
--- a/manifests/cluster-network-addons/0.42.0/operator.yaml
+++ b/manifests/cluster-network-addons/0.42.0/operator.yaml
@@ -155,7 +155,7 @@ spec:
         - name: MACVTAP_CNI_IMAGE
           value: quay.io/kubevirt/macvtap-cni@sha256:407f75760fc096666becfa45d94f51757ebbe8f382e9e7b57ceeded0b8cfb6b8
         - name: OPERATOR_IMAGE
-          value: quay.io/kubevirt/cluster-network-addons-operator:0.42.0
+          value: quay.io/kubevirt/cluster-network-addons-operator:v0.42.0
         - name: OPERATOR_NAME
           value: cluster-network-addons-operator
         - name: OPERATOR_VERSION
@@ -173,7 +173,7 @@ spec:
             fieldRef:
               fieldPath: metadata.name
         - name: WATCH_NAMESPACE
-        image: quay.io/kubevirt/cluster-network-addons-operator:0.42.0
+        image: quay.io/kubevirt/cluster-network-addons-operator:v0.42.0
         imagePullPolicy: Always
         name: cluster-network-addons-operator
         resources: {}


### PR DESCRIPTION
Since releases started to have "v" prefix, the opeator.yaml of v0.42.0 missed it
in the image fields.

See https://github.com/kubevirt/cluster-network-addons-operator/issues/554

Signed-off-by: Or Shoval <oshoval@redhat.com>

<!-- Thanks for sending a pull request!

Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the master branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it

If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
None
```
