### PR TITLE
components, Fix linux-bridge wrong tagged commit

### DIFF
--- a/components.yaml
+++ b/components.yaml
@@ -13,7 +13,7 @@ components:
     metadata: v0.20.4
   linux-bridge:
     url: https://github.com/containernetworking/plugins
-    commit: 2d6356c08c89ef54b41c16896a519966507866b5
+    commit: e13bab99e54b4a34375450518d7db7a3da825e44
     branch: master
     update-policy: tagged
     metadata: v0.9.0


### PR DESCRIPTION
**What this PR does / why we need it**:
There is a bug that caused the wrong commit to be set on the linux-bridge component in components.yaml, resulting with the bumper job to [fail](https://github.com/kubevirt/cluster-network-addons-operator/actions/runs/433440729).
The bug is fixed on #709, and the manual fix is done on this PR:

- **components, fix linux-bridge wrong tagged commit**
Due to a bug in the bumper, the tag-sha was inserted to the commit field.
This caused the bumper script to fail linux-bridge bump-checks, as the githubApi
uses the commit sha to identify the commit.
Manually fixed the commit field.

**Special notes for your reviewer**:

**Release note**:


```release-note
NONE
```
