### PR TITLE
bumper, Add local git rebase action in bumper gitAction Job

### DIFF
--- a/.github/workflows/component-bumper.yml
+++ b/.github/workflows/component-bumper.yml
@@ -13,6 +13,11 @@ jobs:
 
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2
+      with:
+        ref: master
+
+    - name: Pull latest master
+      run:  git pull --ff-only --rebase origin master
 
     - name: Run bumper script
       run: make ARGS="-config-path=components.yaml -token=${{ secrets.GITHUB_TOKEN }}" auto-bumper


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently, if we re-run a gitAction job, it is not rebased
to the most updated master.
Added a local rebase action to fix that.

**Special notes for your reviewer**:
This PR may break the bumper script, but it's necessary to debug this functionality on the repo
**Release note**:

```release-note
NONE
```
