### PR TITLE
add linux-bridge pod description

### DIFF
--- a/data/linux-bridge/002-linux-bridge.yaml
+++ b/data/linux-bridge/002-linux-bridge.yaml
@@ -17,6 +17,8 @@ spec:
         name: kube-cni-linux-bridge-plugin
         tier: node
         app: cni-plugins
+      annotations:
+        description: LinuxBridge installs 'bridge' CNI on cluster nodes, so it can be later used to attach Pods/VMs to Linux bridges
     spec:
 {{ if .EnableSCC }}
       serviceAccountName: linux-bridge


### PR DESCRIPTION
**What this PR does / why we need it**:
Since linux-bridge manifest in created in CNAO repo
Added pod description to linux bridge pod in data/linux-bridge
manifest folder.

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
