### PR TITLE
crdCleanUp, Cleaning release after upgrade test

### DIFF
--- a/test/releases/0.16.0.go
+++ b/test/releases/0.16.0.go
@@ -62,6 +62,13 @@ func init() {
 			"network-addons-config.crd.yaml",
 			"operator.yaml",
 		},
+		CrdCleanUp: []string{
+			"network-attachment-definitions.k8s.cni.cncf.io",
+			"networkaddonsconfigs.networkaddonsoperator.network.kubevirt.io",
+			"nodenetworkconfigurationenactments.nmstate.io",
+			"nodenetworkconfigurationpolicies.nmstate.io",
+			"nodenetworkstates.nmstate.io",
+		},
 	}
 	releases = append(releases, release)
 }

--- a/test/releases/0.17.0.go
+++ b/test/releases/0.17.0.go
@@ -62,6 +62,13 @@ func init() {
 			"network-addons-config.crd.yaml",
 			"operator.yaml",
 		},
+		CrdCleanUp: []string{
+			"network-attachment-definitions.k8s.cni.cncf.io",
+			"networkaddonsconfigs.networkaddonsoperator.network.kubevirt.io",
+			"nodenetworkconfigurationenactments.nmstate.io",
+			"nodenetworkconfigurationpolicies.nmstate.io",
+			"nodenetworkstates.nmstate.io",
+		},
 	}
 	releases = append(releases, release)
 }

--- a/test/releases/0.18.0.go
+++ b/test/releases/0.18.0.go
@@ -62,6 +62,13 @@ func init() {
 			"network-addons-config.crd.yaml",
 			"operator.yaml",
 		},
+		CrdCleanUp: []string{
+			"network-attachment-definitions.k8s.cni.cncf.io",
+			"networkaddonsconfigs.networkaddonsoperator.network.kubevirt.io",
+			"nodenetworkconfigurationenactments.nmstate.io",
+			"nodenetworkconfigurationpolicies.nmstate.io",
+			"nodenetworkstates.nmstate.io",
+		},
 	}
 	releases = append(releases, release)
 }

--- a/test/releases/0.19.0.go
+++ b/test/releases/0.19.0.go
@@ -62,6 +62,13 @@ func init() {
 			"network-addons-config.crd.yaml",
 			"operator.yaml",
 		},
+		CrdCleanUp: []string{
+			"network-attachment-definitions.k8s.cni.cncf.io",
+			"networkaddonsconfigs.networkaddonsoperator.network.kubevirt.io",
+			"nodenetworkconfigurationenactments.nmstate.io",
+			"nodenetworkconfigurationpolicies.nmstate.io",
+			"nodenetworkstates.nmstate.io",
+		},
 	}
 	releases = append(releases, release)
 }

--- a/test/releases/0.20.0.go
+++ b/test/releases/0.20.0.go
@@ -62,6 +62,13 @@ func init() {
 			"network-addons-config.crd.yaml",
 			"operator.yaml",
 		},
+		CrdCleanUp: []string{
+			"network-attachment-definitions.k8s.cni.cncf.io",
+			"networkaddonsconfigs.networkaddonsoperator.network.kubevirt.io",
+			"nodenetworkconfigurationenactments.nmstate.io",
+			"nodenetworkconfigurationpolicies.nmstate.io",
+			"nodenetworkstates.nmstate.io",
+		},
 	}
 	releases = append(releases, release)
 }

--- a/test/releases/0.21.0.go
+++ b/test/releases/0.21.0.go
@@ -62,6 +62,13 @@ func init() {
 			"network-addons-config.crd.yaml",
 			"operator.yaml",
 		},
+		CrdCleanUp: []string{
+			"network-attachment-definitions.k8s.cni.cncf.io",
+			"networkaddonsconfigs.networkaddonsoperator.network.kubevirt.io",
+			"nodenetworkconfigurationenactments.nmstate.io",
+			"nodenetworkconfigurationpolicies.nmstate.io",
+			"nodenetworkstates.nmstate.io",
+		},
 	}
 	releases = append(releases, release)
 }

