### PR TITLE
validation test, Change test look for warning events

### DIFF
--- a/test/check/check.go
+++ b/test/check/check.go
@@ -609,3 +609,13 @@ func CheckFailedEvent(gvk schema.GroupVersionKind, reason string) {
 	defer close(stopChan)
 	objectEventWatcher.WaitFor(stopChan, WarningEvent, fmt.Sprintf("%s: %s", eventemitter.FailedReason, reason))
 }
+
+func CheckNoWarningEvents(gvk schema.GroupVersionKind, rv string) {
+	By("Check absence of Warning events")
+	config := GetConfig(gvk)
+	configV1 := ConvertToConfigV1(config)
+	objectEventWatcher := NewObjectEventWatcher(configV1).SinceResourceVersion(rv).Timeout(time.Minute)
+	stopChan := make(chan struct{})
+	defer close(stopChan)
+	objectEventWatcher.WaitNotForType(stopChan, WarningEvent)
+}

--- a/test/check/events.go
+++ b/test/check/events.go
@@ -209,3 +209,16 @@ func (w *ObjectEventWatcher) WaitNotFor(stopChan chan struct{}, eventType EventT
 	}, fmt.Sprintf("not happen event type %s, reason = %s", string(eventType), reflect.ValueOf(reason).String()))
 	return
 }
+
+func (w *ObjectEventWatcher) WaitNotForType(stopChan chan struct{}, eventType EventType) (e *corev1.Event) {
+	w.dontFailOnMissingEvent = true
+	w.Watch(stopChan, func(event *corev1.Event) bool {
+		if event.Type == string(eventType) {
+			e = event
+			Fail(fmt.Sprintf("Did not expect %s. reason is %s", string(eventType), event.Reason), 1)
+			return true
+		}
+		return false
+	}, fmt.Sprintf("Event type %s did not occur", string(eventType)))
+	return
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently the validation test It("should remain at Available condition") watches for an
Available event after a component's removal. Since there is a current issue with watching
for repeating events [[1]](https://github.com/kubernetes/kubernetes/issues/97367#issuecomment-747421652), the test is flaky.
Change test to watch for the absence of warning (failure) events instead.

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
