### PR TITLE
[release-0.44] bumper, set components.yaml to track stable branches

### DIFF
--- a/components.yaml
+++ b/components.yaml
@@ -3,25 +3,25 @@ components:
     url: https://github.com/kubevirt/bridge-marker
     commit: 967fd7e43523a12a5c97cde834815522e1515a0d
     branch: master
-    update-policy: tagged
+    update-policy: static
     metadata: 0.6.0
   kubemacpool:
     url: https://github.com/k8snetworkplumbingwg/kubemacpool
     commit: 68c40766b8966e2e3e149da2bee5ff55dfc8a6c2
-    branch: master
+    branch: release-v0.21
     update-policy: tagged
     metadata: v0.21.0
   linux-bridge:
     url: https://github.com/containernetworking/plugins
     commit: e13bab99e54b4a34375450518d7db7a3da825e44
     branch: master
-    update-policy: tagged
+    update-policy: static
     metadata: v0.9.0
   macvtap-cni:
     url: https://github.com/kubevirt/macvtap-cni
     commit: 0d5eeca624a707faa018678bd906e3c9f838a3bd
     branch: master
-    update-policy: tagged
+    update-policy: static
     metadata: v0.4.2
   multus:
     url: https://github.com/intel/multus-cni
@@ -32,12 +32,12 @@ components:
   nmstate:
     url: https://github.com/nmstate/kubernetes-nmstate
     commit: 8130868719f272415a0236df1666afeb327cb1bf
-    branch: master
+    branch: release-0.37
     update-policy: tagged
     metadata: v0.37.0
   ovs-cni:
     url: https://github.com/kubevirt/ovs-cni
     commit: 8bf425021750cc622d74968cfb2fe8982bd7776d
     branch: master
-    update-policy: tagged
+    update-policy: static
     metadata: v0.17.0


### PR DESCRIPTION
**What this PR does / why we need it**:
In order for the bumper script to better track the components in
the stable release-0.44 branch, we set components.yaml to track the
stable branch in ones that have stable branches. The rest will be set
to static and will be bumped manually.

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
