### PR TITLE
fix cluster scripts

### DIFF
--- a/automation/components-functests.setup.sh
+++ b/automation/components-functests.setup.sh
@@ -19,7 +19,7 @@ set -exu
 
 source hack/components/git-utils.sh
 source hack/components/yaml-utils.sh
-source cluster/kubevirtci.sh
+source cluster/cluster.sh
 
 teardown() {
     make cluster-down
@@ -34,7 +34,7 @@ make cluster-down cluster-up
 
 # Export .kubeconfig full path, so it will be possible
 # to use 'kubectl' directly from the component directory path
-export KUBECONFIG=$(kubevirtci::kubeconfig)
+export KUBECONFIG=$(cluster::kubeconfig)
 
 # Deploy CNAO latest changes
 make cluster-operator-push

--- a/automation/components-functests.setup.sh
+++ b/automation/components-functests.setup.sh
@@ -41,7 +41,7 @@ make cluster-operator-push
 make cluster-operator-install
 
 # Deploy all network addons components with CNAO
-    cat <<EOF | kubectl apply -f -
+    cat <<EOF | cluster/kubectl.sh apply -f -
 apiVersion: networkaddonsoperator.network.kubevirt.io/v1alpha1
 kind: NetworkAddonsConfig
 metadata:
@@ -58,7 +58,7 @@ spec:
   imagePullPolicy: Always
 EOF
 
-kubectl wait networkaddonsconfig cluster --for condition=Available --timeout=13m
+cluster/kubectl.sh wait networkaddonsconfig cluster --for condition=Available --timeout=13m
 
 # Clone component repository
 component_url=$(yaml-utils::get_component_url ${COMPONENT})

--- a/cluster/cli.sh
+++ b/cluster/cli.sh
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 SCRIPTS_PATH="$(dirname "$(realpath "$0")")"
-source ${SCRIPTS_PATH}/kubevirtci.sh
-kubevirtci::install
+source ${SCRIPTS_PATH}/cluster.sh
+cluster::install
 
-$(kubevirtci::path)/cluster-up/cli.sh "$@"
+$(cluster::path)/cluster-up/cli.sh "$@"

--- a/cluster/cli.sh
+++ b/cluster/cli.sh
@@ -14,7 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-source ./cluster/kubevirtci.sh
+SCRIPTS_PATH="$(dirname "$(realpath "$0")")"
+source ${SCRIPTS_PATH}/kubevirtci.sh
 kubevirtci::install
 
 $(kubevirtci::path)/cluster-up/cli.sh "$@"

--- a/cluster/cluster.sh
+++ b/cluster/cluster.sh
@@ -15,10 +15,26 @@
 export KUBEVIRT_PROVIDER=${KUBEVIRT_PROVIDER:-'k8s-1.17'}
 
 KUBEVIRTCI_VERSION='0b941ea5dc647d3aea6f6a6fff95563d6ce0445e'
+KUBEVIRTCI_REPO='https://github.com/kubevirt/kubevirtci.git'
 # The CLUSTER_PATH var is used in cluster folder and points to the _kubevirtci where the cluster is deployed from.
 CLUSTER_PATH=${CLUSTER_PATH:-"${PWD}/_kubevirtci/"}
 
+function cluster::_get_repo() {
+    git --git-dir ${CLUSTER_PATH}/.git remote get-url origin
+}
+
+function cluster::_get_version() {
+    git --git-dir ${CLUSTER_PATH}/.git log --format="%H" -n 1
+}
+
 function cluster::install() {
+    # Remove cloned kubevirtci repository if it does not match the requested one
+    if [ -d ${CLUSTER_PATH} ]; then
+        if [ $(cluster::_get_repo) != ${KUBEVIRTCI_REPO} -o $(cluster::_get_version) != ${KUBEVIRTCI_VERSION} ]; then
+            rm -rf ${CLUSTER_PATH}
+        fi
+    fi
+
     if [ ! -d ${CLUSTER_PATH} ]; then
         git clone https://github.com/kubevirt/kubevirtci.git ${CLUSTER_PATH}
         (

--- a/cluster/cluster.sh
+++ b/cluster/cluster.sh
@@ -15,22 +15,23 @@
 export KUBEVIRT_PROVIDER=${KUBEVIRT_PROVIDER:-'k8s-1.17'}
 
 KUBEVIRTCI_VERSION='0b941ea5dc647d3aea6f6a6fff95563d6ce0445e'
-KUBEVIRTCI_PATH="${PWD}/_kubevirtci"
+# The CLUSTER_PATH var is used in cluster folder and points to the _kubevirtci where the cluster is deployed from.
+CLUSTER_PATH=${CLUSTER_PATH:-"${PWD}/_kubevirtci/"}
 
-function kubevirtci::install() {
-    if [ ! -d ${KUBEVIRTCI_PATH} ]; then
-        git clone https://github.com/kubevirt/kubevirtci.git ${KUBEVIRTCI_PATH}
+function cluster::install() {
+    if [ ! -d ${CLUSTER_PATH} ]; then
+        git clone https://github.com/kubevirt/kubevirtci.git ${CLUSTER_PATH}
         (
-            cd ${KUBEVIRTCI_PATH}
+            cd ${CLUSTER_PATH}
             git checkout ${KUBEVIRTCI_VERSION}
         )
     fi
 }
 
-function kubevirtci::path() {
-    echo -n ${KUBEVIRTCI_PATH}
+function cluster::path() {
+    echo -n ${CLUSTER_PATH}
 }
 
-function kubevirtci::kubeconfig() {
-    echo -n ${KUBEVIRTCI_PATH}/_ci-configs/${KUBEVIRT_PROVIDER}/.kubeconfig
+function cluster::kubeconfig() {
+    echo -n ${CLUSTER_PATH}/_ci-configs/${KUBEVIRT_PROVIDER}/.kubeconfig
 }

--- a/cluster/down.sh
+++ b/cluster/down.sh
@@ -16,7 +16,8 @@
 
 set -ex
 
-source ./cluster/kubevirtci.sh
+SCRIPTS_PATH="$(dirname "$(realpath "$0")")"
+source ${SCRIPTS_PATH}/kubevirtci.sh
 kubevirtci::install
 
 $(kubevirtci::path)/cluster-up/down.sh

--- a/cluster/down.sh
+++ b/cluster/down.sh
@@ -17,7 +17,7 @@
 set -ex
 
 SCRIPTS_PATH="$(dirname "$(realpath "$0")")"
-source ${SCRIPTS_PATH}/kubevirtci.sh
-kubevirtci::install
+source ${SCRIPTS_PATH}/cluster.sh
+cluster::install
 
-$(kubevirtci::path)/cluster-up/down.sh
+$(cluster::path)/cluster-up/down.sh

--- a/cluster/kubectl.sh
+++ b/cluster/kubectl.sh
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 SCRIPTS_PATH="$(dirname "$(realpath "$0")")"
-source ${SCRIPTS_PATH}/kubevirtci.sh
-kubevirtci::install
+source ${SCRIPTS_PATH}/cluster.sh
+cluster::install
 
-$(kubevirtci::path)/cluster-up/kubectl.sh "$@"
+$(cluster::path)/cluster-up/kubectl.sh "$@"

--- a/cluster/kubectl.sh
+++ b/cluster/kubectl.sh
@@ -14,7 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-source ./cluster/kubevirtci.sh
+SCRIPTS_PATH="$(dirname "$(realpath "$0")")"
+source ${SCRIPTS_PATH}/kubevirtci.sh
 kubevirtci::install
 
 $(kubevirtci::path)/cluster-up/kubectl.sh "$@"

--- a/cluster/ssh.sh
+++ b/cluster/ssh.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -e
+
+SCRIPTS_PATH="$(dirname "$(realpath "$0")")"
+source ${SCRIPTS_PATH}/cluster.sh
+cluster::install
+
+$(cluster::path)/cluster-up/cli.sh ssh "$@"

--- a/cluster/up.sh
+++ b/cluster/up.sh
@@ -17,10 +17,10 @@
 set -ex
 
 SCRIPTS_PATH="$(dirname "$(realpath "$0")")"
-source ${SCRIPTS_PATH}/kubevirtci.sh
-kubevirtci::install
+source ${SCRIPTS_PATH}/cluster.sh
+cluster::install
 
-$(kubevirtci::path)/cluster-up/up.sh
+$(cluster::path)/cluster-up/up.sh
 
 if [[ "$KUBEVIRT_PROVIDER" =~ (ocp|okd)- ]]; then
     echo 'Remove components we do not need to save some resources'

--- a/cluster/up.sh
+++ b/cluster/up.sh
@@ -16,7 +16,8 @@
 
 set -ex
 
-source ./cluster/kubevirtci.sh
+SCRIPTS_PATH="$(dirname "$(realpath "$0")")"
+source ${SCRIPTS_PATH}/kubevirtci.sh
 kubevirtci::install
 
 $(kubevirtci::path)/cluster-up/up.sh

--- a/hack/bump-kubevirtci.sh
+++ b/hack/bump-kubevirtci.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 val=$(git ls-remote https://github.com/kubevirt/kubevirtci | grep HEAD | awk '{print $1}')
-sed -i "/^[[:blank:]]*[KUBEVIRTCI_VERSION[:blank:]]*=/s/=.*/=\"${val}\"/" cluster/kubevirtci.sh
-git --no-pager diff cluster/kubevirtci.sh | grep KUBEVIRTCI_VERSION
+sed -i "/^[[:blank:]]*[KUBEVIRTCI_VERSION[:blank:]]*=/s/=.*/=\"${val}\"/" cluster/cluster.sh
+git --no-pager diff cluster/cluster.sh | grep KUBEVIRTCI_VERSION

--- a/hack/functest.sh
+++ b/hack/functest.sh
@@ -18,12 +18,12 @@
 
 set -ex
 
-source ./cluster/kubevirtci.sh
+source ./cluster/cluster.sh
 
 ${OPERATOR_SDK} test \
     local \
     ./${TEST_SUITE} \
     --operator-namespace cluster-network-addons \
     --no-setup \
-    --kubeconfig $(kubevirtci::kubeconfig) \
+    --kubeconfig $(cluster::kubeconfig) \
     --go-test-flags "${TEST_ARGS}"


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds a few fixes to cluster folder, as a preliminary work for future tier1 tests PRs: #633, #634, #631.

- **cluster scripts, Fix scripts to work from remote paths**
Currently, kubectl.sh, up.sh, down.sh and cli.sh scripts cannot work
from remote paths, since they depend to be working
from CNAO's repo root path.
This was not an issue until now, since script were
only operated from Makefile targets.
This currently prevents us from running these scripts
from another folder, a functionality needed for tier1
tests.
Fixed the scripts to use the script path instead of
relative path.

- **cluster scripts, Fix ambiguous between cluster and vendored _kubevirtci folders**
Currently, both _kubecirtci/ and cluster/ scripts
use the KUBEVIRTCI_PATH var. The issue is that they
point to different paths.
This was not an issue until now because they are only
used internally.
However if one tries to set this variable and calls a script
that use both scripts (for example cluster/kubectl.sh) then the
script breaks due to this mismatch.
kubevirtci.sh script namings further contibute to this ambiguity.
-- Changed cluster/ scripts to use different variable name: CLUSTER_PATH
-- Changed kubevirtci.sh script name to cluster.sh
-- Fixed script function names accordingly: cluster::<function-name>

- **cluster-scripts, Add ssh.sh script**
In order to use ssh.sh in future tier1
tests, we add the ssh.sh script.

- **cluster scripts, Fix kubevirtci.sh to remove _kubevirtci folder**
Currently, when kubevirtci commit version is changed, we get
an error when accessing kubevirtci::install.
Added a fix that will clean up the old _kubevirtci folder

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
