### PR TITLE
validation test, Fix flaky in It("should remain at Available condition")

### DIFF
--- a/test/e2e/workflow/validation_test.go
+++ b/test/e2e/workflow/validation_test.go
@@ -56,12 +56,12 @@ var _ = Describe("NetworkAddonsConfig", func() {
 			})
 
 			It("should remain at Available condition", func() {
-				components := []Component{NMStateComponent}
-				CheckComponentsRemoval(components)
+				By("Waiting for Modified event after config update")
+				CheckModifiedEvent(gvk)
 
-				By("Checking that Available status turn to True after config update")
-				CheckConfigCondition(gvk, ConditionAvailable, ConditionTrue, time.Minute, time.Minute)
-				By("Checking that Degraded status turn to False after config update")
+				By("Checking that Available status turn to True")
+				CheckConfigCondition(gvk, ConditionAvailable, ConditionTrue, CheckImmediately, time.Minute)
+				By("Checking that Degraded status turn to False")
 				CheckConfigCondition(gvk, ConditionDegraded, ConditionFalse, CheckImmediately, time.Minute)
 			})
 		})


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR tries to fix issue #523 

- **validation test, Fix flaky in It("should remain at Available condition")**
The cause of the flaky is that the config status is
checked before the change is performed.
Moving to waiting on the modified event should solve this.

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
