### PR TITLE
Ignore .idea/ folder created by Goland IDE

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ goimports-check
 vet
 whitespace
 whitespace-check
+
+# Goland IDE folder
+.idea/


### PR DESCRIPTION
Goland creates it's config folder .idea/ in project directory, which makes the developers
remember not to `git add` this folder when preparing  a PR.
Let's ignore this folder and forget about it.

Signed-off-by: Radim Hrazdil <rhrazdil@redhat.com>

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
