### PR TITLE
bump ovs-cni to v0.14.0

### DIFF
--- a/components.yaml
+++ b/components.yaml
@@ -37,7 +37,7 @@ components:
     metadata: v0.31.0
   ovs-cni:
     url: https://github.com/kubevirt/ovs-cni
-    commit: 973a42b03f553234add72a909fd262560be61237
+    commit: 5e9b39a7d83192bac2adef982dd5c6200d96d6b0
     branch: master
     update-policy: tagged
-    metadata: v0.13.0
+    metadata: v0.14.0

--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -30,8 +30,8 @@ const (
 	LinuxBridgeMarkerImageDefault = "quay.io/kubevirt/bridge-marker@sha256:99d0fbd707deaf2136968aaa34862b54c73c9e5e963dc44140e726cf9ad41b58"
 	KubeMacPoolImageDefault       = "quay.io/kubevirt/kubemacpool@sha256:79c4534d418c4a350a663e38499c22d54dc68c400f517aead4479f6d862b408e"
 	NMStateHandlerImageDefault    = "quay.io/nmstate/kubernetes-nmstate-handler@sha256:444ab3349882ac58f594396529708146993b831c2e3e1d524eaa12e17e09f150"
-	OvsCniImageDefault            = "quay.io/kubevirt/ovs-cni-plugin@sha256:b4a2a9bcbde3f8b5f24e0ae957fedca57201c91bc9645459a49f0b954057b22b"
-	OvsMarkerImageDefault         = "quay.io/kubevirt/ovs-cni-marker@sha256:1e0a8c6ba54db8e0a4c6ed926bed25e3a272a4db883805a1af020beba131f999"
+	OvsCniImageDefault            = "quay.io/kubevirt/ovs-cni-plugin@sha256:283fcdff34b6dc726f88a7c4a6a0cbc35f8779960d54d69e54845c37f5da3121"
+	OvsMarkerImageDefault         = "quay.io/kubevirt/ovs-cni-marker@sha256:e377a4bd0119de9363fc4a3772bf320afb95f36e10c034cf19b86de47e7fcca3"
 	MacvtapCniImageDefault        = "quay.io/kubevirt/macvtap-cni@sha256:0fbb0f3cde7970c0786aec8213bbf28a9d6328e7644d965262783a8248a9ded9"
 )
 

--- a/test/releases/99.0.0.go
+++ b/test/releases/99.0.0.go
@@ -48,13 +48,13 @@ func init() {
 				ParentName: "ovs-cni-amd64",
 				ParentKind: "DaemonSet",
 				Name:       "ovs-cni-plugin",
-				Image:      "quay.io/kubevirt/ovs-cni-plugin@sha256:b4a2a9bcbde3f8b5f24e0ae957fedca57201c91bc9645459a49f0b954057b22b",
+				Image:      "quay.io/kubevirt/ovs-cni-plugin@sha256:283fcdff34b6dc726f88a7c4a6a0cbc35f8779960d54d69e54845c37f5da3121",
 			},
 			{
 				ParentName: "ovs-cni-amd64",
 				ParentKind: "DaemonSet",
 				Name:       "ovs-cni-marker",
-				Image:      "quay.io/kubevirt/ovs-cni-marker@sha256:1e0a8c6ba54db8e0a4c6ed926bed25e3a272a4db883805a1af020beba131f999",
+				Image:      "quay.io/kubevirt/ovs-cni-marker@sha256:e377a4bd0119de9363fc4a3772bf320afb95f36e10c034cf19b86de47e7fcca3",
 			},
 		},
 		SupportedSpec: cnao.NetworkAddonsConfigSpec{


### PR DESCRIPTION
bump ovs-cni to v0.14.0
Executed by Bumper script

```release-note
bump ovs-cni to v0.14.0
```