### PR TITLE
dockerized yq, Pin yq to version 3.3.4

### DIFF
--- a/hack/components/yaml-utils.sh
+++ b/hack/components/yaml-utils.sh
@@ -3,7 +3,7 @@
 set -xeo pipefail
 
 function __yq() {
-  docker run --rm -i -v ${PWD}:/workdir mikefarah/yq yq "$@"
+  docker run --rm -i -v ${PWD}:/workdir mikefarah/yq:3.3.4 yq "$@"
 }
 
 function __get_parameter_from_yaml() {


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR should fix PR totally failing situation that we currently experience.

- **dockerized yq, Pin yq to version 3.3.4**
Currently some scripts use dockeraized yq in order to parse yamls with ease.
Recently yq issued a new version v4 that breaks former api.
Since we do not need any of the new features presented on v4, we should pin our
script to use the last working yq version 3.3.4

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
