### PR TITLE
Change upgrade test

### DIFF
--- a/test/e2e/lifecycle/deployment_test.go
+++ b/test/e2e/lifecycle/deployment_test.go
@@ -41,8 +41,8 @@ var _ = Context("Cluster Network Addons Operator", func() {
 					// Give validator some time to verify original state
 					time.Sleep(3 * time.Second)
 
-					UninstallRelease(masterRelease)
-					InstallRelease(masterRelease)
+					UninstallOperator(masterRelease)
+					InstallOperator(masterRelease)
 					CheckOperatorIsReady(15 * time.Minute)
 
 					// Give validator some time to verify conditions while the new installation is operating

--- a/test/e2e/lifecycle/upgrade_test.go
+++ b/test/e2e/lifecycle/upgrade_test.go
@@ -17,6 +17,7 @@ var _ = Context("Cluster Network Addons Operator", func() {
 	testUpgrade := func(oldRelease, newRelease Release) {
 		Context(fmt.Sprintf("when operator in version %s is installed and supported spec configured", oldRelease.Version), func() {
 			BeforeEach(func() {
+				UninstallRelease(newRelease)
 				oldReleaseGvk := GetCnaoV1alpha1GroupVersionKind()
 				InstallRelease(oldRelease)
 				CheckOperatorIsReady(podsDeploymentTimeout)
@@ -32,7 +33,6 @@ var _ = Context("Cluster Network Addons Operator", func() {
 			Context("and it is upgraded to the latest release", func() {
 				newReleaseGvk := GetCnaoV1GroupVersionKind()
 				BeforeEach(func() {
-					UninstallRelease(oldRelease)
 					InstallRelease(newRelease)
 					UpdateConfig(newReleaseGvk, newRelease.SupportedSpec)
 					CheckOperatorIsReady(podsDeploymentTimeout)
@@ -56,7 +56,6 @@ var _ = Context("Cluster Network Addons Operator", func() {
 			It(fmt.Sprintf("should transition reported versions while being upgraded to version %s", newRelease.Version), func() {
 				newReleaseGvk := GetCnaoV1GroupVersionKind()
 				// Upgrade the operator
-				UninstallRelease(oldRelease)
 				InstallRelease(newRelease)
 
 				// Check that operator and target versions will be set to the newer. Ignore observed version, since it

--- a/test/releases/0.16.0.go
+++ b/test/releases/0.16.0.go
@@ -59,6 +59,7 @@ func init() {
 			Ovs:         &cnao.Ovs{},
 		},
 		Manifests: []string{
+			"network-addons-config.crd.yaml",
 			"operator.yaml",
 		},
 	}

--- a/test/releases/0.17.0.go
+++ b/test/releases/0.17.0.go
@@ -59,6 +59,7 @@ func init() {
 			Ovs:         &cnao.Ovs{},
 		},
 		Manifests: []string{
+			"network-addons-config.crd.yaml",
 			"operator.yaml",
 		},
 	}

--- a/test/releases/0.18.0.go
+++ b/test/releases/0.18.0.go
@@ -59,6 +59,7 @@ func init() {
 			Ovs:         &cnao.Ovs{},
 		},
 		Manifests: []string{
+			"network-addons-config.crd.yaml",
 			"operator.yaml",
 		},
 	}

--- a/test/releases/0.19.0.go
+++ b/test/releases/0.19.0.go
@@ -59,6 +59,7 @@ func init() {
 			Ovs:         &cnao.Ovs{},
 		},
 		Manifests: []string{
+			"network-addons-config.crd.yaml",
 			"operator.yaml",
 		},
 	}

--- a/test/releases/0.20.0.go
+++ b/test/releases/0.20.0.go
@@ -59,6 +59,7 @@ func init() {
 			Ovs:         &cnao.Ovs{},
 		},
 		Manifests: []string{
+			"network-addons-config.crd.yaml",
 			"operator.yaml",
 		},
 	}

--- a/test/releases/0.21.0.go
+++ b/test/releases/0.21.0.go
@@ -59,6 +59,7 @@ func init() {
 			Ovs:         &cnao.Ovs{},
 		},
 		Manifests: []string{
+			"network-addons-config.crd.yaml",
 			"operator.yaml",
 		},
 	}

--- a/test/releases/0.22.0.go
+++ b/test/releases/0.22.0.go
@@ -59,6 +59,7 @@ func init() {
 			Ovs:         &cnao.Ovs{},
 		},
 		Manifests: []string{
+			"network-addons-config.crd.yaml",
 			"operator.yaml",
 		},
 	}

--- a/test/releases/0.23.0.go
+++ b/test/releases/0.23.0.go
@@ -59,6 +59,7 @@ func init() {
 			Ovs:         &cnao.Ovs{},
 		},
 		Manifests: []string{
+			"network-addons-config.crd.yaml",
 			"operator.yaml",
 		},
 	}

--- a/test/releases/0.24.0.go
+++ b/test/releases/0.24.0.go
@@ -59,6 +59,7 @@ func init() {
 			Ovs:         &cnao.Ovs{},
 		},
 		Manifests: []string{
+			"network-addons-config.crd.yaml",
 			"operator.yaml",
 		},
 	}

--- a/test/releases/0.25.0.go
+++ b/test/releases/0.25.0.go
@@ -59,6 +59,7 @@ func init() {
 			Ovs:         &cnao.Ovs{},
 		},
 		Manifests: []string{
+			"network-addons-config.crd.yaml",
 			"operator.yaml",
 		},
 	}

--- a/test/releases/0.26.0.go
+++ b/test/releases/0.26.0.go
@@ -59,6 +59,7 @@ func init() {
 			Ovs:         &cnao.Ovs{},
 		},
 		Manifests: []string{
+			"network-addons-config.crd.yaml",
 			"operator.yaml",
 		},
 	}

--- a/test/releases/0.27.7.go
+++ b/test/releases/0.27.7.go
@@ -65,6 +65,7 @@ func init() {
 			Ovs:         &cnao.Ovs{},
 		},
 		Manifests: []string{
+			"network-addons-config.crd.yaml",
 			"operator.yaml",
 		},
 	}

--- a/test/releases/0.28.0.go
+++ b/test/releases/0.28.0.go
@@ -65,6 +65,7 @@ func init() {
 			Ovs:         &cnao.Ovs{},
 		},
 		Manifests: []string{
+			"network-addons-config.crd.yaml",
 			"operator.yaml",
 		},
 	}

--- a/test/releases/0.29.0.go
+++ b/test/releases/0.29.0.go
@@ -65,6 +65,7 @@ func init() {
 			Ovs:         &cnao.Ovs{},
 		},
 		Manifests: []string{
+			"network-addons-config.crd.yaml",
 			"operator.yaml",
 		},
 	}

--- a/test/releases/0.30.0.go
+++ b/test/releases/0.30.0.go
@@ -65,6 +65,7 @@ func init() {
 			Ovs:         &cnao.Ovs{},
 		},
 		Manifests: []string{
+			"network-addons-config.crd.yaml",
 			"operator.yaml",
 		},
 	}

--- a/test/releases/0.31.0.go
+++ b/test/releases/0.31.0.go
@@ -65,6 +65,7 @@ func init() {
 			Ovs:         &cnao.Ovs{},
 		},
 		Manifests: []string{
+			"network-addons-config.crd.yaml",
 			"operator.yaml",
 		},
 	}

--- a/test/releases/0.32.0.go
+++ b/test/releases/0.32.0.go
@@ -65,6 +65,7 @@ func init() {
 			Ovs:         &cnao.Ovs{},
 		},
 		Manifests: []string{
+			"network-addons-config.crd.yaml",
 			"operator.yaml",
 		},
 	}

--- a/test/releases/0.33.0.go
+++ b/test/releases/0.33.0.go
@@ -65,6 +65,7 @@ func init() {
 			Ovs:         &cnao.Ovs{},
 		},
 		Manifests: []string{
+			"network-addons-config.crd.yaml",
 			"operator.yaml",
 		},
 	}

--- a/test/releases/0.34.0.go
+++ b/test/releases/0.34.0.go
@@ -65,6 +65,7 @@ func init() {
 			Ovs:         &cnao.Ovs{},
 		},
 		Manifests: []string{
+			"network-addons-config.crd.yaml",
 			"operator.yaml",
 		},
 	}