--- a/test/releases/0.22.0.go
+++ b/test/releases/0.22.0.go
@@ -62,6 +62,13 @@ func init() {
 			"network-addons-config.crd.yaml",
 			"operator.yaml",
 		},
+		CrdCleanUp: []string{
+			"network-attachment-definitions.k8s.cni.cncf.io",
+			"networkaddonsconfigs.networkaddonsoperator.network.kubevirt.io",
+			"nodenetworkconfigurationenactments.nmstate.io",
+			"nodenetworkconfigurationpolicies.nmstate.io",
+			"nodenetworkstates.nmstate.io",
+		},
 	}
 	releases = append(releases, release)
 }

--- a/test/releases/0.23.0.go
+++ b/test/releases/0.23.0.go
@@ -62,6 +62,13 @@ func init() {
 			"network-addons-config.crd.yaml",
 			"operator.yaml",
 		},
+		CrdCleanUp: []string{
+			"network-attachment-definitions.k8s.cni.cncf.io",
+			"networkaddonsconfigs.networkaddonsoperator.network.kubevirt.io",
+			"nodenetworkconfigurationenactments.nmstate.io",
+			"nodenetworkconfigurationpolicies.nmstate.io",
+			"nodenetworkstates.nmstate.io",
+		},
 	}
 	releases = append(releases, release)
 }

--- a/test/releases/0.24.0.go
+++ b/test/releases/0.24.0.go
@@ -62,6 +62,13 @@ func init() {
 			"network-addons-config.crd.yaml",
 			"operator.yaml",
 		},
+		CrdCleanUp: []string{
+			"network-attachment-definitions.k8s.cni.cncf.io",
+			"networkaddonsconfigs.networkaddonsoperator.network.kubevirt.io",
+			"nodenetworkconfigurationenactments.nmstate.io",
+			"nodenetworkconfigurationpolicies.nmstate.io",
+			"nodenetworkstates.nmstate.io",
+		},
 	}
 	releases = append(releases, release)
 }

--- a/test/releases/0.25.0.go
+++ b/test/releases/0.25.0.go
@@ -62,6 +62,13 @@ func init() {
 			"network-addons-config.crd.yaml",
 			"operator.yaml",
 		},
+		CrdCleanUp: []string{
+			"network-attachment-definitions.k8s.cni.cncf.io",
+			"networkaddonsconfigs.networkaddonsoperator.network.kubevirt.io",
+			"nodenetworkconfigurationenactments.nmstate.io",
+			"nodenetworkconfigurationpolicies.nmstate.io",
+			"nodenetworkstates.nmstate.io",
+		},
 	}
 	releases = append(releases, release)
 }

--- a/test/releases/0.26.0.go
+++ b/test/releases/0.26.0.go
@@ -62,6 +62,13 @@ func init() {
 			"network-addons-config.crd.yaml",
 			"operator.yaml",
 		},
+		CrdCleanUp: []string{
+			"network-attachment-definitions.k8s.cni.cncf.io",
+			"networkaddonsconfigs.networkaddonsoperator.network.kubevirt.io",
+			"nodenetworkconfigurationenactments.nmstate.io",
+			"nodenetworkconfigurationpolicies.nmstate.io",
+			"nodenetworkstates.nmstate.io",
+		},
 	}
 	releases = append(releases, release)
 }

--- a/test/releases/0.27.7.go
+++ b/test/releases/0.27.7.go
@@ -68,6 +68,13 @@ func init() {
 			"network-addons-config.crd.yaml",
 			"operator.yaml",
 		},
+		CrdCleanUp: []string{
+			"network-attachment-definitions.k8s.cni.cncf.io",
+			"networkaddonsconfigs.networkaddonsoperator.network.kubevirt.io",
+			"nodenetworkconfigurationenactments.nmstate.io",
+			"nodenetworkconfigurationpolicies.nmstate.io",
+			"nodenetworkstates.nmstate.io",
+		},
 	}
 	releases = append(releases, release)
 }

--- a/test/releases/0.28.0.go
+++ b/test/releases/0.28.0.go
@@ -68,6 +68,13 @@ func init() {
 			"network-addons-config.crd.yaml",
 			"operator.yaml",
 		},
