### PR TITLE
change check.go api to unstructured

### DIFF
--- a/test/e2e/lifecycle/deployment_test.go
+++ b/test/e2e/lifecycle/deployment_test.go
@@ -28,13 +28,13 @@ var _ = Context("Cluster Network Addons Operator", func() {
 			})
 
 			It("reaches Available condition with all containers using expected images", func() {
-				CheckConfigCondition(ConditionAvailable, ConditionTrue, 15*time.Minute, CheckDoNotRepeat)
+				CheckConfigCondition(gvk, ConditionAvailable, ConditionTrue, 15*time.Minute, CheckDoNotRepeat)
 				CheckReleaseUsesExpectedContainerImages(gvk, masterRelease)
 			})
 
 			It("stays in Available condition while the operator is being removed and redeployed", func() {
 				configIsAvailable := func() {
-					CheckConfigCondition(ConditionAvailable, ConditionTrue, CheckImmediately, CheckDoNotRepeat)
+					CheckConfigCondition(gvk, ConditionAvailable, ConditionTrue, CheckImmediately, CheckDoNotRepeat)
 				}
 
 				reinstallingOperator := func() {
@@ -50,7 +50,7 @@ var _ = Context("Cluster Network Addons Operator", func() {
 				}
 
 				// Wait until the configuration reaches Available state
-				CheckConfigCondition(ConditionAvailable, ConditionTrue, 15*time.Minute, CheckDoNotRepeat)
+				CheckConfigCondition(gvk, ConditionAvailable, ConditionTrue, 15*time.Minute, CheckDoNotRepeat)
 
 				// Make sure that configuration stays available during operator's reinstallation
 				KeepCheckingWhile(configIsAvailable, reinstallingOperator)

--- a/test/e2e/lifecycle/upgrade_test.go
+++ b/test/e2e/lifecycle/upgrade_test.go
@@ -21,12 +21,12 @@ var _ = Context("Cluster Network Addons Operator", func() {
 				InstallRelease(oldRelease)
 				CheckOperatorIsReady(podsDeploymentTimeout)
 				CreateConfig(oldReleaseGvk, oldRelease.SupportedSpec)
-				CheckConfigCondition(ConditionAvailable, ConditionTrue, 15*time.Minute, CheckDoNotRepeat)
+				CheckConfigCondition(oldReleaseGvk, ConditionAvailable, ConditionTrue, 15*time.Minute, CheckDoNotRepeat)
 				CheckReleaseUsesExpectedContainerImages(oldReleaseGvk, oldRelease)
 				expectedOperatorVersion := oldRelease.Version
 				expectedObservedVersion := oldRelease.Version
 				expectedTargetVersion := oldRelease.Version
-				CheckConfigVersions(expectedOperatorVersion, expectedObservedVersion, expectedTargetVersion, CheckImmediately, CheckDoNotRepeat)
+				CheckConfigVersions(oldReleaseGvk, expectedOperatorVersion, expectedObservedVersion, expectedTargetVersion, CheckImmediately, CheckDoNotRepeat)
 			})
 
 			Context("and it is upgraded to the latest release", func() {
@@ -41,7 +41,7 @@ var _ = Context("Cluster Network Addons Operator", func() {
 					expectedOperatorVersion := newRelease.Version
 					expectedObservedVersion := newRelease.Version
 					expectedTargetVersion := newRelease.Version
-					CheckConfigVersions(expectedOperatorVersion, expectedObservedVersion, expectedTargetVersion, podsDeploymentTimeout, CheckDoNotRepeat)
+					CheckConfigVersions(newReleaseGvk, expectedOperatorVersion, expectedObservedVersion, expectedTargetVersion, podsDeploymentTimeout, CheckDoNotRepeat)
 				})
 
 				It("it should report expected deployed container images and leave no leftovers from the previous version", func() {
@@ -54,6 +54,7 @@ var _ = Context("Cluster Network Addons Operator", func() {
 			})
 
 			It(fmt.Sprintf("should transition reported versions while being upgraded to version %s", newRelease.Version), func() {
+				newReleaseGvk := GetCnaoV1GroupVersionKind()
 				// Upgrade the operator
 				UninstallRelease(oldRelease)
 				InstallRelease(newRelease)
@@ -63,16 +64,16 @@ var _ = Context("Cluster Network Addons Operator", func() {
 				expectedOperatorVersion := newRelease.Version
 				expectedObservedVersion := CheckIgnoreVersion
 				expectedTargetVersion := newRelease.Version
-				CheckConfigVersions(expectedOperatorVersion, expectedObservedVersion, expectedTargetVersion, podsDeploymentTimeout, CheckDoNotRepeat)
+				CheckConfigVersions(newReleaseGvk, expectedOperatorVersion, expectedObservedVersion, expectedTargetVersion, podsDeploymentTimeout, CheckDoNotRepeat)
 
 				// Wait until the operator finishes configuration
-				CheckConfigCondition(ConditionAvailable, ConditionTrue, podsDeploymentTimeout, CheckDoNotRepeat)
+				CheckConfigCondition(newReleaseGvk, ConditionAvailable, ConditionTrue, podsDeploymentTimeout, CheckDoNotRepeat)
 
 				// Validate that observed version turned to the newer
 				expectedOperatorVersion = newRelease.Version
 				expectedObservedVersion = newRelease.Version
 				expectedTargetVersion = newRelease.Version
-				CheckConfigVersions(expectedOperatorVersion, expectedObservedVersion, expectedTargetVersion, CheckImmediately, CheckDoNotRepeat)
+				CheckConfigVersions(newReleaseGvk, expectedOperatorVersion, expectedObservedVersion, expectedTargetVersion, CheckImmediately, CheckDoNotRepeat)
 			})
 		})
 	}

--- a/test/e2e/workflow/containers_test.go
+++ b/test/e2e/workflow/containers_test.go
@@ -19,7 +19,7 @@ var _ = Describe("NetworkAddonsConfig", func() {
 		gvk := GetCnaoV1GroupVersionKind()
 		BeforeEach(func() {
 			CreateConfig(gvk, configSpec)
-			CheckConfigCondition(ConditionAvailable, ConditionTrue, 15*time.Minute, CheckDoNotRepeat)
+			CheckConfigCondition(gvk, ConditionAvailable, ConditionTrue, 15*time.Minute, CheckDoNotRepeat)
 		})
 
 		It("should report non-empty list of deployed containers", func() {

--- a/test/e2e/workflow/recovery_test.go
+++ b/test/e2e/workflow/recovery_test.go
@@ -21,8 +21,8 @@ var _ = Describe("NetworkAddonsConfig", func() {
 				},
 			}
 			CreateConfig(gvk, configSpec)
-			CheckConfigCondition(ConditionDegraded, ConditionTrue, 5*time.Second, CheckDoNotRepeat)
-			CheckFailedEvent("FailedToValidate")
+			CheckConfigCondition(gvk, ConditionDegraded, ConditionTrue, 5*time.Second, CheckDoNotRepeat)
+			CheckFailedEvent(gvk, "FailedToValidate")
 		})
 
 		Context("and it is updated with a valid config", func() {
@@ -32,9 +32,9 @@ var _ = Describe("NetworkAddonsConfig", func() {
 			})
 
 			It("should turn from Failing to Available", func() {
-				CheckConfigCondition(ConditionAvailable, ConditionTrue, 5*time.Second, CheckDoNotRepeat)
-				CheckConfigCondition(ConditionDegraded, ConditionFalse, CheckImmediately, CheckDoNotRepeat)
-				CheckAvailableEvent()
+				CheckConfigCondition(gvk, ConditionAvailable, ConditionTrue, 5*time.Second, CheckDoNotRepeat)
+				CheckConfigCondition(gvk, ConditionDegraded, ConditionFalse, CheckImmediately, CheckDoNotRepeat)
+				CheckAvailableEvent(gvk)
 			})
 		})
 	})

--- a/test/e2e/workflow/validation_test.go
+++ b/test/e2e/workflow/validation_test.go
@@ -56,8 +56,12 @@ var _ = Describe("NetworkAddonsConfig", func() {
 			})
 
 			It("should remain at Available condition", func() {
-				CheckConfigCondition(gvk, ConditionAvailable, ConditionTrue, time.Minute, CheckDoNotRepeat)
-				CheckConfigCondition(gvk, ConditionDegraded, ConditionFalse, CheckImmediately, CheckDoNotRepeat)
+				By("Waiting for config update to take effect")
+				time.Sleep(10*time.Second)
+				By("Checking that Available status turn to True after config update")
+				CheckConfigCondition(gvk, ConditionAvailable, ConditionTrue, time.Minute, time.Minute)
+				By("Checking that Degraded status turn to False after config update")
+				CheckConfigCondition(gvk, ConditionDegraded, ConditionFalse, CheckImmediately, time.Minute)
 			})
 		})
 	})

--- a/test/e2e/workflow/validation_test.go
+++ b/test/e2e/workflow/validation_test.go
@@ -31,8 +31,8 @@ var _ = Describe("NetworkAddonsConfig", func() {
 			})
 
 			It("should report Failing condition and Available must be set to False", func() {
-				CheckConfigCondition(ConditionDegraded, ConditionTrue, time.Minute, CheckDoNotRepeat)
-				CheckConfigCondition(ConditionAvailable, ConditionFalse, CheckImmediately, CheckDoNotRepeat)
+				CheckConfigCondition(gvk, ConditionDegraded, ConditionTrue, time.Minute, CheckDoNotRepeat)
+				CheckConfigCondition(gvk, ConditionAvailable, ConditionFalse, CheckImmediately, CheckDoNotRepeat)
 			})
 		})
 	})
