### PR TITLE
bump nmstate to v0.33.0

### DIFF
--- a/automation/check-patch.e2e-nmstate-functests.sh
+++ b/automation/check-patch.e2e-nmstate-functests.sh
@@ -40,9 +40,10 @@ main() {
     cd ${TMP_COMPONENT_PATH}
 
     make test-e2e-handler \
-        E2E_TEST_TIMEOUT=${TIMEOUT} \
-        E2E_TEST_ARGS="-ginkgo.noColor --junit-output=$ARTIFACTS/junit.functest.xml" \
-        HANDLER_NAMESPACE=$NAMESPACE \
+        E2E_TEST_TIMEOUT=$TIMEOUT \
+        e2e_test_args="-noColor" \
+        E2E_TEST_SUITE_ARGS="--junit-output=$ARTIFACTS/junit.functest.xml" \
+        OPERATOR_NAMESPACE=$NAMESPACE \
         CLUSTER_PATH=$CLUSTER_PATH \
         KUBECONFIG=$KUBECONFIG \
         KUBECTL=$KUBECTL

--- a/components.yaml
+++ b/components.yaml
@@ -31,7 +31,7 @@ components:
     metadata: v3.4.2
   nmstate:
     url: https://github.com/nmstate/kubernetes-nmstate
-    commit: 402aa3ad97fdeef27677a018e428ba2e2e5cda29
+    commit: master
     branch: master
     update-policy: tagged
     metadata: v0.33.0

--- a/components.yaml
+++ b/components.yaml
@@ -31,10 +31,10 @@ components:
     metadata: v3.4.2
   nmstate:
     url: https://github.com/nmstate/kubernetes-nmstate
-    commit: d1a0439f89560f65b6561a6c1745d96d548e1d7b
+    commit: 402aa3ad97fdeef27677a018e428ba2e2e5cda29
     branch: master
     update-policy: tagged
-    metadata: v0.32.0
+    metadata: v0.33.0
   ovs-cni:
     url: https://github.com/kubevirt/ovs-cni
     commit: 4f206e6354dc9b158a6f1070238673f14795ce8c

--- a/data/nmstate/nmstate.io_nodenetworkconfigurationenactments.yaml
+++ b/data/nmstate/nmstate.io_nodenetworkconfigurationenactments.yaml
@@ -1,22 +1,32 @@
+
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: nodenetworkstates.nmstate.io
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.4.0
+  creationTimestamp: null
+  name: nodenetworkconfigurationenactments.nmstate.io
 spec:
   group: nmstate.io
   names:
-    kind: NodeNetworkState
-    listKind: NodeNetworkStateList
-    plural: nodenetworkstates
+    kind: NodeNetworkConfigurationEnactment
+    listKind: NodeNetworkConfigurationEnactmentList
+    plural: nodenetworkconfigurationenactments
     shortNames:
-    - nns
-    singular: nodenetworkstate
+    - nnce
+    singular: nodenetworkconfigurationenactment
   scope: Cluster
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - description: Status
+      jsonPath: .status.conditions[?(@.type=="Available")].reason
+      name: Status
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: NodeNetworkState is the Schema for the nodenetworkstates API
+        description: NodeNetworkConfigurationEnactment is the Schema for the nodenetworkconfigurationenactments API
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
@@ -27,7 +37,7 @@ spec:
           metadata:
             type: object
           status:
-            description: NodeNetworkStateStatus is the status of the NodeNetworkState of a specific node
+            description: NodeNetworkConfigurationEnactmentStatus defines the observed state of NodeNetworkConfigurationEnactment
             properties:
               conditions:
                 items:
@@ -51,23 +61,29 @@ spec:
                   - type
                   type: object
                 type: array
-              currentState:
-                description: "State contains the namestatectl yaml [1] as string instead of golang struct so we don't need to be in sync with the schema. \n [1] https://github.com/nmstate/nmstate/blob/master/libnmstate/schemas/operational-state.yaml"
+              desiredState:
+                description: The desired state rendered for the enactment's node using the policy desiredState as template
                 type: object
                 x-kubernetes-preserve-unknown-fields: true
-              lastSuccessfulUpdateTime:
-                format: date-time
-                type: string
+              policyGeneration:
+                description: The generation from policy needed to check if an enactment condition status belongs to the same policy version
+                format: int64
+                type: integer
             type: object
         type: object
     served: true
     storage: false
     subresources:
       status: {}
-  - name: v1beta1
+  - additionalPrinterColumns:
+    - description: Status
+      jsonPath: .status.conditions[?(@.type=="Available")].reason
+      name: Status
+      type: string
+    name: v1beta1
     schema:
       openAPIV3Schema:
-        description: NodeNetworkState is the Schema for the nodenetworkstates API
+        description: NodeNetworkConfigurationEnactment is the Schema for the nodenetworkconfigurationenactments API
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
@@ -78,7 +94,7 @@ spec:
           metadata:
             type: object
           status:
-            description: NodeNetworkStateStatus is the status of the NodeNetworkState of a specific node
+            description: NodeNetworkConfigurationEnactmentStatus defines the observed state of NodeNetworkConfigurationEnactment
             properties:
               conditions:
                 items:
@@ -102,16 +118,23 @@ spec:
                   - type
                   type: object
                 type: array
-              currentState:
-                description: "State contains the namestatectl yaml [1] as string instead of golang struct so we don't need to be in sync with the schema. \n [1] https://github.com/nmstate/nmstate/blob/master/libnmstate/schemas/operational-state.yaml"
+              desiredState:
+                description: The desired state rendered for the enactment's node using the policy desiredState as template
                 type: object
                 x-kubernetes-preserve-unknown-fields: true
-              lastSuccessfulUpdateTime:
-                format: date-time
-                type: string
+              policyGeneration:
+                description: The generation from policy needed to check if an enactment condition status belongs to the same policy version
+                format: int64
+                type: integer
             type: object
         type: object
     served: true
     storage: true
     subresources:
       status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/data/nmstate/nmstate.io_nodenetworkconfigurationpolicies.yaml
+++ b/data/nmstate/nmstate.io_nodenetworkconfigurationpolicies.yaml
@@ -1,6 +1,11 @@
+
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.4.0
+  creationTimestamp: null
   name: nodenetworkconfigurationpolicies.nmstate.io
 spec:
   group: nmstate.io
@@ -137,3 +142,9 @@ spec:
     storage: true
     subresources:
       status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/data/nmstate/nmstate.io_nodenetworkstates.yaml
+++ b/data/nmstate/nmstate.io_nodenetworkstates.yaml
@@ -1,27 +1,27 @@
+
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: nodenetworkconfigurationenactments.nmstate.io
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.4.0
+  creationTimestamp: null
+  name: nodenetworkstates.nmstate.io
 spec:
   group: nmstate.io
   names:
-    kind: NodeNetworkConfigurationEnactment
-    listKind: NodeNetworkConfigurationEnactmentList
-    plural: nodenetworkconfigurationenactments
+    kind: NodeNetworkState
+    listKind: NodeNetworkStateList
+    plural: nodenetworkstates
     shortNames:
-    - nnce
-    singular: nodenetworkconfigurationenactment
+    - nns
+    singular: nodenetworkstate
   scope: Cluster
   versions:
-  - additionalPrinterColumns:
-    - description: Status
-      jsonPath: .status.conditions[?(@.type=="Available")].reason
-      name: Status
-      type: string
-    name: v1alpha1
+  - name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: NodeNetworkConfigurationEnactment is the Schema for the nodenetworkconfigurationenactments API
+        description: NodeNetworkState is the Schema for the nodenetworkstates API
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
@@ -32,7 +32,7 @@ spec:
           metadata:
             type: object
           status:
-            description: NodeNetworkConfigurationEnactmentStatus defines the observed state of NodeNetworkConfigurationEnactment
+            description: NodeNetworkStateStatus is the status of the NodeNetworkState of a specific node
             properties:
               conditions:
                 items:
@@ -56,29 +56,22 @@ spec:
                   - type
                   type: object
                 type: array
-              desiredState:
-                description: The desired state rendered for the enactment's node using the policy desiredState as template
+              currentState:
                 type: object
                 x-kubernetes-preserve-unknown-fields: true
-              policyGeneration:
-                description: The generation from policy needed to check if an enactment condition status belongs to the same policy version
-                format: int64
-                type: integer
+              lastSuccessfulUpdateTime:
+                format: date-time
+                type: string
             type: object
         type: object
     served: true
     storage: false
     subresources:
       status: {}
-  - additionalPrinterColumns:
-    - description: Status
-      jsonPath: .status.conditions[?(@.type=="Available")].reason
-      name: Status
-      type: string
-    name: v1beta1
+  - name: v1beta1
     schema:
       openAPIV3Schema:
-        description: NodeNetworkConfigurationEnactment is the Schema for the nodenetworkconfigurationenactments API
+        description: NodeNetworkState is the Schema for the nodenetworkstates API
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
@@ -89,7 +82,7 @@ spec:
           metadata:
             type: object
           status:
-            description: NodeNetworkConfigurationEnactmentStatus defines the observed state of NodeNetworkConfigurationEnactment
+            description: NodeNetworkStateStatus is the status of the NodeNetworkState of a specific node
             properties:
               conditions:
                 items:
@@ -113,17 +106,21 @@ spec:
                   - type
                   type: object
                 type: array
-              desiredState:
-                description: The desired state rendered for the enactment's node using the policy desiredState as template
+              currentState:
                 type: object
                 x-kubernetes-preserve-unknown-fields: true
-              policyGeneration:
-                description: The generation from policy needed to check if an enactment condition status belongs to the same policy version
-                format: int64
-                type: integer
+              lastSuccessfulUpdateTime:
+                format: date-time
+                type: string
             type: object
         type: object
     served: true
     storage: true
     subresources:
       status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/data/nmstate/operator.yaml
+++ b/data/nmstate/operator.yaml
@@ -21,6 +21,8 @@ spec:
         app: kubernetes-nmstate
         component: kubernetes-nmstate-webhook
         name: {{template "handlerPrefix" .}}nmstate-webhook
+      annotations:
+        description: kubernetes-nmstate-webhook resets NNCP status
     spec:
       serviceAccountName: {{template "handlerPrefix" .}}nmstate-handler
       nodeSelector: {{ toYaml .PlacementConfiguration.Infra.NodeSelector | nindent 8 }}
@@ -34,7 +36,7 @@ spec:
           image: {{ .HandlerImage }}
           imagePullPolicy: {{ .HandlerPullPolicy }}
           command:
-          - kubernetes-nmstate
+          - manager
           env:
             - name: WATCH_NAMESPACE
               value: ""
@@ -101,11 +103,16 @@ spec:
         app: kubernetes-nmstate
         component: kubernetes-nmstate-handler
         name: {{template "handlerPrefix" .}}nmstate-handler
+      annotations:
+        description: kubernetes-nmstate-handler configures and presents node networking, reconciling declerative NNCP and reports with NNS and NNCE
     spec:
       # Needed to force vlan filtering config with iproute commands until
       # future nmstate/NM is in place.
       # https://github.com/nmstate/nmstate/pull/440
       hostNetwork: true
+      # Use Default to get node's DNS configuration [1]
+      # [1] https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy
+      dnsPolicy: Default
       serviceAccountName: {{template "handlerPrefix" .}}nmstate-handler
       nodeSelector: {{ toYaml .PlacementConfiguration.Workloads.NodeSelector | nindent 8 }}
       tolerations: {{ toYaml .PlacementConfiguration.Workloads.Tolerations | nindent 8 }}
@@ -113,12 +120,12 @@ spec:
       containers:
         - name: nmstate-handler
           args:
-            - --v=production
+          - --v=production
           # Replace this with the built image name
           image: {{ .HandlerImage }}
           imagePullPolicy: {{ .HandlerPullPolicy }}
           command:
-            - kubernetes-nmstate
+            - manager
           env:
             - name: WATCH_NAMESPACE
               value: ""

--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -29,7 +29,7 @@ const (
 	LinuxBridgeCniImageDefault    = "quay.io/kubevirt/cni-default-plugins@sha256:3dd438117076016d6d2acd508b93f106ca80a28c0af6e2e914d812f9a1d55142"
 	LinuxBridgeMarkerImageDefault = "quay.io/kubevirt/bridge-marker@sha256:6132543df838d324020d25979f088138534ca396f7ca995d5af76181fc8080e3"
 	KubeMacPoolImageDefault       = "quay.io/kubevirt/kubemacpool@sha256:4216d83bf7fe08244294e3532a9d7983a1d85a0d8b849ed21258225c00cbf779"
-	NMStateHandlerImageDefault    = "quay.io/nmstate/kubernetes-nmstate-handler@sha256:b4bc41ce7f9e5fa7eef6a25c27ba13770c53fc6710ea8e4c4b5f6cf68e97821c"
+	NMStateHandlerImageDefault    = "quay.io/nmstate/kubernetes-nmstate-handler@sha256:76b5683c2314db8c81a61337d8e473c8821a2d0c7b1a35b6f69b668fb4671716"
 	OvsCniImageDefault            = "quay.io/kubevirt/ovs-cni-plugin@sha256:9db7ddf54b3232b1f55af6f7d37877b15cd4edda0cf7999c971063281ded5235"
 	OvsMarkerImageDefault         = "quay.io/kubevirt/ovs-cni-marker@sha256:8d1f37cee54946072d8ec1eaca3c35244c3b0b9bd10e960c39af2b5d91830091"
 	MacvtapCniImageDefault        = "quay.io/kubevirt/macvtap-cni@sha256:f20d5e56f8b8c1ab7e5a64e536b66f65aa688b2d1dc0b37e3c26c2af2b481266"

--- a/test/releases/99.0.0.go
+++ b/test/releases/99.0.0.go
@@ -36,13 +36,13 @@ func init() {
 				ParentName: "nmstate-handler",
 				ParentKind: "DaemonSet",
 				Name:       "nmstate-handler",
-				Image:      "quay.io/nmstate/kubernetes-nmstate-handler@sha256:b4bc41ce7f9e5fa7eef6a25c27ba13770c53fc6710ea8e4c4b5f6cf68e97821c",
+				Image:      "quay.io/nmstate/kubernetes-nmstate-handler@sha256:76b5683c2314db8c81a61337d8e473c8821a2d0c7b1a35b6f69b668fb4671716",
 			},
 			{
 				ParentName: "nmstate-webhook",
 				ParentKind: "Deployment",
 				Name:       "nmstate-webhook",
-				Image:      "quay.io/nmstate/kubernetes-nmstate-handler@sha256:b4bc41ce7f9e5fa7eef6a25c27ba13770c53fc6710ea8e4c4b5f6cf68e97821c",
+				Image:      "quay.io/nmstate/kubernetes-nmstate-handler@sha256:76b5683c2314db8c81a61337d8e473c8821a2d0c7b1a35b6f69b668fb4671716",
 			},
 			{
 				ParentName: "ovs-cni-amd64",


### PR DESCRIPTION
This PR bumps kubernetes nmstate to v0.33.0 and also fixes a the test flags in the tier1 test.

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
