### PR TITLE
bumper, Add collectModifiedToTreeList to collect bump files

### DIFF
--- a/tools/bumper/bumper.go
+++ b/tools/bumper/bumper.go
@@ -121,6 +121,16 @@ func handleBump(cnaoRepo *gitCnaoRepo, component component, componentName, compo
 		return errors.Wrap(err, "Failed to bump component")
 	}
 
+	logger.Printf("Gather bump output files to list")
+	bumpFilesList, err := cnaoRepo.collectBumpFile()
+	if err != nil {
+		return errors.Wrap(err, "Failed to collect bump output files")
+	}
+	if len(bumpFilesList) == 0 {
+		logger.Printf("No modified/untracked files to bump. Aborting bump.")
+		return nil
+	}
+
 	// create a new branch name
 	branchName := strings.Replace(strings.ToLower(proposedPrTitle), " ", "_", -1)
 	logger.Printf("Opening new Branch %s", branchName)


### PR DESCRIPTION
**What this PR does / why we need it**:
Adding collectModifiedToTreeList that will collect the files
generated by the bump-<component> modified+untracked files
and add them to a githubTree List for future digest in githubApi.

**Special notes for your reviewer**:
depends on PR #617

**Release note**:

```release-note
NONE
```
