### PR TITLE
bump-knmstate, update nmstate bump script crds

### DIFF
--- a/hack/components/bump-nmstate.sh
+++ b/hack/components/bump-nmstate.sh
@@ -47,7 +47,7 @@ echo 'Configure nmstate-webhook and nmstate-handler templates and save the rende
 echo 'Copy kubernetes-nmstate manifests'
 rm -rf data/nmstate/*
 cp $NMSTATE_PATH/config/cnao/handler/* data/nmstate/
-cp $NMSTATE_PATH/deploy/crds/*nodenetwork*crd* data/nmstate/
+cp $NMSTATE_PATH/deploy/crds/nmstate.io_nodenetwork*.yaml data/nmstate/
 cp $NMSTATE_PATH/deploy/openshift/scc.yaml data/nmstate/scc.yaml
 sed -i "s/---/{{ if .EnableSCC }}\n---/" data/nmstate/scc.yaml
 echo "{{ end }}" >> data/nmstate/scc.yaml


### PR DESCRIPTION
**What this PR does / why we need it**:
Due to changes made on the crd file names
on kubernetes-nmstate repo, we need to update
the bump-nmstate script accordingly

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
