### PR TITLE
bumper, Add quay login to bumper job

### DIFF
--- a/.github/workflows/component-bumper-master.yml
+++ b/.github/workflows/component-bumper-master.yml
@@ -14,6 +14,9 @@ jobs:
     - name: Set environment variables
       run: echo "BASE_BRANCH=master" >> $GITHUB_ENV
 
+    - name: Login to Quay
+      run: docker login -u="kubevirt+network" -p="${{ secrets.QUAY_ROBOT_TOKEN }}" quay.io
+
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2
       with:

--- a/.github/workflows/component-bumper-release-0.42.yml
+++ b/.github/workflows/component-bumper-release-0.42.yml
@@ -14,6 +14,9 @@ jobs:
     - name: Set environment variables
       run: echo "BASE_BRANCH=release-0.42" >> $GITHUB_ENV
 
+    - name: Login to Quay
+      run: docker login -u="kubevirt+network" -p="${{ secrets.QUAY_ROBOT_TOKEN }}" quay.io
+
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2
       with:


### PR DESCRIPTION
**What this PR does / why we need it**:
when bumping linux-bridge component we need to be registered as a quay user
that has write permissions, in order to push them.
Added a step to login to quay using the "kubevirt+network" quay robot credentials.

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
