### PR TITLE
bumper, Add a new bumper workflow for release-0.44

### DIFF
--- a/.github/workflows/component-bumper-release-0.44.yml
+++ b/.github/workflows/component-bumper-release-0.44.yml
@@ -1,0 +1,29 @@
+name: Auto-Bump Components' Versions
+
+on:
+  schedule:
+    - cron:  '0 5 * * *'
+
+jobs:
+
+  build:
+    name: release-0.44 - CNAO Component Bump Job
+    runs-on: ubuntu-latest
+    steps:
+
+    - name: Set environment variables
+      run: echo "BASE_BRANCH=release-0.44" >> $GITHUB_ENV
+
+    - name: Login to Quay
+      run: docker login -u="kubevirt+network" -p="${{ secrets.QUAY_ROBOT_TOKEN }}" quay.io
+
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v2
+      with:
+        ref: ${{ env.BASE_BRANCH }}
+
+    - name: Pull latest of latest branch
+      run:  git pull --ff-only --rebase origin ${{ env.BASE_BRANCH }}
+
+    - name: Run bumper script
+      run: make ARGS="-config-path=components.yaml -token=${{ secrets.GITHUB_TOKEN }} -base-branch=${{ env.BASE_BRANCH }}" auto-bumper


### PR DESCRIPTION
**What this PR does / why we need it**:
In order for the bumper to track and auto bump in the release-0.44 stable branch
we add a new workflow to track it.

**Special notes for your reviewer**:
This PR is pending until the PR to update release-0.44's components file is merged (#728).

**Release note**:

```release-note
NONE
```
