### PR TITLE
bumper, add PUSH_IMAGES allow linux-bridge docker push

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -185,7 +185,7 @@ vendor: $(GO)
 	$(GO) mod vendor
 
 auto-bumper: $(GO)
-	$(GO) run $(shell ls tools/bumper/*.go | grep -v test) ${ARGS}
+	PUSH_IMAGES=true $(GO) run $(shell ls tools/bumper/*.go | grep -v test) ${ARGS}
 
 bump-%:
 	CNAO_VERSION=${VERSION} ./hack/components/bump-$*.sh


### PR DESCRIPTION
**What this PR does / why we need it**:
make bump-linux-bridge needs to also push the image to quay.
we do this by adding the PUSH_IMAGES env var to the script.
Since we want the bumper to be able to correctly bump linux-bridge component,
we add this env var to the run in Makefile target

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
