### PR TITLE
unit-test, Remove copy to artifact in script

### DIFF
--- a/automation/check-patch.unit-test.sh
+++ b/automation/check-patch.unit-test.sh
@@ -4,14 +4,9 @@
 # cluster on any environment with basic dependencies listed in
 # check-patch.packages installed and docker running.
 
-teardown() {
-    cp $(find . -name "*junit*.xml") $ARTIFACTS
-}
-
 main() {
     source automation/check-patch.setup.sh
     cd ${TMP_PROJECT_PATH}
-    trap teardown EXIT SIGINT SIGTERM SIGSTOP
     make bump-all
     make check
     make docker-build


### PR DESCRIPTION
**What this PR does / why we need it**:
We don't copy anything to artifacts folder during the unit test so
better remove it.
side note: should also fix the issue preventing prow ci [PR](https://github.com/kubevirt/project-infra/pull/811) to pass rehearsals

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
