### PR TITLE
bumper, fix isPrAlreadyOpened on non master branches

### DIFF
--- a/tools/bumper/cnao_repo_commands.go
+++ b/tools/bumper/cnao_repo_commands.go
@@ -155,7 +155,7 @@ func (cnaoRepoOps *gitCnaoRepo) isComponentBumpNeeded(currentReleaseVersion, lat
 func (cnaoRepoOps *gitCnaoRepo) isPrAlreadyOpened(proposedPrTitle string) (bool, error) {
 	logger.Printf("checking if there is an already open bump PR for this release")
 
-	prList, _, err := cnaoRepoOps.githubInterface.listPullRequests(cnaoRepoOps.getCnaoRepoOwnerFromUrl(), cnaoRepoOps.getCnaoRepoNameFromUrl())
+	prList, _, err := cnaoRepoOps.githubInterface.listPullRequests(cnaoRepoOps.getCnaoRepoOwnerFromUrl(), cnaoRepoOps.getCnaoRepoNameFromUrl(), cnaoRepoOps.configParams.Branch)
 	if err != nil {
 		return false, errors.Wrapf(err, "Failed to get list of PRs from %s/%s repo", cnaoRepoOps.getCnaoRepoOwnerFromUrl(), cnaoRepoOps.getCnaoRepoNameFromUrl())
 	}

--- a/tools/bumper/component_commands.go
+++ b/tools/bumper/component_commands.go
@@ -39,7 +39,7 @@ type githubInterface interface {
 	getCommit(owner string, repo string, sha string) (*github.Commit, *github.Response, error)
 	createCommit(owner string, repo string, commit *github.Commit) (*github.Commit, *github.Response, error)
 	updateRef(owner string, repo string, ref *github.Reference, force bool) (*github.Reference, *github.Response, error)
-	listPullRequests(owner string, repo string) ([]*github.PullRequest, *github.Response, error)
+	listPullRequests(owner string, repo string, branch string) ([]*github.PullRequest, *github.Response, error)
 	createPullRequest(owner string, repo string, pull *github.NewPullRequest) (*github.PullRequest, *github.Response, error)
 }
 
@@ -75,8 +75,8 @@ func (g githubApi) updateRef(owner string, repo string, ref *github.Reference, f
 	return g.client.Git.UpdateRef(g.ctx, owner, repo, ref, force)
 }
 
-func (g githubApi) listPullRequests(owner string, repo string) ([]*github.PullRequest, *github.Response, error) {
-	return g.client.PullRequests.List(g.ctx, owner, repo, &github.PullRequestListOptions{State: "open", Base: "master"})
+func (g githubApi) listPullRequests(owner string, repo string, branch string) ([]*github.PullRequest, *github.Response, error) {
+	return g.client.PullRequests.List(g.ctx, owner, repo, &github.PullRequestListOptions{State: "open", Base: branch})
 }
 
 func (g githubApi) createPullRequest(owner string, repo string, pull *github.NewPullRequest) (*github.PullRequest, *github.Response, error) {


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently isPrAlreadyOpened is only checking existance of PRs on
master branch.
Fixed to check specifically on branch
Expanded ci unit test to check isPrAlreadyOpened on branched PRs.

**Special notes for your reviewer**:
Should fix #739

**Release note**:

```release-note
NONE
```
