### PR TITLE
Change config to use unstructured

### DIFF
--- a/test/e2e/lifecycle/deployment_test.go
+++ b/test/e2e/lifecycle/deployment_test.go
@@ -22,13 +22,14 @@ var _ = Context("Cluster Network Addons Operator", func() {
 		})
 
 		Context("and when NodeNetworkConfig with supported spec is created", func() {
+			gvk := GetCnaoV1GroupVersionKind()
 			BeforeEach(func() {
-				CreateConfig(masterRelease.SupportedSpec)
+				CreateConfig(gvk, masterRelease.SupportedSpec)
 			})
 
 			It("reaches Available condition with all containers using expected images", func() {
 				CheckConfigCondition(ConditionAvailable, ConditionTrue, 15*time.Minute, CheckDoNotRepeat)
-				CheckReleaseUsesExpectedContainerImages(masterRelease)
+				CheckReleaseUsesExpectedContainerImages(gvk, masterRelease)
 			})
 
 			It("stays in Available condition while the operator is being removed and redeployed", func() {

--- a/test/e2e/lifecycle/main_test.go
+++ b/test/e2e/lifecycle/main_test.go
@@ -39,8 +39,9 @@ var _ = BeforeSuite(func() {
 
 var _ = AfterEach(func() {
 	By("Performing cleanup")
-	if GetConfig() != nil {
-		DeleteConfig()
+	gvk := GetCnaoV1GroupVersionKind()
+	if GetConfig(gvk) != nil {
+		DeleteConfig(gvk)
 	}
 	CheckComponentsRemoval(AllComponents)
 	for _, release := range Releases() {

--- a/test/e2e/workflow/containers_test.go
+++ b/test/e2e/workflow/containers_test.go
@@ -16,15 +16,16 @@ var _ = Describe("NetworkAddonsConfig", func() {
 		configSpec := cnao.NetworkAddonsConfigSpec{
 			LinuxBridge: &cnao.LinuxBridge{},
 		}
-
+		gvk := GetCnaoV1GroupVersionKind()
 		BeforeEach(func() {
-			CreateConfig(configSpec)
+			CreateConfig(gvk, configSpec)
 			CheckConfigCondition(ConditionAvailable, ConditionTrue, 15*time.Minute, CheckDoNotRepeat)
 		})
 
 		It("should report non-empty list of deployed containers", func() {
-			config := GetConfig()
-			Expect(config.Status.Containers).NotTo(BeEmpty())
+			configStatus := GetConfigStatus(gvk)
+
+			Expect(configStatus.Containers).NotTo(BeEmpty())
 		})
 	})
 })

--- a/test/e2e/workflow/main_test.go
+++ b/test/e2e/workflow/main_test.go
@@ -2,8 +2,8 @@ package test
 
 import (
 	"context"
-	"time"
 	"testing"
+	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -55,8 +55,9 @@ var _ = AfterSuite(func() {
 var _ = AfterEach(func() {
 	PrintOperatorPodStability()
 	By("Performing cleanup")
-	if GetConfig() != nil {
-		DeleteConfig()
+	gvk := GetCnaoV1GroupVersionKind()
+	if GetConfig(gvk) != nil {
+		DeleteConfig(gvk)
 	}
 	CheckComponentsRemoval(AllComponents)
 })

--- a/test/e2e/workflow/recovery_test.go
+++ b/test/e2e/workflow/recovery_test.go
@@ -12,6 +12,7 @@ import (
 
 //2297
 var _ = Describe("NetworkAddonsConfig", func() {
+	gvk := GetCnaoV1GroupVersionKind()
 	Context("when invalid config is applied", func() {
 		BeforeEach(func() {
 			configSpec := cnao.NetworkAddonsConfigSpec{
@@ -19,7 +20,7 @@ var _ = Describe("NetworkAddonsConfig", func() {
 					RangeStart: "this:aint:right",
 				},
 			}
-			CreateConfig(configSpec)
+			CreateConfig(gvk, configSpec)
 			CheckConfigCondition(ConditionDegraded, ConditionTrue, 5*time.Second, CheckDoNotRepeat)
 			CheckFailedEvent("FailedToValidate")
 		})
@@ -27,7 +28,7 @@ var _ = Describe("NetworkAddonsConfig", func() {
 		Context("and it is updated with a valid config", func() {
 			BeforeEach(func() {
 				configSpec := cnao.NetworkAddonsConfigSpec{}
-				UpdateConfig(configSpec)
+				UpdateConfig(gvk, configSpec)
 			})
 
 			It("should turn from Failing to Available", func() {

--- a/test/e2e/workflow/validation_test.go
+++ b/test/e2e/workflow/validation_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 var _ = Describe("NetworkAddonsConfig", func() {
+	gvk := GetCnaoV1GroupVersionKind()
 	Context("when there is no running config", func() {
 		Context("and an invalid config is created", func() {
 			BeforeEach(func() {
@@ -26,7 +27,7 @@ var _ = Describe("NetworkAddonsConfig", func() {
 					NMState:     &cnao.NMState{},
 					MacvtapCni:  &cnao.MacvtapCni{},
 				}
-				CreateConfig(configSpec)
+				CreateConfig(gvk, configSpec)
 			})
 
 			It("should report Failing condition and Available must be set to False", func() {
@@ -42,7 +43,7 @@ var _ = Describe("NetworkAddonsConfig", func() {
 				LinuxBridge: &cnao.LinuxBridge{},
 				NMState:     &cnao.NMState{},
 			}
-			CreateConfig(configSpec)
+			CreateConfig(gvk, configSpec)
 			CheckConfigCondition(ConditionAvailable, ConditionTrue, 2*time.Minute, CheckDoNotRepeat)
 		})
 
@@ -51,7 +52,7 @@ var _ = Describe("NetworkAddonsConfig", func() {
 				configSpec := cnao.NetworkAddonsConfigSpec{
 					LinuxBridge: &cnao.LinuxBridge{},
 				}
-				UpdateConfig(configSpec)
+				UpdateConfig(gvk, configSpec)
 			})
 
 			It("should remain at Available condition", func() {

--- a/test/e2e/workflow/version_test.go
+++ b/test/e2e/workflow/version_test.go
@@ -11,12 +11,13 @@ import (
 )
 
 var _ = Describe("NetworkAddonsConfig", func() {
+	gvk := GetCnaoV1GroupVersionKind()
 	Context("when a config is created", func() {
 		BeforeEach(func() {
 			configSpec := cnao.NetworkAddonsConfigSpec{
 				LinuxBridge: &cnao.LinuxBridge{},
 			}
-			CreateConfig(configSpec)
+			CreateConfig(gvk, configSpec)
 		})
 
 		It("should set targetVersion and operatorVersion immediately after it turns Progressing", func() {
@@ -35,7 +36,7 @@ var _ = Describe("NetworkAddonsConfig", func() {
 			configSpec := cnao.NetworkAddonsConfigSpec{
 				Multus: &cnao.Multus{},
 			}
-			CreateConfig(configSpec)
+			CreateConfig(gvk, configSpec)
 			CheckConfigCondition(ConditionAvailable, ConditionTrue, 15*time.Minute, CheckDoNotRepeat)
 		})
 
@@ -53,7 +54,7 @@ var _ = Describe("NetworkAddonsConfig", func() {
 				// Give validator some time to verify original state
 				time.Sleep(3 * time.Second)
 
-				UpdateConfig(configSpec)
+				UpdateConfig(gvk, configSpec)
 				CheckConfigCondition(ConditionAvailable, ConditionTrue, 15*time.Minute, CheckDoNotRepeat)
 
 				// Give validator some time to verify versions while we stay in updated config

--- a/test/releases/releases.go
+++ b/test/releases/releases.go
@@ -6,10 +6,12 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/blang/semver"
-	"github.com/gobwas/glob"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+
+	"github.com/blang/semver"
+	"github.com/gobwas/glob"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	cnao "github.com/kubevirt/cluster-network-addons-operator/pkg/apis/networkaddonsoperator/shared"
 	. "github.com/kubevirt/cluster-network-addons-operator/test/kubectl"
@@ -112,7 +114,7 @@ func UninstallRelease(release Release) {
 
 // Make sure that container images currently used (reported in NetworkAddonsConfig)
 // are matching images expected for given release
-func CheckReleaseUsesExpectedContainerImages(release Release) {
+func CheckReleaseUsesExpectedContainerImages(gvk schema.GroupVersionKind, release Release) {
 	By(fmt.Sprintf("Checking that all deployed images match release %s", release.Version))
 
 	expectedContainers := sortContainers(release.Containers)
@@ -121,8 +123,8 @@ func CheckReleaseUsesExpectedContainerImages(release Release) {
 		expectedContainers = dropMultusContainers(expectedContainers)
 	}
 
-	config := GetConfig()
-	deployedContainers := sortContainers(config.Status.Containers)
+	configStatus := GetConfigStatus(gvk)
+	deployedContainers := sortContainers(configStatus.Containers)
 
 	Expect(deployedContainers).To(Equal(expectedContainers))
 }


### PR DESCRIPTION
This PR is changes config operations to support both v1, v1alpha1 NetworkAddonsConfig

- **refactor operations to accept unstructured**
Currently, functions that create/update/remove NetworkAddonsConfig type
only use the currently stored NetworkAddonsConfig version:v1
This is not an issue during upgrade tests since we're not upgrading
the crd itself, so we always support v1.
Let's support both APIs by using unstructred objects
when calling k8s client.

- **update e2e tests to use new config changes**
this commit introduces the change in config API to
all the relevant e2e tests

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
