### PR TITLE
delete objects, Fix tracking of already removed objects

### DIFF
--- a/pkg/controller/networkaddonsconfig/networkaddonsconfig_controller.go
+++ b/pkg/controller/networkaddonsconfig/networkaddonsconfig_controller.go
@@ -267,6 +267,9 @@ func (r *ReconcileNetworkAddonsConfig) Reconcile(request reconcile.Request) (rec
 		return reconcile.Result{}, err
 	}
 
+	// Track state of all deployed pods
+	r.trackDeployedObjects(objs, networkAddonsConfig.GetGeneration())
+
 	// Delete generated objsToRemove on Kubernetes API server
 	err = r.deleteObjects(objsToRemove)
 	if err != nil {
@@ -274,9 +277,6 @@ func (r *ReconcileNetworkAddonsConfig) Reconcile(request reconcile.Request) (rec
 		r.statusManager.SetFailing(statusmanager.OperatorConfig, "FailedToDeleteObjects", err.Error())
 		return reconcile.Result{}, err
 	}
-
-	// Track state of all deployed pods
-	r.trackDeployedObjects(objs, networkAddonsConfig.GetGeneration())
 
 	// Everything went smooth, remove failures from NetworkAddonsConfig if there are any from
 	// previous runs.

--- a/test/check/check.go
+++ b/test/check/check.go
@@ -571,11 +571,10 @@ func retrieveRange() (string, string) {
 }
 
 func CheckAvailableEvent(gvk schema.GroupVersionKind) {
-	//checkConfigLatestEvent(eventemitter.AvailableReason, eventemitter.AvailableMessage, duration, timeout)
 	By("Check for Available event")
 	config := GetConfig(gvk)
 	configV1 := ConvertToConfigV1(config)
-	objectEventWatcher := NewObjectEventWatcher(configV1).SinceWatchedObjectResourceVersion().Timeout(time.Duration(15) * time.Minute)
+	objectEventWatcher := NewObjectEventWatcher(configV1).SinceNow().Timeout(time.Duration(15) * time.Minute)
 	stopChan := make(chan struct{})
 	defer close(stopChan)
 	objectEventWatcher.WaitFor(stopChan, NormalEvent, eventemitter.AvailableReason)

--- a/test/e2e/workflow/recovery_test.go
+++ b/test/e2e/workflow/recovery_test.go
@@ -32,9 +32,9 @@ var _ = Describe("NetworkAddonsConfig", func() {
 			})
 
 			It("should turn from Failing to Available", func() {
+				CheckAvailableEvent(gvk)
 				CheckConfigCondition(gvk, ConditionAvailable, ConditionTrue, 5*time.Second, CheckDoNotRepeat)
 				CheckConfigCondition(gvk, ConditionDegraded, ConditionFalse, CheckImmediately, CheckDoNotRepeat)
-				CheckAvailableEvent(gvk)
 			})
 		})
 	})

--- a/test/e2e/workflow/validation_test.go
+++ b/test/e2e/workflow/validation_test.go
@@ -56,8 +56,8 @@ var _ = Describe("NetworkAddonsConfig", func() {
 			})
 
 			It("should remain at Available condition", func() {
-				By("Waiting for Modified event after config update")
-				CheckModifiedEvent(gvk)
+				By("Waiting for Available event after config update")
+				CheckAvailableEvent(gvk)
 
 				By("Checking that Available status turn to True")
 				CheckConfigCondition(gvk, ConditionAvailable, ConditionTrue, CheckImmediately, time.Minute)


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes a transient situation where an object which just got deleted
is still tracked by the CNAO reconciler, thus causing a temporary failed status
This fix also stabilizes the flaky [issue](https://github.com/kubevirt/cluster-network-addons-operator/issues/650) reported in validation e2e tests. 

- **delete objects, Fix Tracking of already removed objects**
Currently, the reconciler updates the list of objects to deploy
only after any objects are removed. This causes a temporary period
where the object is declared as gone.
Changed the order of trackDeployedObjects and deleteObjects to
keep the tracked objects updated correctly.

- **expectAvaialableEvent, Change to Watch policy to since now**
In order to check Available event after object removal,
we move to use CheckAvailableEvent.
We also change the event watch policy to SinceNow,
since it seems that the change is sufficiently caught.

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
