### PR TITLE
bumper, Add stdout to exec output

### DIFF
--- a/tools/bumper/bumper.go
+++ b/tools/bumper/bumper.go
@@ -90,9 +90,12 @@ func main() {
 				exitWithError(errors.Wrap(err, "Failed to update components yaml"))
 			}
 
+			logger.Printf("Running bump-%s script", componentName)
 			cmd := exec.Command("make", fmt.Sprintf("bump-%s", componentName))
-			if out, err := cmd.CombinedOutput(); err != nil {
-				exitWithError(errors.Wrapf(err, "Failed to run bump script. StdOut = %s", string(out)))
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			if err := cmd.Run(); err != nil {
+				exitWithError(errors.Wrapf(err, "Failed to run bump script, \nStdout:\n%s\nStderr:\n%s", cmd.Stdout, cmd.Stderr))
 			}
 
 			// create a new branch name

--- a/tools/bumper/parser.go
+++ b/tools/bumper/parser.go
@@ -44,7 +44,7 @@ func parseComponentsYaml(componentsConfigPath string) (componentsConfig, error) 
 }
 
 func updateComponentsYaml(componentsConfigPath string, config componentsConfig) error {
-	logger.Printf("Marshaling components config")
+	logger.Printf("updating components config")
 	yamlConfig, err := yaml.Marshal(&config)
 	if err != nil {
 		return errors.Wrap(err, "Failed to marshal updated components config")


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds logging capabilities to the bumper script

- **bumper, , Fix updateComponentsYaml log**
this commit is a minor fix in log text
in updateComponentsYaml method.

- **bumper, Change running command of bump exec**
Currently, running of 'make bump-<component>'
is only displayed if there is an error.
In order to improve logging visibility,
we want to always show the exec output.
This will improve debugging in the future.

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
