### PR TITLE
fix AddToScheme to add all served versions

### DIFF
--- a/pkg/apis/addtoscheme_networkaddonsoperator_v1.go
+++ b/pkg/apis/addtoscheme_networkaddonsoperator_v1.go
@@ -1,10 +1,10 @@
 package apis
 
 import (
-	v1 "github.com/kubevirt/cluster-network-addons-operator/pkg/apis/networkaddonsoperator/v1"
+	cnaov1 "github.com/kubevirt/cluster-network-addons-operator/pkg/apis/networkaddonsoperator/v1"
 )
 
 func init() {
 	// Register the types with the Scheme so the components can map objects to GroupVersionKinds and back
-	AddToSchemes = append(AddToSchemes, v1.SchemeBuilder.AddToScheme)
+	AddToSchemes = append(AddToSchemes, cnaov1.SchemeBuilder.AddToScheme)
 }

--- a/pkg/apis/addtoscheme_networkaddonsoperator_v1alpha1.go
+++ b/pkg/apis/addtoscheme_networkaddonsoperator_v1alpha1.go
@@ -1,0 +1,10 @@
+package apis
+
+import (
+	cnaov1alpha1 "github.com/kubevirt/cluster-network-addons-operator/pkg/apis/networkaddonsoperator/v1alpha1"
+)
+
+func init() {
+	// Register the types with the Scheme so the components can map objects to GroupVersionKinds and back
+	AddToSchemes = append(AddToSchemes, cnaov1alpha1.SchemeBuilder.AddToScheme)
+}

--- a/pkg/apis/apis.go
+++ b/pkg/apis/apis.go
@@ -2,14 +2,10 @@ package apis
 
 import (
 	"k8s.io/apimachinery/pkg/runtime"
-
-	"github.com/kubevirt/cluster-network-addons-operator/pkg/apis/networkaddonsoperator/v1alpha1"
 )
 
 // AddToSchemes may be used to add all resources defined in the project to a Scheme
-var AddToSchemes = runtime.SchemeBuilder{
-	v1alpha1.SchemeBuilder.AddToScheme,
-}
+var AddToSchemes runtime.SchemeBuilder
 
 // AddToScheme adds all Resources to the Scheme
 func AddToScheme(s *runtime.Scheme) error {


### PR DESCRIPTION
**What this PR does / why we need it**:
We are currently using the old shceme version when
adding resources to schema.
Let's change it to use all served versions v1 and v1alpha1

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
