### PR TITLE
bumper, fix githubAction job env vars

### DIFF
--- a/.github/workflows/component-bumper-master.yml
+++ b/.github/workflows/component-bumper-master.yml
@@ -17,10 +17,10 @@ jobs:
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2
       with:
-        ref: $BASE_BRANCH
+        ref: ${{ env.BASE_BRANCH }}
 
     - name: Pull latest of latest branch
-      run:  git pull --ff-only --rebase origin $BASE_BRANCH
+      run:  git pull --ff-only --rebase origin ${{ env.BASE_BRANCH }}
 
     - name: Run bumper script
-      run: make ARGS="-config-path=components.yaml -token=${{ secrets.GITHUB_TOKEN }} -base-branch=$BASE_BRANCH" auto-bumper
+      run: make ARGS="-config-path=components.yaml -token=${{ secrets.GITHUB_TOKEN }} -base-branch=${{ env.BASE_BRANCH }}" auto-bumper


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently bumper job fails due to
misuse of the env vars recently inserted.
Fixed env vars to githubAction standard, 
similar to how it's done on HCO githubAction Job [[1]](https://github.com/kubevirt/hyperconverged-cluster-operator/actions/runs/376928097/workflow#L45).

[1] https://github.com/kubevirt/hyperconverged-cluster-operator/actions/runs/376928097/workflow#L45

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
