### PR TITLE
bumper, Add resetRepoInAllowedList to remove bump outputs

### DIFF
--- a/tools/bumper/bumper.go
+++ b/tools/bumper/bumper.go
@@ -79,42 +79,55 @@ func main() {
 
 		if componentBumpNeeded {
 			logger.Printf("Bumping %s from %s to %s", componentName, currentReleaseTag, updatedReleaseTag)
-			// reset --hard git repo
-			exitWithError(fmt.Errorf("reset --hader repo not implemented yet"))
 
-			// Create PR
-			exitWithError(fmt.Errorf("create PR not implemented yet"))
-
-			// update components yaml in the bumping repo instance
-			componentsConfig, err := cnaoRepo.getComponentsConfig(inputArgs.componentsConfigPath)
-			if err != nil {
-				exitWithError(errors.Wrap(err, "Failed to get components config during bump"))
-			}
-
-			// update component's entry in config yaml
-			component.Commit = updatedReleaseCommit
-			component.Metadata = updatedReleaseTag
-			componentsConfig.Components[componentName] = component
-			err = cnaoRepo.updateComponentsConfig(inputArgs.componentsConfigPath, componentsConfig)
-			if err != nil {
-				exitWithError(errors.Wrap(err, "Failed to update components yaml"))
-			}
-
-			err = cnaoRepo.bumpComponent(componentName)
+			err = handleBump(cnaoRepo, component, componentName, inputArgs.componentsConfigPath, updatedReleaseTag, updatedReleaseCommit, proposedPrTitle)
 			if err != nil {
 				exitWithError(errors.Wrapf(err, "Failed to bump component %s", componentName))
 			}
-
-			// create a new branch name
-			branchName := strings.Replace(strings.ToLower(proposedPrTitle), " ", "_", -1)
-			logger.Printf("Opening new Branch %s", branchName)
-
-			// push branch to PR
-			exitWithError(fmt.Errorf("push branch to PR not implemented yet"))
 		} else {
 			logger.Printf("Bump not needed in component %s", componentName)
 		}
 	}
+}
+
+func handleBump(cnaoRepo *gitCnaoRepo, component component, componentName, componentsConfigPath, updatedReleaseTag, updatedReleaseCommit, proposedPrTitle string) error {
+	defer func() {
+		err := cnaoRepo.reset()
+		if err != nil {
+			exitWithError(errors.Wrapf(err, "Failed to bump component %s: reset repo failed", componentName))
+		}
+	}()
+
+	// Create PR
+	exitWithError(fmt.Errorf("create PR not implemented yet"))
+
+	// update components yaml in the bumping repo instance
+	componentsConfig, err := cnaoRepo.getComponentsConfig(componentsConfigPath)
+	if err != nil {
+		return errors.Wrap(err, "Failed to get components config during bump")
+	}
+
+	// update component's entry in config yaml
+	component.Commit = updatedReleaseCommit
+	component.Metadata = updatedReleaseTag
+	componentsConfig.Components[componentName] = component
+	err = cnaoRepo.updateComponentsConfig(componentsConfigPath, componentsConfig)
+	if err != nil {
+		return errors.Wrap(err, "Failed to update components yaml")
+	}
+
+	err = cnaoRepo.bumpComponent(componentName)
+	if err != nil {
+		return errors.Wrap(err, "Failed to bump component")
+	}
+
+	// create a new branch name
+	branchName := strings.Replace(strings.ToLower(proposedPrTitle), " ", "_", -1)
+	logger.Printf("Opening new Branch %s", branchName)
+
+	// push branch to PR
+	exitWithError(fmt.Errorf("push branch to PR not implemented yet"))
+	return nil
 }
 
 func initLog() *log.Logger {


### PR DESCRIPTION
**What this PR does / why we need it**:
This method will be performed on the cnaoRepo instance
between each bumping of a component, to remove any bumping residue
Since bump output files are located in specific locations,
we add an allowList, to make sure only the bumping outputs
get removed.
Also adding a final resetRepoInAllowedList after all components
got bumped to finish the bumper script with no residual files.
In order to use the resetRepo function with defer, we move the
bump operation to a function.

**Special notes for your reviewer**:
PR depends on #616 to merge

**Release note**:

```release-note
NONE
```
