### PR TITLE
bumper, Add bumper make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -182,6 +182,9 @@ vendor: $(GO)
 	$(GO) mod tidy
 	$(GO) mod vendor
 
+auto-bumper:
+	$(GO) run $(shell ls tools/bumper/*.go | grep -v test) ${ARGS}
+
 bump-%:
 	CNAO_VERSION=${VERSION} ./hack/components/bump-$*.sh
 bump-all: bump-knmstate bump-kubemacpool bump-macvtap bump-linux-bridge bump-multus bump-ovs-cni bump-bridge-marker
@@ -212,6 +215,7 @@ bump-all: bump-knmstate bump-kubemacpool bump-macvtap bump-linux-bridge bump-mul
 	prepare-minor \
 	prepare-major \
 	vendor \
+	auto-bumper \
 	bump-% \
 	bump-all \
 	gen-k8s \

--- a/tools/bumper/README.md
+++ b/tools/bumper/README.md
@@ -2,9 +2,12 @@
 
 The Bumper script goes over all of CNAO's components, using the components.yaml config, finds new releases and bumps them in separate PRs. The script can be run locally or via an automation such as GitHub Actions.
 
+## Running the script manually
+
+In order to run the script manually, you need to have a github token. To create a token in your github user, follow this [guide](https://docs.github.com/en/free-pro-team@latest/github/authenticating-to-github/creating-a-personal-access-token).
+
 ## How to run the script
 
 ```
-go build $GOPATH/src/github.com/kubevirt/cluster-network-addons-operator/tools/bumper
-./bumper -config-path=<path-to-components.yaml> -token=<git-token>
+make ARGS="-config-path=<path-to-components.yaml> -token=<git-token>" auto-bumper
 ```


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently running bumper script requires 2 commands.
The bumper exec output is added to the main directory
and may be mistakenly added to the project.

Let's change the command to run with 'go run',
and move it to a Makefile target for better usability
README is updated accordingly.
Also we add a link to how to produce a github token in README

Also added a link to token creation in case
of running script manually

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
