### PR TITLE
bumper, fix returning annotated tag sha on tagged update-policy

### DIFF
--- a/tools/bumper/component_commands.go
+++ b/tools/bumper/component_commands.go
@@ -218,7 +218,7 @@ func (componentOps *gitComponent) getLatestTaggedFromBranch(repo, owner, branch,
 
 		for _, commit := range branchCommits {
 			if commit.GetSHA() == commitShaOfTag {
-				return tagName, tag.GetObject().GetSHA(), nil
+				return tagName, commit.GetSHA(), nil
 			}
 		}
 	}

--- a/tools/bumper/component_commands_test.go
+++ b/tools/bumper/component_commands_test.go
@@ -144,6 +144,8 @@ var _ = Describe("Testing internal git component", func() {
 			if r.shouldReturnErr {
 				Expect(err).To(HaveOccurred(), "should fail to run getUpdatedReleaseInfo")
 			} else {
+				Expect(err).ToNot(HaveOccurred(), "should not fail to run getUpdatedReleaseInfo")
+
 				expectedCommit := expectedTagCommitMap[r.expectedTagKey]
 				expectedTag, err := describeHash(repoDir, expectedCommit)
 				Expect(err).ToNot(HaveOccurred(), "should not fail to run describeHash")
@@ -180,13 +182,13 @@ var _ = Describe("Testing internal git component", func() {
 		Entry("Update-policy tagged: should return latest tag in release branch. current: v0.0.2", updatedReleaseParams{
 			comp:            &component{Updatepolicy: updatePolicyTagged, Branch: "release-v1.0.0", Metadata: "v0.0.2"},
 			currentTagKey:   "v0.0.2",
-			expectedTagKey:  "v1.0.1",
+			expectedTagKey:  "v1.0.2",
 			shouldReturnErr: false,
 		}),
 		Entry("Update-policy tagged: should return latest tag in release branch. current: v1.0.0", updatedReleaseParams{
 			comp:            &component{Updatepolicy: updatePolicyTagged, Branch: "release-v1.0.0", Metadata: "v1.0.0"},
 			currentTagKey:   "v1.0.0",
-			expectedTagKey:  "v1.0.1",
+			expectedTagKey:  "v1.0.2",
 			shouldReturnErr: false,
 		}),
 		Entry("Update-policy tagged: should fail if unknown branch", updatedReleaseParams{


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently when using tagged update policy mode, the bumper script is returning
the annotated tag sha and not the relevant commit sha of this tag.
The sha of an annotated tag is different than the sha of it's matching commit,
whereas the sha of lightweight tag is the same as the sha of it's matching commit.
This will cause the future bump to fail, as the annotated tag is not directly connected
via the githubApi.
Moreover, the mocked listMatchingRefs routine did not catch the issue since it used git log, which
show that commit sha's and not the tags themselves in order to assemble the tag list.
Fixed to return the commit sha.
Fixed the listMatchingRefs mock to use 'show-ref --tag', and adjusted the test to catch this issue.

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