--- a/test/releases/0.35.0.go
+++ b/test/releases/0.35.0.go
@@ -65,6 +65,7 @@ func init() {
 			Ovs:         &cnao.Ovs{},
 		},
 		Manifests: []string{
+			"network-addons-config.crd.yaml",
 			"operator.yaml",
 		},
 	}

--- a/test/releases/0.35.1.go
+++ b/test/releases/0.35.1.go
@@ -65,6 +65,7 @@ func init() {
 			Ovs:         &cnao.Ovs{},
 		},
 		Manifests: []string{
+			"network-addons-config.crd.yaml",
 			"operator.yaml",
 		},
 	}

--- a/test/releases/0.36.0.go
+++ b/test/releases/0.36.0.go
@@ -59,6 +59,7 @@ func init() {
 			Ovs:         &cnao.Ovs{},
 		},
 		Manifests: []string{
+			"network-addons-config.crd.yaml",
 			"operator.yaml",
 		},
 	}

--- a/test/releases/0.38.0.go
+++ b/test/releases/0.38.0.go
@@ -59,6 +59,7 @@ func init() {
 			Ovs:         &cnao.Ovs{},
 		},
 		Manifests: []string{
+			"network-addons-config.crd.yaml",
 			"operator.yaml",
 		},
 	}

