### PR TITLE
bumper, add support of deleted files

### DIFF
--- a/tools/bumper/cnao_repo_commands.go
+++ b/tools/bumper/cnao_repo_commands.go
@@ -39,7 +39,7 @@ func getCnaoRepo(api *githubApi, baseBranch string) (*gitCnaoRepo, error) {
 	}
 
 	cnaoComponentParams := &component{
-		Url: repoUrl,
+		Url:    repoUrl,
 		Branch: baseBranch,
 	}
 
@@ -196,14 +196,18 @@ func (cnaoRepoOps *gitCnaoRepo) collectModifiedToTreeList(allowedList []string) 
 		}
 
 		fileNameWithPath := filepath.Join(cnaoRepoOps.gitRepo.localDir, localFile)
-		content, err := ioutil.ReadFile(fileNameWithPath)
-		if err != nil {
-			return nil, errors.Wrapf(err, "Failed to read local file %s", fileNameWithPath)
+		var treeEntryContent *string
+		if status.Worktree != git.Deleted {
+			content, err := ioutil.ReadFile(fileNameWithPath)
+			if err != nil {
+				return nil, errors.Wrapf(err, "Failed to read local file %s", fileNameWithPath)
+			}
+			treeEntryContent = github.String(string(content))
 		}
 
 		if fileInGlobList(localFile, allowedList) {
 			logger.Printf("File added to tree: %s", localFile)
-			entries = append(entries, &github.TreeEntry{Path: github.String(localFile), Type: github.String("blob"), Content: github.String(string(content)), Mode: github.String("100644")})
+			entries = append(entries, &github.TreeEntry{Path: github.String(localFile), Type: github.String("blob"), Content: treeEntryContent, Mode: github.String("100644")})
 		} else {
 			logger.Printf("Skipping file %s, not in allowed list", localFile)
 		}

--- a/tools/bumper/git_fakes.go
+++ b/tools/bumper/git_fakes.go
@@ -394,3 +394,15 @@ func modifyFiles(repoDir string, files []string) {
 		Expect(err).ToNot(HaveOccurred(), fmt.Sprintf("should not fail to write generic string (file name) to file %s", fileNameWithPath))
 	}
 }
+
+func deleteFiles(repoDir string, files []string) {
+	for _, fileName := range files {
+		fileNameWithPath := filepath.Join(repoDir, fileName)
+		if !fileExists(fileNameWithPath) {
+			Fail(fmt.Sprintf("file %s cannot be deleted since it doesn't exist", fileName))
+		}
+
+		err := os.Remove(fileNameWithPath)
+		Expect(err).ToNot(HaveOccurred(), fmt.Sprintf("should not fail to deleting file %s", fileNameWithPath))
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently, the bumper script fails when trying to collect
deleted files for the bump PR.
Added support of deleted files in the script (using [example](https://github.com/google/go-github/blob/e4b511744f5bbb020d00e172a284468137d4e5fc/github/git_trees_test.go#L188) code).

**Special notes for your reviewer**:
note a [knmstate bump PR](https://github.com/kubevirt/cluster-network-addons-operator/pull/675) created by running the bumper script locally.

**Release note**:

```release-note
NONE
```
