### PR TITLE
bumper, Remove Draft flag from bumper generated PRs

### DIFF
--- a/tools/bumper/cnao_repo_commands.go
+++ b/tools/bumper/cnao_repo_commands.go
@@ -295,7 +295,6 @@ func (cnaoRepoOps *gitCnaoRepo) createPR(prTitle, branchName string) (*github.Pu
 		Base:                &prBranch,
 		Body:                &prDescription,
 		MaintainerCanModify: github.Bool(true),
-		Draft:               github.Bool(true),
 	}
 
 	pr, _, err := cnaoRepoOps.githubInterface.createPullRequest(cnaoRepoOps.getCnaoRepoOwnerFromUrl(), cnaoRepoOps.getCnaoRepoNameFromUrl(), newPR)


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently PRs opened by the bumper script are
in draft mode. Since the script is stable we
want to move script to issue real PRs.
Removed Draft flag from created PRs

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