+		CrdCleanUp: []string{
+			"network-attachment-definitions.k8s.cni.cncf.io",
+			"networkaddonsconfigs.networkaddonsoperator.network.kubevirt.io",
+			"nodenetworkconfigurationenactments.nmstate.io",
+			"nodenetworkconfigurationpolicies.nmstate.io",
+			"nodenetworkstates.nmstate.io",
+		},
 	}
 	releases = append(releases, release)
 }

--- a/test/releases/0.29.0.go
+++ b/test/releases/0.29.0.go
@@ -68,6 +68,13 @@ func init() {
 			"network-addons-config.crd.yaml",
 			"operator.yaml",
 		},
+		CrdCleanUp: []string{
+			"network-attachment-definitions.k8s.cni.cncf.io",
+			"networkaddonsconfigs.networkaddonsoperator.network.kubevirt.io",
+			"nodenetworkconfigurationenactments.nmstate.io",
+			"nodenetworkconfigurationpolicies.nmstate.io",
+			"nodenetworkstates.nmstate.io",
+		},
 	}
 	releases = append(releases, release)
 }

--- a/test/releases/0.30.0.go
+++ b/test/releases/0.30.0.go
@@ -68,6 +68,13 @@ func init() {
 			"network-addons-config.crd.yaml",
 			"operator.yaml",
 		},
+		CrdCleanUp: []string{
+			"network-attachment-definitions.k8s.cni.cncf.io",
+			"networkaddonsconfigs.networkaddonsoperator.network.kubevirt.io",
+			"nodenetworkconfigurationenactments.nmstate.io",
+			"nodenetworkconfigurationpolicies.nmstate.io",
+			"nodenetworkstates.nmstate.io",
+		},
 	}
 	releases = append(releases, release)
 }

--- a/test/releases/0.31.0.go
+++ b/test/releases/0.31.0.go
@@ -68,6 +68,13 @@ func init() {
 			"network-addons-config.crd.yaml",
 			"operator.yaml",
 		},
+		CrdCleanUp: []string{
+			"network-attachment-definitions.k8s.cni.cncf.io",
+			"networkaddonsconfigs.networkaddonsoperator.network.kubevirt.io",
+			"nodenetworkconfigurationenactments.nmstate.io",
+			"nodenetworkconfigurationpolicies.nmstate.io",
+			"nodenetworkstates.nmstate.io",
+		},
 	}
 	releases = append(releases, release)
 }

--- a/test/releases/0.32.0.go
+++ b/test/releases/0.32.0.go
@@ -68,6 +68,13 @@ func init() {
 			"network-addons-config.crd.yaml",
 			"operator.yaml",
 		},
+		CrdCleanUp: []string{
+			"network-attachment-definitions.k8s.cni.cncf.io",
+			"networkaddonsconfigs.networkaddonsoperator.network.kubevirt.io",
+			"nodenetworkconfigurationenactments.nmstate.io",
+			"nodenetworkconfigurationpolicies.nmstate.io",
+			"nodenetworkstates.nmstate.io",
+		},
 	}
 	releases = append(releases, release)
 }

--- a/test/releases/0.33.0.go
+++ b/test/releases/0.33.0.go
@@ -68,6 +68,13 @@ func init() {
 			"network-addons-config.crd.yaml",
 			"operator.yaml",
 		},
+		CrdCleanUp: []string{
+			"network-attachment-definitions.k8s.cni.cncf.io",
+			"networkaddonsconfigs.networkaddonsoperator.network.kubevirt.io",
+			"nodenetworkconfigurationenactments.nmstate.io",
+			"nodenetworkconfigurationpolicies.nmstate.io",
+			"nodenetworkstates.nmstate.io",
+		},
 	}
 	releases = append(releases, release)
 }

--- a/test/releases/0.34.0.go
+++ b/test/releases/0.34.0.go
@@ -68,6 +68,13 @@ func init() {
 			"network-addons-config.crd.yaml",
 			"operator.yaml",
 		},
