### PR TITLE
bump ovs-cni to v0.15.1

### DIFF
--- a/components.yaml
+++ b/components.yaml
@@ -37,7 +37,7 @@ components:
     metadata: v0.32.0
   ovs-cni:
     url: https://github.com/kubevirt/ovs-cni
-    commit: 477353e47338fcde618716f51bd8ed80264bbb25
+    commit: 2dfdc46e4050d07656491d49c4d31c91db3d6357
     branch: master
     update-policy: tagged
-    metadata: v0.15.0
+    metadata: v0.15.1

--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -30,8 +30,8 @@ const (
 	LinuxBridgeMarkerImageDefault = "quay.io/kubevirt/bridge-marker@sha256:6132543df838d324020d25979f088138534ca396f7ca995d5af76181fc8080e3"
 	KubeMacPoolImageDefault       = "quay.io/kubevirt/kubemacpool@sha256:79c4534d418c4a350a663e38499c22d54dc68c400f517aead4479f6d862b408e"
 	NMStateHandlerImageDefault    = "quay.io/nmstate/kubernetes-nmstate-handler@sha256:b4bc41ce7f9e5fa7eef6a25c27ba13770c53fc6710ea8e4c4b5f6cf68e97821c"
-	OvsCniImageDefault            = "quay.io/kubevirt/ovs-cni-plugin@sha256:27ce180502ee9ed7dec708982d872a7c67937faefa60316a9b423bb0dead6e2d"
-	OvsMarkerImageDefault         = "quay.io/kubevirt/ovs-cni-marker@sha256:a734fc4e8ce2a338c0501aaa1e294000e5f67e9847e58503606d8aefdf911dd2"
+	OvsCniImageDefault            = "quay.io/kubevirt/ovs-cni-plugin@sha256:65379e640aba706173f6d1675d7c57155e460639a601b68336a05f152e7fe7a9"
+	OvsMarkerImageDefault         = "quay.io/kubevirt/ovs-cni-marker@sha256:45ee4b7ebca38f95d9b82c4c765f5778fd02df343a7f012c246a109bff1aca33"
 	MacvtapCniImageDefault        = "quay.io/kubevirt/macvtap-cni@sha256:2d255b0385b9080bd0de7fa0d9214d03637e27ef5eab49a991cf75bede24719e"
 )
 

--- a/test/releases/99.0.0.go
+++ b/test/releases/99.0.0.go
@@ -48,13 +48,13 @@ func init() {
 				ParentName: "ovs-cni-amd64",
 				ParentKind: "DaemonSet",
 				Name:       "ovs-cni-plugin",
-				Image:      "quay.io/kubevirt/ovs-cni-plugin@sha256:27ce180502ee9ed7dec708982d872a7c67937faefa60316a9b423bb0dead6e2d",
+				Image:      "quay.io/kubevirt/ovs-cni-plugin@sha256:65379e640aba706173f6d1675d7c57155e460639a601b68336a05f152e7fe7a9",
 			},
 			{
 				ParentName: "ovs-cni-amd64",
 				ParentKind: "DaemonSet",
 				Name:       "ovs-cni-marker",
-				Image:      "quay.io/kubevirt/ovs-cni-marker@sha256:a734fc4e8ce2a338c0501aaa1e294000e5f67e9847e58503606d8aefdf911dd2",
+				Image:      "quay.io/kubevirt/ovs-cni-marker@sha256:45ee4b7ebca38f95d9b82c4c765f5778fd02df343a7f012c246a109bff1aca33",
 			},
 		},
 		SupportedSpec: cnao.NetworkAddonsConfigSpec{


### PR DESCRIPTION
bump ovs-cni to v0.15.1
Executed by Bumper script

```release-note
bump ovs-cni to v0.15.1
```