### PR TITLE
bumper, Change bumper git action jobs names

### DIFF
--- a/.github/workflows/component-bumper-master.yml
+++ b/.github/workflows/component-bumper-master.yml
@@ -1,4 +1,4 @@
-name: Auto-Bump Components' Versions
+name: master - Auto-Bump Components' Versions
 
 on:
   schedule:

--- a/.github/workflows/component-bumper-release-0.42.yml
+++ b/.github/workflows/component-bumper-release-0.42.yml
@@ -1,4 +1,4 @@
-name: Auto-Bump Components' Versions
+name: release-0.42 - Auto-Bump Components' Versions
 
 on:
   schedule:


### PR DESCRIPTION
**What this PR does / why we need it**:
I initially thought that having the same name, the two workflows (master & release-0.42 bumper jobs) will show up in the same [entree](https://github.com/kubevirt/cluster-network-addons-operator/actions/runs/397658238).
Now that I see it's not like that, I've added this PR to make the master & release-0.42 bumper jobs to have distinct names.

- **bumper, Change bumper git action jobs names**
Currently the job run has a distinctive name, but the workflow job
has the same name. Since the jobs are not grouped, then better to
give them a distinctive name as well.

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