+		CrdCleanUp: []string{
+			"network-attachment-definitions.k8s.cni.cncf.io",
+			"networkaddonsconfigs.networkaddonsoperator.network.kubevirt.io",
+			"nodenetworkconfigurationenactments.nmstate.io",
+			"nodenetworkconfigurationpolicies.nmstate.io",
+			"nodenetworkstates.nmstate.io",
+		},
 	}
 	releases = append(releases, release)
 }

--- a/test/releases/0.35.0.go
+++ b/test/releases/0.35.0.go
@@ -68,6 +68,13 @@ func init() {
 			"network-addons-config.crd.yaml",
 			"operator.yaml",
 		},
+		CrdCleanUp: []string{
+			"network-attachment-definitions.k8s.cni.cncf.io",
+			"networkaddonsconfigs.networkaddonsoperator.network.kubevirt.io",
+			"nodenetworkconfigurationenactments.nmstate.io",
+			"nodenetworkconfigurationpolicies.nmstate.io",
+			"nodenetworkstates.nmstate.io",
+		},
 	}
 	releases = append(releases, release)
 }

--- a/test/releases/0.35.1.go
+++ b/test/releases/0.35.1.go
@@ -68,6 +68,13 @@ func init() {
 			"network-addons-config.crd.yaml",
 			"operator.yaml",
 		},
+		CrdCleanUp: []string{
+			"network-attachment-definitions.k8s.cni.cncf.io",
+			"networkaddonsconfigs.networkaddonsoperator.network.kubevirt.io",
+			"nodenetworkconfigurationenactments.nmstate.io",
+			"nodenetworkconfigurationpolicies.nmstate.io",
+			"nodenetworkstates.nmstate.io",
+		},
 	}
 	releases = append(releases, release)
 }

--- a/test/releases/0.36.0.go
+++ b/test/releases/0.36.0.go
@@ -62,6 +62,13 @@ func init() {
 			"network-addons-config.crd.yaml",
 			"operator.yaml",
 		},
+		CrdCleanUp: []string{
+			"network-attachment-definitions.k8s.cni.cncf.io",
+			"networkaddonsconfigs.networkaddonsoperator.network.kubevirt.io",
+			"nodenetworkconfigurationenactments.nmstate.io",
+			"nodenetworkconfigurationpolicies.nmstate.io",
+			"nodenetworkstates.nmstate.io",
+		},
 	}
 	releases = append(releases, release)
 }

--- a/test/releases/0.38.0.go
+++ b/test/releases/0.38.0.go
@@ -62,6 +62,13 @@ func init() {
 			"network-addons-config.crd.yaml",
 			"operator.yaml",
 		},
+		CrdCleanUp: []string{
+			"network-attachment-definitions.k8s.cni.cncf.io",
+			"networkaddonsconfigs.networkaddonsoperator.network.kubevirt.io",
+			"nodenetworkconfigurationenactments.nmstate.io",
+			"nodenetworkconfigurationpolicies.nmstate.io",
+			"nodenetworkstates.nmstate.io",
+		},
 	}
 	releases = append(releases, release)
 }

--- a/test/releases/0.39.3.go
+++ b/test/releases/0.39.3.go
@@ -62,6 +62,13 @@ func init() {
 			"network-addons-config.crd.yaml",
 			"operator.yaml",
 		},
+		CrdCleanUp: []string{
+			"network-attachment-definitions.k8s.cni.cncf.io",
+			"networkaddonsconfigs.networkaddonsoperator.network.kubevirt.io",
+			"nodenetworkconfigurationenactments.nmstate.io",
+			"nodenetworkconfigurationpolicies.nmstate.io",
+			"nodenetworkstates.nmstate.io",
+		},
 	}
 	releases = append(releases, release)
 }

--- a/test/releases/0.40.0.go
+++ b/test/releases/0.40.0.go
@@ -68,6 +68,13 @@ func init() {
 			"network-addons-config.crd.yaml",
 			"operator.yaml",
 		},
+		CrdCleanUp: []string{
+			"network-attachment-definitions.k8s.cni.cncf.io",
+			"networkaddonsconfigs.networkaddonsoperator.network.kubevirt.io",
+			"nodenetworkconfigurationenactments.nmstate.io",
+			"nodenetworkconfigurationpolicies.nmstate.io",
+			"nodenetworkstates.nmstate.io",
+		},
 	}
 	releases = append(releases, release)
 }

