### PR TITLE
specialCleanUp, Fix reset cause by []error{nil}

### DIFF
--- a/pkg/network/network.go
+++ b/pkg/network/network.go
@@ -233,7 +233,9 @@ func RenderObjsToRemove(prev, conf *cnao.NetworkAddonsConfigSpec, manifestDir st
 func errorListToMultiLineString(errs []error) string {
 	stringErrs := []string{}
 	for _, err := range errs {
-		stringErrs = append(stringErrs, err.Error())
+		if err != nil {
+			stringErrs = append(stringErrs, err.Error())
+		}
 	}
 	return strings.Join(stringErrs, "\n")
 }

--- a/pkg/network/nmstate.go
+++ b/pkg/network/nmstate.go
@@ -45,11 +45,7 @@ func renderNMState(conf *cnao.NetworkAddonsConfigSpec, manifestDir string, clust
 	return objs, nil
 }
 
-func cleanUpNMState(conf *cnao.NetworkAddonsConfigSpec, ctx context.Context, client k8sclient.Client) []error {
-	if conf.NMState == nil {
-		return nil
-	}
-
+func removeDaemonSetHandlerWorker(ctx context.Context, client k8sclient.Client) []error {
 	// Get existing
 	existing := &unstructured.Unstructured{}
 	gvk := schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "DaemonSet"}
@@ -72,8 +68,18 @@ func cleanUpNMState(conf *cnao.NetworkAddonsConfigSpec, ctx context.Context, cli
 
 	} else if apierrors.IsNotFound(err) {
 		// object not found, no need for action.
-		return nil
+		return []error{}
+	}
+	return []error{}
+}
+
+func cleanUpNMState(conf *cnao.NetworkAddonsConfigSpec, ctx context.Context, client k8sclient.Client) []error {
+	if conf.NMState == nil {
+		return []error{}
 	}
 
-	return []error{err}
+	errList := []error{}
+	errList = append(errList, removeDaemonSetHandlerWorker(ctx, client)...)
+
+	return errList
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently, if cleanUpMultusOldName returns nil,
it gets appended to the errList, and since
len([]error{nil}) != 0, it tried to access
Error() method of nil.
Let's fix this by making sure we are not
appending nil to the list, and also by adding a
protection in errorListToMultiLineString

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
