### PR TITLE
Fix installation of bridge and tuning CNIs

### DIFF
--- a/data/linux-bridge/002-linux-bridge.yaml
+++ b/data/linux-bridge/002-linux-bridge.yaml
@@ -32,14 +32,15 @@ spec:
             - /bin/bash
             - -c
             - |
-              cp -rf /usr/src/containernetworking/plugins/bin/*bridge /opt/cni/bin/
-              cp -rf /usr/src/containernetworking/plugins/bin/*tuning /opt/cni/bin/
+              echo 'Installing bridge and tuning CNIs'
+              cp -f /usr/src/containernetworking/plugins/bin/*bridge /opt/cni/bin/
+              cp -f /usr/src/containernetworking/plugins/bin/*tuning /opt/cni/bin/
               # Some projects (e.g. openshift/console) use cnv- prefix to distinguish between
               # binaries shipped by OpenShift and those shipped by KubeVirt (D/S matters).
               # Following two lines make sure we will provide both names when needed.
-              find /opt/cni/bin/cnv-bridge || ln -s /opt/cni/bin/bridge /opt/cni/bin/cnv-bridge
-              find /opt/cni/bin/cnv-tuning || ln -s /opt/cni/bin/tuning /opt/cni/bin/cnv-tuning
-              echo "Entering sleep... (success)"
+              find /opt/cni/bin/cnv-bridge &>/dev/null || ln -s /opt/cni/bin/bridge {{ .CNIBinDir }}/cnv-bridge
+              find /opt/cni/bin/cnv-tuning &>/dev/null || ln -s /opt/cni/bin/tuning {{ .CNIBinDir }}/cnv-tuning
+              echo 'Entering sleep... (success)'
               sleep infinity
           resources:
             requests:
@@ -49,7 +50,7 @@ spec:
             privileged: true
           volumeMounts:
             - name: cnibin
-              mountPath: /opt/cni/bin
+              mountPath: {{ .CNIBinDir }}
       volumes:
         - name: cnibin
           hostPath:

--- a/hack/components/bump-linux-bridge.sh
+++ b/hack/components/bump-linux-bridge.sh
@@ -22,7 +22,7 @@ echo 'Get linux-bridge tag'
 LINUX_BRIDGE_TAG=$(git-utils::get_component_tag ${LINUX_BRIDGE_PATH})
 
 echo 'Build container image with linux-bridge binaries'
-LINUX_BRIDGE_TAR_CONTAINER_DIR=/usr/src/github.com/containernetworking/plugins/bin
+LINUX_BRIDGE_TAR_CONTAINER_DIR=/usr/src/containernetworking/plugins/bin
 LINUX_BRIDGE_TAR_FILE=cni-plugins-linux-amd64-${LINUX_BRIDGE_TAG}.tgz
 LINUX_BRIDGE_IMAGE=quay.io/kubevirt/cni-default-plugins
 LINUX_BRIDGE_IMAGE_TAGGED=${LINUX_BRIDGE_IMAGE}:${LINUX_BRIDGE_TAG}


### PR DESCRIPTION


<!-- Thanks for sending a pull request!

Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the master branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it

If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**What this PR does / why we need it**:

We have two serious bugs in the bridge CNI.

One, we never installed our own bridge and tuning CNI, since the source
of our copy was not matching directories used in the CNI plugins
container image. The only reason why this worked so far is that we were
able to consume these plugins from the Multus deployment.

Second, the symlink making sure that we always have an alias to these
CNIs prefixed with cnv- was not working on OpenShift. The reason is that
on OpenShift, the directory containing CNI binaries is different, but
our `ln` did not respect that.

Signed-off-by: Petr Horacek <phoracek@redhat.com>

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
Fix installation of bridge CNI on OpenShift
```
