### PR TITLE
bumper, Remove unsupported command from bumper script

### DIFF
--- a/tools/bumper/component_commands.go
+++ b/tools/bumper/component_commands.go
@@ -117,11 +117,6 @@ func newGithubApi(token string) (*githubApi, error) {
 		ctx:    ctx,
 	}
 
-	_, _, err := githubApi.client.Users.Get(ctx, "")
-	if err != nil {
-		return nil, errors.Wrapf(err, "Failed to get user from github client API")
-	}
-
 	return githubApi, nil
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR is meant to fix gitAction [job failing](https://github.com/kubevirt/cluster-network-addons-operator/runs/1304048168?check_suite_focus=true) on following error:
```
INFO: 2020/10/25 05:14:54 ~~~~~~~~Bumper Script~~~~~~~~
INFO: 2020/10/25 05:14:54 Exiting with Error: Failed to create github api instance: Failed to get user from github client API: GET https://api.github.com/user: 403 Resource not accessible by integration []
exit status 1
```

- **bumper, Remove unsupported command from bumper script**
Currently the bumper script gitAction fails.
This is because we attempt to get the githubAPI User
which is not supported by gitAction.
As this function is only meant to check the githubApi
valid connection, it is not necessary.
Removed from bumper script.

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
