### PR TITLE
bump macvtap-cni to v0.4.2

### DIFF
--- a/components.yaml
+++ b/components.yaml
@@ -19,10 +19,10 @@ components:
     metadata: v0.8.7
   macvtap-cni:
     url: https://github.com/kubevirt/macvtap-cni
-    commit: 5315da018124d5ba328f7fec5a530a08287c9d01
+    commit: 0d5eeca624a707faa018678bd906e3c9f838a3bd
     branch: master
     update-policy: tagged
-    metadata: v0.4.1
+    metadata: v0.4.2
   multus:
     url: https://github.com/intel/multus-cni
     commit: 4eac660359f223d34bcaf0fddbc42fd542f02ba1

--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -32,7 +32,7 @@ const (
 	NMStateHandlerImageDefault    = "quay.io/nmstate/kubernetes-nmstate-handler@sha256:b4bc41ce7f9e5fa7eef6a25c27ba13770c53fc6710ea8e4c4b5f6cf68e97821c"
 	OvsCniImageDefault            = "quay.io/kubevirt/ovs-cni-plugin@sha256:9cb7b313b0277458f667cc235677207c7a37f3a9e8cf42b4d7850692c97fdc39"
 	OvsMarkerImageDefault         = "quay.io/kubevirt/ovs-cni-marker@sha256:92679a8a5192b9d039e29eb0c5a87157157e5044026af67a10aaa44b769943b1"
-	MacvtapCniImageDefault        = "quay.io/kubevirt/macvtap-cni@sha256:2d255b0385b9080bd0de7fa0d9214d03637e27ef5eab49a991cf75bede24719e"
+	MacvtapCniImageDefault        = "quay.io/kubevirt/macvtap-cni@sha256:f20d5e56f8b8c1ab7e5a64e536b66f65aa688b2d1dc0b37e3c26c2af2b481266"
 )
 
 type AddonsImages struct {


### PR DESCRIPTION
bump macvtap-cni to v0.4.2
Executed by Bumper script

```release-note
bump macvtap-cni to v0.4.2
```