### PR TITLE
[WIP] Bump provider to k8s-1.19

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,8 +315,8 @@ make docker-build-registry
 # bring up a local cluster with Kubernetes
 make cluster-up
 
-# bridge up a local cluster with kubernetes 1.17
-export KUBEVIRT_PROVIDER=k8s-1.17
+# bridge up a local cluster with kubernetes 1.19
+export KUBEVIRT_PROVIDER=k8s-1.19
 make cluster-up
 
 # build images and push them to the local cluster

--- a/automation/check-patch.e2e-lifecycle-k8s.sh
+++ b/automation/check-patch.e2e-lifecycle-k8s.sh
@@ -16,7 +16,7 @@ versionChanged() {
 }
 
 main() {
-    export KUBEVIRT_PROVIDER='k8s-1.17'
+    export KUBEVIRT_PROVIDER='k8s-1.19'
 
     source automation/check-patch.setup.sh
     cd ${TMP_PROJECT_PATH}

--- a/automation/check-patch.e2e-workflow-k8s.sh
+++ b/automation/check-patch.e2e-workflow-k8s.sh
@@ -12,7 +12,7 @@ teardown() {
 }
 
 main() {
-    export KUBEVIRT_PROVIDER='k8s-1.17'
+    export KUBEVIRT_PROVIDER='k8s-1.19'
 
     source automation/check-patch.setup.sh
     cd ${TMP_PROJECT_PATH}

--- a/automation/components-functests.setup.sh
+++ b/automation/components-functests.setup.sh
@@ -29,7 +29,7 @@ teardown() {
 trap teardown EXIT SIGINT SIGTERM SIGQUIT
 
 # Spin up Kubernetes cluster
-export KUBEVIRT_PROVIDER='k8s-1.17'
+export KUBEVIRT_PROVIDER='k8s-1.19'
 make cluster-down cluster-up
 
 # Export .kubeconfig full path, so it will be possible

--- a/cluster/cluster.sh
+++ b/cluster/cluster.sh
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-export KUBEVIRT_PROVIDER=${KUBEVIRT_PROVIDER:-'k8s-1.17'}
+export KUBEVIRT_PROVIDER=${KUBEVIRT_PROVIDER:-'k8s-1.19'}
 export KUBEVIRTCI_TAG='2011121336-c2cf403'
 
 KUBEVIRTCI_REPO='https://github.com/kubevirt/kubevirtci.git'

--- a/cluster/cluster.sh
+++ b/cluster/cluster.sh
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 export KUBEVIRT_PROVIDER=${KUBEVIRT_PROVIDER:-'k8s-1.17'}
+export KUBEVIRTCI_TAG='2011121336-c2cf403'
 
-KUBEVIRTCI_VERSION='0b941ea5dc647d3aea6f6a6fff95563d6ce0445e'
 KUBEVIRTCI_REPO='https://github.com/kubevirt/kubevirtci.git'
 # The CLUSTER_PATH var is used in cluster folder and points to the _kubevirtci where the cluster is deployed from.
 CLUSTER_PATH=${CLUSTER_PATH:-"${PWD}/_kubevirtci/"}
@@ -23,14 +23,14 @@ function cluster::_get_repo() {
     git --git-dir ${CLUSTER_PATH}/.git remote get-url origin
 }
 
-function cluster::_get_version() {
-    git --git-dir ${CLUSTER_PATH}/.git log --format="%H" -n 1
+function cluster::_get_tag() {
+    git --git-dir ${CLUSTER_PATH}/.git describe --tags
 }
 
 function cluster::install() {
     # Remove cloned kubevirtci repository if it does not match the requested one
     if [ -d ${CLUSTER_PATH} ]; then
-        if [ $(cluster::_get_repo) != ${KUBEVIRTCI_REPO} -o $(cluster::_get_version) != ${KUBEVIRTCI_VERSION} ]; then
+        if [ $(cluster::_get_repo) != ${KUBEVIRTCI_REPO} -o $(cluster::_get_tag) != ${KUBEVIRTCI_TAG} ]; then
             rm -rf ${CLUSTER_PATH}
         fi
     fi
@@ -39,7 +39,7 @@ function cluster::install() {
         git clone https://github.com/kubevirt/kubevirtci.git ${CLUSTER_PATH}
         (
             cd ${CLUSTER_PATH}
-            git checkout ${KUBEVIRTCI_VERSION}
+            git checkout ${KUBEVIRTCI_TAG}
         )
     fi
 }

--- a/components.yaml
+++ b/components.yaml
@@ -1,7 +1,7 @@
 components:
   bridge-marker:
     url: https://github.com/kubevirt/bridge-marker
-    commit: fae2fec995f7882b8a304df7ad26ddbaaa0f5f3c
+    commit: master
     branch: master
     update-policy: tagged
     metadata: 0.5.0
@@ -19,7 +19,7 @@ components:
     metadata: v0.8.7
   macvtap-cni:
     url: https://github.com/kubevirt/macvtap-cni
-    commit: 0d5eeca624a707faa018678bd906e3c9f838a3bd
+    commit: master
     branch: master
     update-policy: tagged
     metadata: v0.4.2


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR moves to use KUBEVIRTCI_TAG in order to get the latest 
kubevirtci tag, and then bumps to k8s-1.19 provider

- **cluster, update to latest KUBEVIRTCI_TAG**
kuybecivrtci recently moved to use KUBEVIRTCI_TAG
Changed to use KUBEVIRTCI_TAG instead of KUBEVIRTCI_COMMIT.
Bumped to latest KUBEVIRTCI_TAG

- **provider, bump to k8s-1.19 provider**

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