@@ -44,7 +44,7 @@ var _ = Describe("NetworkAddonsConfig", func() {
 				NMState:     &cnao.NMState{},
 			}
 			CreateConfig(gvk, configSpec)
-			CheckConfigCondition(ConditionAvailable, ConditionTrue, 2*time.Minute, CheckDoNotRepeat)
+			CheckConfigCondition(gvk, ConditionAvailable, ConditionTrue, 2*time.Minute, CheckDoNotRepeat)
 		})
 
 		Context("and a component which does support removal is removed from the Spec", func() {
@@ -56,8 +56,8 @@ var _ = Describe("NetworkAddonsConfig", func() {
 			})
 
 			It("should remain at Available condition", func() {
-				CheckConfigCondition(ConditionAvailable, ConditionTrue, time.Minute, CheckDoNotRepeat)
-				CheckConfigCondition(ConditionDegraded, ConditionFalse, CheckImmediately, CheckDoNotRepeat)
+				CheckConfigCondition(gvk, ConditionAvailable, ConditionTrue, time.Minute, CheckDoNotRepeat)
+				CheckConfigCondition(gvk, ConditionDegraded, ConditionFalse, CheckImmediately, CheckDoNotRepeat)
 			})
 		})
 	})

--- a/test/e2e/workflow/version_test.go
+++ b/test/e2e/workflow/version_test.go
@@ -21,13 +21,13 @@ var _ = Describe("NetworkAddonsConfig", func() {
 		})
 
 		It("should set targetVersion and operatorVersion immediately after it turns Progressing", func() {
-			CheckConfigCondition(ConditionProgressing, ConditionTrue, time.Minute, CheckDoNotRepeat)
-			CheckConfigVersions(operatorVersion, CheckIgnoreVersion, operatorVersion, CheckImmediately, CheckDoNotRepeat)
+			CheckConfigCondition(gvk, ConditionProgressing, ConditionTrue, time.Minute, CheckDoNotRepeat)
+			CheckConfigVersions(gvk, operatorVersion, CheckIgnoreVersion, operatorVersion, CheckImmediately, CheckDoNotRepeat)
 		})
 
 		It("should set observedVersion once turns it Available", func() {
-			CheckConfigCondition(ConditionAvailable, ConditionTrue, 15*time.Minute, CheckDoNotRepeat)
-			CheckConfigVersions(operatorVersion, operatorVersion, operatorVersion, CheckImmediately, CheckDoNotRepeat)
+			CheckConfigCondition(gvk, ConditionAvailable, ConditionTrue, 15*time.Minute, CheckDoNotRepeat)
+			CheckConfigVersions(gvk, operatorVersion, operatorVersion, operatorVersion, CheckImmediately, CheckDoNotRepeat)
 		})
 	})
 
