### PR TITLE
ci, make timeout configurable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,8 +30,10 @@ GINKGO_EXTRA_ARGS ?=
 GINKGO_ARGS ?= --v -r --progress $(GINKGO_EXTRA_ARGS)
 GINKGO ?= build/_output/bin/ginkgo
 
+export E2E_TEST_TIMEOUT ?= 3h
+
 E2E_TEST_EXTRA_ARGS ?=
-E2E_TEST_ARGS ?= $(strip -test.v -test.timeout 3h -ginkgo.v $(E2E_TEST_EXTRA_ARGS))
+E2E_TEST_ARGS ?= $(strip -test.v -test.timeout $(E2E_TEST_TIMEOUT) -ginkgo.v $(E2E_TEST_EXTRA_ARGS))
 E2E_SUITES = \
 	test/e2e/lifecycle \
 	test/e2e/workflow

--- a/automation/check-patch.e2e-lifecycle-k8s.sh
+++ b/automation/check-patch.e2e-lifecycle-k8s.sh
@@ -25,6 +25,7 @@ main() {
         # Since we cannot test upgrade of to-be-released version, drop it from the lifecycle tests
         to_be_released=$(hack/version.sh)
         export RELEASES_DESELECTOR="${to_be_released}"
+        export E2E_TEST_TIMEOUT=4h
     else
         # Don't run all upgrade tests in regular PRs, stick to those released under HCO
         export RELEASES_SELECTOR="{0.18.0,0.23.0,0.27.7,0.39.3,99.0.0}"


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently the ci tests timeout is hardcoded to 3h. since release lifecycle
test are growing past the 3h limit, we want to make the timeout configurable.
Change the ci timeout to be configurable
Updated the lifecycle lane in release case to 4h

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
