### PR TITLE
refactor fix of flaky validation test

### DIFF
--- a/test/e2e/workflow/validation_test.go
+++ b/test/e2e/workflow/validation_test.go
@@ -56,8 +56,9 @@ var _ = Describe("NetworkAddonsConfig", func() {
 			})
 
 			It("should remain at Available condition", func() {
-				By("Waiting for config update to take effect")
-				time.Sleep(10*time.Second)
+				components := []Component{NMStateComponent}
+				CheckComponentsRemoval(components)
+
 				By("Checking that Available status turn to True after config update")
 				CheckConfigCondition(gvk, ConditionAvailable, ConditionTrue, time.Minute, time.Minute)
 				By("Checking that Degraded status turn to False after config update")


### PR DESCRIPTION
**What this PR does / why we need it**:
Due to a problem catching the time where a component
was removed from the spec in validation test
the wait for the available status was sometimes missed,
causing a flakiness in the test.
Currently this is solved by a sleep.
Let's improve this by waiting for the specific component removal

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
