### PR TITLE
ci, Bump provider to k8s-1.19 on ci lanes

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,8 +313,8 @@ make docker-build-registry
 # bring up a local cluster with Kubernetes
 make cluster-up
 
-# bridge up a local cluster with kubernetes 1.17
-export KUBEVIRT_PROVIDER=k8s-1.17
+# bridge up a local cluster with kubernetes 1.19
+export KUBEVIRT_PROVIDER=k8s-1.19
 make cluster-up
 
 # build images and push them to the local cluster

--- a/automation/check-patch.e2e-lifecycle-k8s.sh
+++ b/automation/check-patch.e2e-lifecycle-k8s.sh
@@ -16,7 +16,7 @@ versionChanged() {
 }
 
 main() {
-    export KUBEVIRT_PROVIDER='k8s-1.17'
+    export KUBEVIRT_PROVIDER='k8s-1.19'
 
     source automation/check-patch.setup.sh
     cd ${TMP_PROJECT_PATH}

--- a/automation/check-patch.e2e-workflow-k8s.sh
+++ b/automation/check-patch.e2e-workflow-k8s.sh
@@ -12,7 +12,7 @@ teardown() {
 }
 
 main() {
-    export KUBEVIRT_PROVIDER='k8s-1.17'
+    export KUBEVIRT_PROVIDER='k8s-1.19'
 
     source automation/check-patch.setup.sh
     cd ${TMP_PROJECT_PATH}


### PR DESCRIPTION
**What this PR does / why we need it**:
ci, Bump provider to k8s-1.19 on ci lanes

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
