### PR TITLE
bumper, Add bumper githubAction job for release-0.42 branch

### DIFF
--- a/.github/workflows/component-bumper-release-0.42.yml
+++ b/.github/workflows/component-bumper-release-0.42.yml
@@ -1,0 +1,26 @@
+name: Auto-Bump Components' Versions
+
+on:
+  schedule:
+    - cron:  '0 5 * * *'
+
+jobs:
+
+  build:
+    name: release-0.42 - CNAO Component Bump Job
+    runs-on: ubuntu-latest
+    steps:
+
+    - name: Set environment variables
+      run: echo "BASE_BRANCH=release-0.42" >> $GITHUB_ENV
+
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v2
+      with:
+        ref: ${{ env.BASE_BRANCH }}
+
+    - name: Pull latest of latest branch
+      run:  git pull --ff-only --rebase origin ${{ env.BASE_BRANCH }}
+
+    - name: Run bumper script
+      run: make ARGS="-config-path=components.yaml -token=${{ secrets.GITHUB_TOKEN }} -base-branch=${{ env.BASE_BRANCH }}" auto-bumper


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently the gitAction jobs can only be
configured on the master(/base) branch
To run the bumper on the release-0.42 branch
the job is added in master branch.

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
