### PR TITLE
Fix manifest link versioning in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,16 +249,16 @@ spec:
 First install the operator itself:
 
 ```shell
-kubectl apply -f https://raw.githubusercontent.com/kubevirt/cluster-network-addons-operator/master/manifests/cluster-network-addons/0.42.0/namespace.yaml
-kubectl apply -f https://raw.githubusercontent.com/kubevirt/cluster-network-addons-operator/master/manifests/cluster-network-addons/0.42.0/network-addons-config.crd.yaml
-kubectl apply -f https://raw.githubusercontent.com/kubevirt/cluster-network-addons-operator/master/manifests/cluster-network-addons/0.42.0/operator.yaml
+kubectl apply -f https://github.com/kubevirt/cluster-network-addons-operator/releases/download/v0.42.0/namespace.yaml
+kubectl apply -f https://github.com/kubevirt/cluster-network-addons-operator/releases/download/v0.42.0/network-addons-config.crd.yaml
+kubectl apply -f https://github.com/kubevirt/cluster-network-addons-operator/releases/download/v0.42.0/operator.yaml
 ```
 
 Then you need to create a configuration for the operator [example
 CR](manifests/cluster-network-addons/0.4.0/network-addons-config-example.cr.yaml):
 
 ```shell
-kubectl apply -f https://raw.githubusercontent.com/kubevirt/cluster-network-addons-operator/master/manifests/cluster-network-addons/0.42.0/network-addons-config-example.cr.yaml
+kubectl apply -f https://github.com/kubevirt/cluster-network-addons-operator/releases/download/v0.42.0/network-addons-config-example.cr.yaml
 ```
 
 Finally you can wait for the operator to finish deployment:


### PR DESCRIPTION
Instead of using absolute path for linking manifests in
README.md, use links to released assets.

Signed-off-by: Radim Hrazdil <rhrazdil@redhat.com>

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
