### PR TITLE
Bump kubemacpool to v0.20.2

### DIFF
--- a/components.yaml
+++ b/components.yaml
@@ -19,10 +19,10 @@ components:
     metadata: "0.3.0"
   kubemacpool:
     url: "https://github.com/k8snetworkplumbingwg/kubemacpool"
-    commit: "7600ea1e8a945a5665071bdc7e6d8619adb65195"
+    commit: "932d5f04ee508c9f39516010b40d2170705d2cb7"
     branch: "master"
     update-policy: "tagged"
-    metadata: "v0.20.0"
+    metadata: "v0.20.2"
   nmstate:
     url: "https://github.com/nmstate/kubernetes-nmstate"
     commit: "a0d3d5658390fac730bafcc85506a0a681da98ac"


### PR DESCRIPTION
Signed-off-by: Radim Hrazdil <rhrazdil@redhat.com>

**What this PR does / why we need it**:

**Special notes for your reviewer**:

```release-note
Bump kubemacpool to v0.20.2
```
