### PR TITLE
bumper, Add go install make target dependency to auto-bumper in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -182,7 +182,7 @@ vendor: $(GO)
 	$(GO) mod tidy
 	$(GO) mod vendor
 
-auto-bumper:
+auto-bumper: $(GO)
 	$(GO) run $(shell ls tools/bumper/*.go | grep -v test) ${ARGS}
 
 bump-%:


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently auto-bumper will fail if go is not installed
Added the go install target dependency to fix that

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