--- a/test/releases/0.39.3.go
+++ b/test/releases/0.39.3.go
@@ -59,6 +59,7 @@ func init() {
 			Ovs:         &cnao.Ovs{},
 		},
 		Manifests: []string{
+			"network-addons-config.crd.yaml",
 			"operator.yaml",
 		},
 	}

--- a/test/releases/0.40.0.go
+++ b/test/releases/0.40.0.go
@@ -65,6 +65,7 @@ func init() {
 			Ovs:         &cnao.Ovs{},
 		},
 		Manifests: []string{
+			"network-addons-config.crd.yaml",
 			"operator.yaml",
 		},
 	}

--- a/test/releases/0.40.1.go
+++ b/test/releases/0.40.1.go
@@ -65,6 +65,7 @@ func init() {
 			Ovs:         &cnao.Ovs{},
 		},
 		Manifests: []string{
+			"network-addons-config.crd.yaml",
 			"operator.yaml",
 		},
 	}

--- a/test/releases/0.41.0.go
+++ b/test/releases/0.41.0.go
@@ -65,6 +65,7 @@ func init() {
 			Ovs:         &cnao.Ovs{},
 		},
 		Manifests: []string{
+			"network-addons-config.crd.yaml",
 			"operator.yaml",
 		},
 	}

--- a/test/releases/0.42.0.go
+++ b/test/releases/0.42.0.go
@@ -65,6 +65,7 @@ func init() {
 			Ovs:         &cnao.Ovs{},
 		},
 		Manifests: []string{
+			"network-addons-config.crd.yaml",
 			"operator.yaml",
 		},
 	}

--- a/test/releases/99.0.0.go
+++ b/test/releases/99.0.0.go
@@ -65,6 +65,7 @@ func init() {
 			Ovs:         &cnao.Ovs{},
 		},
 		Manifests: []string{
+			"network-addons-config.crd.yaml",
 			"operator.yaml",
 		},
 	}

--- a/test/releases/releases.go
+++ b/test/releases/releases.go
@@ -94,7 +94,7 @@ func LatestRelease() Release {
 	return r[len(r)-1]
 }
 
-// Installs given release (RBAC and Deployment)
+// Installs given release (CRD, RBAC and Deployment)
 func InstallRelease(release Release) {
 	By(fmt.Sprintf("Installing release %s", release.Version))
 	for _, manifestName := range release.Manifests {
@@ -110,6 +110,22 @@ func UninstallRelease(release Release) {
 		out, err := Kubectl("delete", "--ignore-not-found", "-f", "_out/cluster-network-addons/"+release.Version+"/"+manifestName)
 		Expect(err).NotTo(HaveOccurred(), out)
 	}
+}
+
+// Installs given release (RBAC and Deployment)
+func InstallOperator(release Release) {
+	manifestName := "operator.yaml"
+	By(fmt.Sprintf("Installing operator %s", release.Version))
+	out, err := Kubectl("apply", "-f", "_out/cluster-network-addons/"+release.Version+"/"+manifestName)
+	Expect(err).NotTo(HaveOccurred(), out)
+}
+
+// Removes given release from cluster
+func UninstallOperator(release Release) {
+	manifestName := "operator.yaml"
+	By(fmt.Sprintf("Uninstalling operator %s", release.Version))
+	out, err := Kubectl("delete", "--ignore-not-found", "-f", "_out/cluster-network-addons/"+release.Version+"/"+manifestName)
+	Expect(err).NotTo(HaveOccurred(), out)
 }
 
 // Make sure that container images currently used (reported in NetworkAddonsConfig)


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR change the upgrade test to work more like OLM performs upgrade

- **change upgrade test to also update crd manifest**
Currently upgrade test only updates operator.yaml manifest,
while keeping the currently deployed crd.
This is not how OLM performs upgrade, and since we want to
test the actual upgrade scenario then we should also upgrade the crd

- **remove UninstallRelease from upgrade test**
Currently manifests are updated by
uninstalling the old and intalling the new.
Now that we are also uninstalling the crd,
we need to change this behavior to only update the manifests
We also keep operator tests while crd is not kept deployed.

**Special notes for your reviewer**:
This PR depends on #537 to be merged

**Release note**:

```release-note
NONE
```