--- a/test/releases/0.40.1.go
+++ b/test/releases/0.40.1.go
@@ -68,6 +68,13 @@ func init() {
 			"network-addons-config.crd.yaml",
 			"operator.yaml",
 		},
+		CrdCleanUp: []string{
+			"network-attachment-definitions.k8s.cni.cncf.io",
+			"networkaddonsconfigs.networkaddonsoperator.network.kubevirt.io",
+			"nodenetworkconfigurationenactments.nmstate.io",
+			"nodenetworkconfigurationpolicies.nmstate.io",
+			"nodenetworkstates.nmstate.io",
+		},
 	}
 	releases = append(releases, release)
 }

--- a/test/releases/0.41.0.go
+++ b/test/releases/0.41.0.go
@@ -68,6 +68,13 @@ func init() {
 			"network-addons-config.crd.yaml",
 			"operator.yaml",
 		},
+		CrdCleanUp: []string{
+			"network-attachment-definitions.k8s.cni.cncf.io",
+			"networkaddonsconfigs.networkaddonsoperator.network.kubevirt.io",
+			"nodenetworkconfigurationenactments.nmstate.io",
+			"nodenetworkconfigurationpolicies.nmstate.io",
+			"nodenetworkstates.nmstate.io",
+		},
 	}
 	releases = append(releases, release)
 }

--- a/test/releases/0.42.0.go
+++ b/test/releases/0.42.0.go
@@ -68,6 +68,13 @@ func init() {
 			"network-addons-config.crd.yaml",
 			"operator.yaml",
 		},
+		CrdCleanUp: []string{
+			"network-attachment-definitions.k8s.cni.cncf.io",
+			"networkaddonsconfigs.networkaddonsoperator.network.kubevirt.io",
+			"nodenetworkconfigurationenactments.nmstate.io",
+			"nodenetworkconfigurationpolicies.nmstate.io",
+			"nodenetworkstates.nmstate.io",
+		},
 	}
 	releases = append(releases, release)
 }

--- a/test/releases/99.0.0.go
+++ b/test/releases/99.0.0.go
@@ -68,6 +68,13 @@ func init() {
 			"network-addons-config.crd.yaml",
 			"operator.yaml",
 		},
+		CrdCleanUp: []string{
+			"network-attachment-definitions.k8s.cni.cncf.io",
+			"networkaddonsconfigs.networkaddonsoperator.network.kubevirt.io",
+			"nodenetworkconfigurationenactments.nmstate.io",
+			"nodenetworkconfigurationpolicies.nmstate.io",
+			"nodenetworkstates.nmstate.io",
+		},
 	}
 	releases = append(releases, release)
 }

--- a/test/releases/releases.go
+++ b/test/releases/releases.go
@@ -28,6 +28,8 @@ type Release struct {
 	SupportedSpec cnao.NetworkAddonsConfigSpec
 	// Manifest that can be used to install the operator in given release
 	Manifests []string
+	// CrdCleanUp is used to uninstall CRDs between upgrade tests
+	CrdCleanUp []string
 }
 
 // Releases are populated by respective release modules using init()
@@ -110,6 +112,12 @@ func UninstallRelease(release Release) {
 		out, err := Kubectl("delete", "--ignore-not-found", "-f", "_out/cluster-network-addons/"+release.Version+"/"+manifestName)
 		Expect(err).NotTo(HaveOccurred(), out)
 	}
+
+	for _, crdInstance := range release.CrdCleanUp {
+		out, err := Kubectl("delete", "crd", "--ignore-not-found", crdInstance)
+		Expect(err).NotTo(HaveOccurred(), out)
+	}
+
 }
 
 // Installs given release (RBAC and Deployment)


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently, after cnao is uninstalled, the crd's
of it's components are not deleted.
This causes a "downgrade" situation when
upgrade test move from 1 test to the other.
For example, in the first test, release is upgraded
from old version to current version, but in the next test
the old version is not been able to be set because the new crd's
are still there.

In order to solve this, and since CNAO is not supporting downgrades,
we are attempting to remove the crds manually after each upgrade test.

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
