### PR TITLE
[release-0.42] placement-configuration, Allow day2 changes

### DIFF
--- a/pkg/network/network.go
+++ b/pkg/network/network.go
@@ -85,7 +85,6 @@ func IsChangeSafe(prev, next *cnao.NetworkAddonsConfigSpec) error {
 
 	errs := []error{}
 
-	errs = append(errs, changeSafePlacementConfiguration(prev, next)...)
 	errs = append(errs, changeSafeKubeMacPool(prev, next)...)
 	errs = append(errs, changeSafeImagePullPolicy(prev, next)...)
 	errs = append(errs, changeSafeSelfSignConfiguration(prev, next)...)

--- a/pkg/network/placement_configuration.go
+++ b/pkg/network/placement_configuration.go
@@ -1,16 +1,13 @@
 package network
 
 import (
-	"reflect"
-
-	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 
 	cnao "github.com/kubevirt/cluster-network-addons-operator/pkg/apis/networkaddonsoperator/shared"
 )
 
-var (
-	defaultPlacementConfiguration = cnao.PlacementConfiguration{
+func GetDefaultPlacementConfiguration() cnao.PlacementConfiguration {
+	return cnao.PlacementConfiguration{
 		Infra: &cnao.Placement{
 			NodeSelector: map[string]string{
 				"beta.kubernetes.io/arch":        "amd64",
@@ -36,32 +33,19 @@ var (
 			},
 		},
 	}
-)
-
-func fillDefaultsPlacementConfiguration(conf, previous *cnao.NetworkAddonsConfigSpec) []error {
-	if conf.PlacementConfiguration == nil || conf.PlacementConfiguration.Infra == nil || conf.PlacementConfiguration.Workloads == nil {
-		if previous != nil && previous.PlacementConfiguration != nil {
-			conf.PlacementConfiguration = previous.PlacementConfiguration
-			return []error{}
-		}
-
-		if conf.PlacementConfiguration == nil {
-			conf.PlacementConfiguration = &defaultPlacementConfiguration
-			return []error{}
-		}
-		if conf.PlacementConfiguration.Infra == nil {
-			conf.PlacementConfiguration.Infra = defaultPlacementConfiguration.Infra
-		}
-		if conf.PlacementConfiguration.Workloads == nil {
-			conf.PlacementConfiguration.Workloads = defaultPlacementConfiguration.Workloads
-		}
-	}
-	return []error{}
 }
 
-func changeSafePlacementConfiguration(prev, next *cnao.NetworkAddonsConfigSpec) []error {
-	if prev.PlacementConfiguration != nil && next.PlacementConfiguration != nil && !reflect.DeepEqual(prev.PlacementConfiguration, next.PlacementConfiguration) {
-		return []error{errors.Errorf("cannot modify PlacementConfiguration once it is deployed")}
+func fillDefaultsPlacementConfiguration(conf, previous *cnao.NetworkAddonsConfigSpec) []error {
+	defaultPlacementConfiguration := GetDefaultPlacementConfiguration()
+	if conf.PlacementConfiguration == nil {
+		conf.PlacementConfiguration = &defaultPlacementConfiguration
+		return []error{}
+	}
+	if conf.PlacementConfiguration.Infra == nil {
+		conf.PlacementConfiguration.Infra = defaultPlacementConfiguration.Infra
+	}
+	if conf.PlacementConfiguration.Workloads == nil {
+		conf.PlacementConfiguration.Workloads = defaultPlacementConfiguration.Workloads
 	}
 	return []error{}
 }

--- a/pkg/network/placement_configuration_test.go
+++ b/pkg/network/placement_configuration_test.go
@@ -14,6 +14,7 @@ var _ = Describe("Testing PlacementConfiguration", func() {
 		currentConfig  *cnao.NetworkAddonsConfigSpec
 		expectedConfig cnao.PlacementConfiguration
 	}
+	defaultPlacementConfiguration := GetDefaultPlacementConfiguration()
 	DescribeTable("Fill defaults function",
 		func(c fillDefaultsCase) {
 			errorList := fillDefaultsPlacementConfiguration(c.currentConfig, c.previousConfig)
@@ -49,95 +50,34 @@ var _ = Describe("Testing PlacementConfiguration", func() {
 				Infra:     defaultPlacementConfiguration.Infra,
 			},
 		}),
-		Entry("When the user hasn't explicitly changed PlacementConfiguration and a previous configuration exits should use the previous values on the current one", fillDefaultsCase{
-			previousConfig: &cnao.NetworkAddonsConfigSpec{
+		Entry("When new Infra & Workloads PlacementConfiguration is not nil should keep new values", fillDefaultsCase{
+			previousConfig: &cnao.NetworkAddonsConfigSpec{},
+			currentConfig: &cnao.NetworkAddonsConfigSpec{
 				PlacementConfiguration: &cnao.PlacementConfiguration{
 					Workloads: &cnao.Placement{
 						NodeSelector: map[string]string{
 							"beta.kubernetes.io/arch": "amd64",
 						},
 					},
+					Infra: &cnao.Placement{
+						NodeSelector: map[string]string{
+							"node-role.kubernetes.io/master": "",
+						},
+					},
 				},
 			},
-			currentConfig: &cnao.NetworkAddonsConfigSpec{},
 			expectedConfig: cnao.PlacementConfiguration{
 				Workloads: &cnao.Placement{
 					NodeSelector: map[string]string{
 						"beta.kubernetes.io/arch": "amd64",
 					},
 				},
-			},
-		}),
-	)
-	type changeSafeCase struct {
-		previousConfig *cnao.NetworkAddonsConfigSpec
-		currentConfig  *cnao.NetworkAddonsConfigSpec
-		expectedError  string
-	}
-	DescribeTable("Change safe function",
-		func(c changeSafeCase) {
-			errorList := changeSafePlacementConfiguration(c.previousConfig, c.currentConfig)
-			if c.expectedError == "" {
-				Expect(errorList).To(BeEmpty())
-			} else {
-				Expect(len(errorList)).To(Equal(1), "validation failed due to an unexpected error: %v", errorList)
-				Expect(errorList[0].Error()).To(MatchRegexp(c.expectedError))
-			}
-		},
-		Entry("When they are equal should NOT return an error", changeSafeCase{
-			previousConfig: &cnao.NetworkAddonsConfigSpec{
-				PlacementConfiguration: &cnao.PlacementConfiguration{
-					Infra: &cnao.Placement{
-						NodeSelector: map[string]string{
-							"label": "value",
-						},
+				Infra: &cnao.Placement{
+					NodeSelector: map[string]string{
+						"node-role.kubernetes.io/master": "",
 					},
 				},
 			},
-			currentConfig: &cnao.NetworkAddonsConfigSpec{
-				PlacementConfiguration: &cnao.PlacementConfiguration{
-					Infra: &cnao.Placement{
-						NodeSelector: map[string]string{
-							"label": "value",
-						},
-					},
-				},
-			},
-			expectedError: "",
-		}),
-		Entry("When they are not equal should return an error", changeSafeCase{
-			previousConfig: &cnao.NetworkAddonsConfigSpec{
-				PlacementConfiguration: &cnao.PlacementConfiguration{
-					Infra: &cnao.Placement{
-						NodeSelector: map[string]string{
-							"label": "value",
-						},
-					},
-				},
-			},
-			currentConfig: &cnao.NetworkAddonsConfigSpec{
-				PlacementConfiguration: &cnao.PlacementConfiguration{
-					Infra: &cnao.Placement{
-						NodeSelector: map[string]string{
-							"newlabel": "newvalue",
-						},
-					},
-				},
-			},
-			expectedError: "cannot modify PlacementConfiguration once it is deployed",
-		}),
-		Entry("When trying to remove PlacementConfiguration should NOT return an error", changeSafeCase{
-			previousConfig: &cnao.NetworkAddonsConfigSpec{
-				PlacementConfiguration: &cnao.PlacementConfiguration{
-					Infra: &cnao.Placement{
-						NodeSelector: map[string]string{
-							"label": "value",
-						},
-					},
-				},
-			},
-			currentConfig: &cnao.NetworkAddonsConfigSpec{},
-			expectedError: "",
 		}),
 	)
 })


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently placement-configuration should not allow
day2 changes.
Changed to allow day2 changes

**Special notes for your reviewer**:

**Release note**:

```release-note
Allow placement-configuration day2 changes
```
