### PR TITLE
[release-0.42] skip KMP opt-mode tests not maching CNAO config

### DIFF
--- a/automation/check-patch.e2e-kubemacpool-functests.sh
+++ b/automation/check-patch.e2e-kubemacpool-functests.sh
@@ -9,6 +9,24 @@
 # yum -y install automation/check-patch.packages
 # automation/check-patch.e2e-kubemacpool-functests.sh
 
+function __get_skipped_tests() {
+	local  __resultvar=$1
+	local skipped_regex=""
+
+	# We can't test all KMP opt-mode CNAO context, as the operator will reconcile
+	# back to the configured opt-mode when the test tries to change it.
+	# So we check KMP webhook's opt-mode and skip tests accordingly
+	if grep 'default/mutatevirtualmachines_opt_out_patch.yaml' hack/components/bump-kubemacpool.sh; then
+		echo "KMP VM webhook is set to opt-out mode. Skipping opt-in Context"
+		skipped_regex="${skipped_regex} \(opt-in\smode\)"
+	elif grep 'default/mutatevirtualmachines_opt_in_patch.yaml' hack/components/bump-kubemacpool.sh; then
+		echo "KMP VM webhook is set to opt-in mode. Skipping opt-out Context"
+		skipped_regex="${skipped_regex} \(opt-out\smode\)"
+	fi
+
+	eval $__resultvar="'$skipped_regex'"
+}
+
 teardown() {
     make cluster-down
     rm -rf "${TMP_COMPONENT_PATH}"
@@ -28,9 +46,13 @@ main() {
     echo "Deploy KubeVirt latest stable release"
     ./hack/deploy-kubevirt.sh
 
+    echo "Get skip tests regex"
+    __get_skipped_tests SKIPPED_TESTS
+
     # Run KubeMacPool functional tests
     cd ${TMP_COMPONENT_PATH}
-    KUBECONFIG=${KUBECONFIG} E2E_TEST_ARGS="--junit-output=$ARTIFACTS/junit.functest.xml" make functest
+
+    KUBECONFIG=${KUBECONFIG} E2E_TEST_ARGS="--junit-output=$ARTIFACTS/junit.functest.xml --ginkgo.skip $SKIPPED_TESTS" make functest
 }
 
 [[ "${BASH_SOURCE[0]}" == "$0" ]] && main "$@"


### PR DESCRIPTION
**What this PR does / why we need it**:
This is a manual backport of #567 

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
