### PR TITLE
bumper, Make base-branch configurable

### DIFF
--- a/.github/workflows/component-bumper.yml
+++ b/.github/workflows/component-bumper.yml
@@ -7,17 +7,20 @@ on:
 jobs:
 
   build:
-    name: CNAO Component Bump Job
+    name: [master] CNAO Component Bump Job
     runs-on: ubuntu-latest
     steps:
+
+    - name: Set environment variables
+      run: echo "::set-env name=BASE_BRANCH::master";
 
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2
       with:
-        ref: master
+        ref: ${{ env.BASE_BRANCH }}
 
-    - name: Pull latest master
-      run:  git pull --ff-only --rebase origin master
+    - name: Pull latest of latest branch
+      run:  git pull --ff-only --rebase origin ${{ env.BASE_BRANCH }}
 
     - name: Run bumper script
-      run: make ARGS="-config-path=components.yaml -token=${{ secrets.GITHUB_TOKEN }}" auto-bumper
+      run: make ARGS="-config-path=components.yaml -token=${{ secrets.GITHUB_TOKEN }} -base-branch=${{ env.BASE_BRANCH }}" auto-bumper

--- a/tools/bumper/README.md
+++ b/tools/bumper/README.md
@@ -9,9 +9,10 @@ In order to run the script manually, you need to have a github token. To create 
 ## How to run the script
 
 ```
-make ARGS="-config-path=<path-to-components.yaml-relative-to-bumping-repo> -token=<git-token>" auto-bumper
+make ARGS="-config-path=<path-to-components.yaml-relative-to-bumping-repo> -token=<git-token>" -base-branch=<base-branch> auto-bumper
 ```
 
 Where:
 * config-path: relative path to components.yaml from the bumping repo. In its current position we'll simply: config-path="components.yaml"
 * token: personal/gitActions github-token.
+* base-branch: the branch on which the bumper script runs, and on which the PRs will be opened. default is master

--- a/tools/bumper/bumper.go
+++ b/tools/bumper/bumper.go
@@ -15,6 +15,7 @@ var logger *log.Logger
 type inputParams struct {
 	componentsConfigPath string
 	gitToken             string
+	baseBranch           string
 }
 
 const (
@@ -35,7 +36,7 @@ func main() {
 		exitWithError(errors.Wrap(err, "Failed to create github api instance"))
 	}
 
-	cnaoRepo, err := getCnaoRepo(githubApi)
+	cnaoRepo, err := getCnaoRepo(githubApi, inputArgs.baseBranch)
 	if err != nil {
 		exitWithError(errors.Wrap(err, "Failed to clone cnao repo"))
 	}
@@ -127,6 +128,7 @@ func handleBump(cnaoRepo *gitCnaoRepo, component component, componentName, compo
 		return nil
 	}
 
+	return nil
 	logger.Printf("Generate Bump PR using GithubAPI")
 	_, err = cnaoRepo.generateBumpPr(proposedPrTitle, bumpFilesList)
 	if err != nil {
@@ -144,11 +146,15 @@ func initLog() *log.Logger {
 }
 
 func initFlags(paramArgs *inputParams) {
-	flag.StringVar(&paramArgs.componentsConfigPath, "config-path", "", "relative path to components yaml from bumping repo")
+	flag.StringVar(&paramArgs.componentsConfigPath, "config-path", "", "relative path to components yaml from CNAO repo")
 	flag.StringVar(&paramArgs.gitToken, "token", "", "git Token")
+	flag.StringVar(&paramArgs.baseBranch, "base-branch", "master", "the branch CNAO is running the bumper script on, and on which the PRs will be opened")
 	flag.Parse()
-	if flag.NFlag() != 2 {
-		exitWithError(fmt.Errorf("Wrong Number of input parameters %d, should be 2. Use --help for usage", flag.NFlag()))
+	if paramArgs.componentsConfigPath == "" {
+		exitWithError(fmt.Errorf("config-path mandatory input paramter not entered. Use --help for usage"))
+	}
+	if paramArgs.gitToken == "" {
+		exitWithError(fmt.Errorf("github token mandatory input paramter not entered. Use --help for usage"))
 	}
 }
 

--- a/tools/bumper/bumper.go
+++ b/tools/bumper/bumper.go
@@ -128,7 +128,6 @@ func handleBump(cnaoRepo *gitCnaoRepo, component component, componentName, compo
 		return nil
 	}
 
-	return nil
 	logger.Printf("Generate Bump PR using GithubAPI")
 	_, err = cnaoRepo.generateBumpPr(proposedPrTitle, bumpFilesList)
 	if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds the ability to run the bumper script on other branches other than master.

- **bumper, allow bumper to bumper from non-master branches**
Currently, the bumper script assumes it is run on
master branch.
We want to also allow running this on stable branches
Change base-branch to be input parameter to bumper script

- **bumper, Change gitHubAction job to be base-branch aware**
Following the change in bumper script, we adjust the
githubAction job to specify which brnahc it run from.
**Note:** we use 2 gitActions since there is an [issue](https://github.com/actions/checkout/issues/299) with actions/checkout@v2
that we solve in this [manner](https://github.com/kubevirt/cluster-network-addons-operator/pull/637)

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
