### PR TITLE
pin multus to 3.4.2 since latest version breaks CNAO

### DIFF
--- a/components.yaml
+++ b/components.yaml
@@ -27,7 +27,7 @@ components:
     url: https://github.com/intel/multus-cni
     commit: 4eac660359f223d34bcaf0fddbc42fd542f02ba1
     branch: master
-    update-policy: tagged
+    update-policy: static
     metadata: v3.4.2
   nmstate:
     url: https://github.com/nmstate/kubernetes-nmstate


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently latest multus version v3.6 breaks CNAO pods (open issue #621 ).
until this issue is resolved let's pin multus to v3.4.2

**Special notes for your reviewer**:

**Release note**:


```release-note
NONE
```