@@ -37,12 +37,12 @@ var _ = Describe("NetworkAddonsConfig", func() {
 				Multus: &cnao.Multus{},
 			}
 			CreateConfig(gvk, configSpec)
-			CheckConfigCondition(ConditionAvailable, ConditionTrue, 15*time.Minute, CheckDoNotRepeat)
+			CheckConfigCondition(gvk, ConditionAvailable, ConditionTrue, 15*time.Minute, CheckDoNotRepeat)
 		})
 
 		It("should keep reported versions while being changed", func() {
 			versionRemainsTheSame := func() {
-				CheckConfigVersions(operatorVersion, operatorVersion, operatorVersion, CheckImmediately, CheckDoNotRepeat)
+				CheckConfigVersions(gvk, operatorVersion, operatorVersion, operatorVersion, CheckImmediately, CheckDoNotRepeat)
 			}
 
 			updatingConfig := func() {
@@ -55,7 +55,7 @@ var _ = Describe("NetworkAddonsConfig", func() {
 				time.Sleep(3 * time.Second)
 
 				UpdateConfig(gvk, configSpec)
-				CheckConfigCondition(ConditionAvailable, ConditionTrue, 15*time.Minute, CheckDoNotRepeat)
+				CheckConfigCondition(gvk, ConditionAvailable, ConditionTrue, 15*time.Minute, CheckDoNotRepeat)
 
 				// Give validator some time to verify versions while we stay in updated config
 				time.Sleep(3 * time.Second)

--- a/test/operations/operations.go
+++ b/test/operations/operations.go
@@ -85,9 +85,9 @@ func GetConfigStatus(gvk schema.GroupVersionKind) *cnao.NetworkAddonsConfigStatu
 		By("Getting the current config status")
 		switch gvk {
 		case GetCnaoV1GroupVersionKind():
-			return &convertToConfigV1(config).Status
+			return &ConvertToConfigV1(config).Status
 		case GetCnaoV1alpha1GroupVersionKind():
-			return &convertToConfigV1alpha1(config).Status
+			return &ConvertToConfigV1alpha1(config).Status
 		}
 
 		Fail(fmt.Sprintf("gvk %v not supported", gvk))
@@ -95,7 +95,7 @@ func GetConfigStatus(gvk schema.GroupVersionKind) *cnao.NetworkAddonsConfigStatu
 	return nil
 }
 
-func convertToConfigV1(unstructuredConfig *unstructured.Unstructured) *cnaov1.NetworkAddonsConfig {
+func ConvertToConfigV1(unstructuredConfig *unstructured.Unstructured) *cnaov1.NetworkAddonsConfig {
 	configV1 := &cnaov1.NetworkAddonsConfig{}
 	err := runtime.DefaultUnstructuredConverter.FromUnstructured(unstructuredConfig.Object, configV1)
 	Expect(err).NotTo(HaveOccurred(), "Failed to convert unstructured config to cnaov1 Config")
@@ -103,7 +103,7 @@ func convertToConfigV1(unstructuredConfig *unstructured.Unstructured) *cnaov1.Ne
 	return configV1
 }
 
-func convertToConfigV1alpha1(unstructuredConfig *unstructured.Unstructured) *cnaov1alpha1.NetworkAddonsConfig {
+func ConvertToConfigV1alpha1(unstructuredConfig *unstructured.Unstructured) *cnaov1alpha1.NetworkAddonsConfig {
 	configV1alpha1 := &cnaov1alpha1.NetworkAddonsConfig{}
 	err := runtime.DefaultUnstructuredConverter.FromUnstructured(unstructuredConfig.Object, configV1alpha1)
 	Expect(err).NotTo(HaveOccurred(), "Failed to convert unstructured config to cnaov1alpha1 Config")

--- a/test/operations/operations.go
+++ b/test/operations/operations.go
@@ -24,7 +24,6 @@ import (
 )
 
 func GetConfig(gvk schema.GroupVersionKind) *unstructured.Unstructured {
-	By("Getting the current config")
 	config := &unstructured.Unstructured{}
 	config.SetGroupVersionKind(gvk)
 	err := framework.Global.Client.Get(context.TODO(), types.NamespacedName{Name: names.OPERATOR_CONFIG}, config)
@@ -82,7 +81,6 @@ func DeleteConfig(gvk schema.GroupVersionKind) {
 func GetConfigStatus(gvk schema.GroupVersionKind) *cnao.NetworkAddonsConfigStatus {
 	config := GetConfig(gvk)
 	if config != nil {
-		By("Getting the current config status")
 		switch gvk {
 		case GetCnaoV1GroupVersionKind():
 			return &ConvertToConfigV1(config).Status


### PR DESCRIPTION
**What this PR does / why we need it**:
Following #566, this PR changes the api in check.go to use unstructured config.

- **refactor check.go to use unstructured config**
Currently, check.go api use v1 NetworkAddonsConfig only.
Let's support both v1, v1alpha1 APIs by using unstructred objects.

- **update e2e tests to use new check.go changes**
this commit introduces the change in check.go API to
all the relevant e2e tests

- **remove noisy By() prints**
GetConfig and GetConfigStatus both use By() prints
that cause much noise during e2e tests
As they are not really informative, we should remove them

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
