### PR TITLE
strict-reconcile, Add strict-reconcile test

### DIFF
--- a/test/e2e/workflow/deployment_test.go
+++ b/test/e2e/workflow/deployment_test.go
@@ -1,16 +1,22 @@
 package test
 
 import (
+	"context"
 	"fmt"
 	"time"
 
+	framework "github.com/operator-framework/operator-sdk/pkg/test"
+	v1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/retry"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 
 	cnao "github.com/kubevirt/cluster-network-addons-operator/pkg/apis/networkaddonsoperator/shared"
+	"github.com/kubevirt/cluster-network-addons-operator/pkg/components"
 	"github.com/kubevirt/cluster-network-addons-operator/pkg/network"
 	. "github.com/kubevirt/cluster-network-addons-operator/test/check"
 	. "github.com/kubevirt/cluster-network-addons-operator/test/okd"
@@ -247,6 +253,46 @@ var _ = Describe("NetworkAddonsConfig", func() {
 			By("Comparing the ranges")
 			Expect(rangeStart).ToNot(Equal(oldRangeStart))
 			Expect(rangeEnd).ToNot(Equal(oldRangeEnd))
+		})
+	})
+	Context("when Macvtap is deployed", func() {
+		BeforeEach(func() {
+			configSpec := cnao.NetworkAddonsConfigSpec{
+				MacvtapCni: &cnao.MacvtapCni{},
+			}
+			CreateConfig(gvk, configSpec)
+			CheckConfigCondition(gvk, ConditionAvailable, ConditionTrue, 15*time.Minute, CheckDoNotRepeat)
+		})
+		Context("and a forbidden day2 change is introduced to Macvtap daemonSet", func() {
+			annotationKey := "newDay2Changes"
+			BeforeEach(func() {
+				By("Setting a new Annotation to the macvtap daemonSet")
+				err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+					macvtapDaemonSet := &v1.DaemonSet{}
+					err := framework.Global.Client.Get(context.TODO(), types.NamespacedName{Name: MacvtapComponent.DaemonSets[0], Namespace: components.Namespace}, macvtapDaemonSet)
+					Expect(err).ToNot(HaveOccurred(), "should succeed getting the macvtap daemonSet")
+
+					macvtapDaemonSet.Spec.Template.SetAnnotations(map[string]string{annotationKey: ""})
+					return framework.Global.Client.Update(context.TODO(), macvtapDaemonSet)
+				})
+				Expect(err).ToNot(HaveOccurred(), "should succeed setting a new Annotation to the macvtap daemonSet")
+			})
+
+			It("should reconcile the object and remove the new Annotation", func() {
+				By("checking that the Annotation eventually removed reconciled out by the CNAO operator")
+				Eventually(func() bool {
+					macvtapDaemonSet := &v1.DaemonSet{}
+					err := framework.Global.Client.Get(context.TODO(), types.NamespacedName{Name: MacvtapComponent.DaemonSets[0], Namespace: components.Namespace}, macvtapDaemonSet)
+					Expect(err).ToNot(HaveOccurred(), "should succeed getting the macvtap daemonSet")
+
+					deamonSetAnnotations := macvtapDaemonSet.Spec.Template.GetAnnotations()
+					if _, exist := deamonSetAnnotations[annotationKey]; exist {
+						return false
+					}
+					return true
+
+				}, 2*time.Minute, time.Second).Should(BeTrue(), fmt.Sprintf("Timed out waiting for macvtap daemonset added Annotation to be removed"))
+			})
 		})
 	})
 })


### PR DESCRIPTION
**What this PR does / why we need it**:
CNAO performs strict reconciling to make sure that un-allowed day2
changes are not done on its components.
In order to ensure this functionality does not break, we want to add
a test on a arbitrary component object.
Added a test to make sure strict-reconcile feature is preserved.

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
