### PR TITLE
bump ovs-cni to v0.15.0

### DIFF
--- a/components.yaml
+++ b/components.yaml
@@ -37,7 +37,7 @@ components:
     metadata: v0.32.0
   ovs-cni:
     url: https://github.com/kubevirt/ovs-cni
-    commit: 973a42b03f553234add72a909fd262560be61237
+    commit: 477353e47338fcde618716f51bd8ed80264bbb25
     branch: master
     update-policy: tagged
-    metadata: v0.13.0
+    metadata: v0.15.0

--- a/data/ovs/001-ovs-cni.yaml
+++ b/data/ovs/001-ovs-cni.yaml
@@ -16,6 +16,8 @@ spec:
       labels:
         tier: node
         app: ovs-cni
+      annotations:
+        description: OVS CNI allows users to attach their Pods/VMs to Open vSwitch bridges available on nodes
     spec:
       serviceAccountName: ovs-cni-marker
       hostNetwork: true

--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -30,8 +30,8 @@ const (
 	LinuxBridgeMarkerImageDefault = "quay.io/kubevirt/bridge-marker@sha256:99d0fbd707deaf2136968aaa34862b54c73c9e5e963dc44140e726cf9ad41b58"
 	KubeMacPoolImageDefault       = "quay.io/kubevirt/kubemacpool@sha256:79c4534d418c4a350a663e38499c22d54dc68c400f517aead4479f6d862b408e"
 	NMStateHandlerImageDefault    = "quay.io/nmstate/kubernetes-nmstate-handler@sha256:b4bc41ce7f9e5fa7eef6a25c27ba13770c53fc6710ea8e4c4b5f6cf68e97821c"
-	OvsCniImageDefault            = "quay.io/kubevirt/ovs-cni-plugin@sha256:b4a2a9bcbde3f8b5f24e0ae957fedca57201c91bc9645459a49f0b954057b22b"
-	OvsMarkerImageDefault         = "quay.io/kubevirt/ovs-cni-marker@sha256:1e0a8c6ba54db8e0a4c6ed926bed25e3a272a4db883805a1af020beba131f999"
+	OvsCniImageDefault            = "quay.io/kubevirt/ovs-cni-plugin@sha256:27ce180502ee9ed7dec708982d872a7c67937faefa60316a9b423bb0dead6e2d"
+	OvsMarkerImageDefault         = "quay.io/kubevirt/ovs-cni-marker@sha256:a734fc4e8ce2a338c0501aaa1e294000e5f67e9847e58503606d8aefdf911dd2"
 	MacvtapCniImageDefault        = "quay.io/kubevirt/macvtap-cni@sha256:0fbb0f3cde7970c0786aec8213bbf28a9d6328e7644d965262783a8248a9ded9"
 )
 

--- a/test/releases/99.0.0.go
+++ b/test/releases/99.0.0.go
@@ -48,13 +48,13 @@ func init() {
 				ParentName: "ovs-cni-amd64",
 				ParentKind: "DaemonSet",
 				Name:       "ovs-cni-plugin",
-				Image:      "quay.io/kubevirt/ovs-cni-plugin@sha256:b4a2a9bcbde3f8b5f24e0ae957fedca57201c91bc9645459a49f0b954057b22b",
+				Image:      "quay.io/kubevirt/ovs-cni-plugin@sha256:27ce180502ee9ed7dec708982d872a7c67937faefa60316a9b423bb0dead6e2d",
 			},
 			{
 				ParentName: "ovs-cni-amd64",
 				ParentKind: "DaemonSet",
 				Name:       "ovs-cni-marker",
-				Image:      "quay.io/kubevirt/ovs-cni-marker@sha256:1e0a8c6ba54db8e0a4c6ed926bed25e3a272a4db883805a1af020beba131f999",
+				Image:      "quay.io/kubevirt/ovs-cni-marker@sha256:a734fc4e8ce2a338c0501aaa1e294000e5f67e9847e58503606d8aefdf911dd2",
 			},
 		},
 		SupportedSpec: cnao.NetworkAddonsConfigSpec{


### PR DESCRIPTION
bump ovs-cni to v0.15.0
Executed by Bumper script

```release-note
bump ovs-cni to v0.15.0
```