### PR TITLE
bump kubemacpool to v0.20.1

### DIFF
--- a/components.yaml
+++ b/components.yaml
@@ -19,10 +19,10 @@ components:
     metadata: "0.3.0"
   kubemacpool:
     url: "https://github.com/k8snetworkplumbingwg/kubemacpool"
-    commit: "7600ea1e8a945a5665071bdc7e6d8619adb65195"
+    commit: "71b8cb049611ee44675f1df7443b95cc1e77e970"
     branch: "master"
     update-policy: "tagged"
-    metadata: "v0.20.0"
+    metadata: "v0.20.1"
   nmstate:
     url: "https://github.com/nmstate/kubernetes-nmstate"
     commit: "a0d3d5658390fac730bafcc85506a0a681da98ac"

--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -28,7 +28,7 @@ const (
 	MultusImageDefault            = "nfvpe/multus@sha256:167722b954355361bd69829466f27172b871dbdbf86b85a95816362885dc0aba"
 	LinuxBridgeCniImageDefault    = "quay.io/kubevirt/cni-default-plugins@sha256:3dd438117076016d6d2acd508b93f106ca80a28c0af6e2e914d812f9a1d55142"
 	LinuxBridgeMarkerImageDefault = "quay.io/kubevirt/bridge-marker@sha256:e55f73526468fee46a35ae41aa860f492d208b8a7a132832c5b9a76d4a51566a"
-	KubeMacPoolImageDefault       = "quay.io/kubevirt/kubemacpool@sha256:ad8ca6d379d495804969ba4d03da9a6936ff8f413f6f6c7bd20e0138dc0303c4"
+	KubeMacPoolImageDefault       = "quay.io/kubevirt/kubemacpool@sha256:e5f7120a9435c4884b61dead334c03ebbf2cb1a7d00d65615d3ae625f7caf9ce"
 	NMStateHandlerImageDefault    = "quay.io/nmstate/kubernetes-nmstate-handler@sha256:444ab3349882ac58f594396529708146993b831c2e3e1d524eaa12e17e09f150"
 	OvsCniImageDefault            = "quay.io/kubevirt/ovs-cni-plugin@sha256:b4a2a9bcbde3f8b5f24e0ae957fedca57201c91bc9645459a49f0b954057b22b"
 	OvsMarkerImageDefault         = "quay.io/kubevirt/ovs-cni-marker@sha256:1e0a8c6ba54db8e0a4c6ed926bed25e3a272a4db883805a1af020beba131f999"

--- a/test/releases/99.0.0.go
+++ b/test/releases/99.0.0.go
@@ -30,7 +30,7 @@ func init() {
 				ParentName: "kubemacpool-mac-controller-manager",
 				ParentKind: "Deployment",
 				Name:       "manager",
-				Image:      "quay.io/kubevirt/kubemacpool@sha256:ad8ca6d379d495804969ba4d03da9a6936ff8f413f6f6c7bd20e0138dc0303c4",
+				Image:      "quay.io/kubevirt/kubemacpool@sha256:e5f7120a9435c4884b61dead334c03ebbf2cb1a7d00d65615d3ae625f7caf9ce",
 			},
 			{
 				ParentName: "nmstate-handler",


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR bumps kubemacpool to v0.20.1

**Special notes for your reviewer**:

**Release note**:


```release-note
bump kubemacpool to v0.20.1
```
