### PR TITLE
Fix release 0.41.0 manifest

### DIFF
--- a/manifests/cluster-network-addons/0.41.0/cluster-network-addons-operator.0.41.0.clusterserviceversion.yaml
+++ b/manifests/cluster-network-addons/0.41.0/cluster-network-addons-operator.0.41.0.clusterserviceversion.yaml
@@ -175,7 +175,7 @@ spec:
                   - name: MACVTAP_CNI_IMAGE
                     value: quay.io/kubevirt/macvtap-cni:v0.2.0
                   - name: OPERATOR_IMAGE
-                    value: quay.io/kubevirt/cluster-network-addons-operator:v0.41.0
+                    value: quay.io/kubevirt/cluster-network-addons-operator:0.41.0
                   - name: OPERATOR_NAME
                     value: cluster-network-addons-operator
                   - name: OPERATOR_VERSION
@@ -193,7 +193,7 @@ spec:
                       fieldRef:
                         fieldPath: metadata.name
                   - name: WATCH_NAMESPACE
-                  image: quay.io/kubevirt/cluster-network-addons-operator:v0.41.0
+                  image: quay.io/kubevirt/cluster-network-addons-operator:0.41.0
                   imagePullPolicy: Always
                   name: cluster-network-addons-operator
                   resources: {}


### PR DESCRIPTION
The releases started have v prefix just on 0.42.0
hence the v on the images isnt right.
Quay have by mistake both with and without v,
but the one without v should be used for 0.41.0

Signed-off-by: Or Shoval <oshoval@redhat.com>

<!-- Thanks for sending a pull request!

Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the master branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it

If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
None
```
