### PR TITLE
cluster-up, remove NetworkManager installation

### DIFF
--- a/cluster/up.sh
+++ b/cluster/up.sh
@@ -30,19 +30,6 @@ if [[ "$KUBEVIRT_PROVIDER" =~ (ocp|okd)- ]]; then
 fi
 
 if [[ "$KUBEVIRT_PROVIDER" =~ k8s- ]]; then
-    echo 'Install NetworkManager on nodes'
-    for node in $(./cluster/kubectl.sh get nodes --no-headers | awk '{print $1}'); do
-        ./cluster/cli.sh ssh ${node} sudo -- yum install -y yum-plugin-copr
-        ./cluster/cli.sh ssh ${node} sudo -- yum copr enable -y networkmanager/NetworkManager-1.26
-        ./cluster/cli.sh ssh ${node} sudo -- yum install -y NetworkManager-1.26.2 NetworkManager-ovs-1.26.2
-        ./cluster/cli.sh ssh ${node} sudo -- systemctl daemon-reload
-        ./cluster/cli.sh ssh ${node} sudo -- systemctl restart NetworkManager
-        echo "Check NetworkManager is working fine on node $node"
-        ./cluster/cli.sh ssh ${node} -- nmcli device show > /dev/null
-    done
-fi
-
-if [[ "$KUBEVIRT_PROVIDER" =~ k8s- ]]; then
     echo 'Installing Open vSwitch on nodes'
     for node in $(./cluster/kubectl.sh get nodes --no-headers | awk '{print $1}'); do
         ./cluster/cli.sh ssh ${node} -- sudo yum install -y http://cbs.centos.org/kojifiles/packages/openvswitch/2.9.2/1.el7/x86_64/openvswitch-2.9.2-1.el7.x86_64.rpm http://cbs.centos.org/kojifiles/packages/openvswitch/2.9.2/1.el7/x86_64/openvswitch-devel-2.9.2-1.el7.x86_64.rpm http://cbs.centos.org/kojifiles/packages/dpdk/17.11/3.el7/x86_64/dpdk-17.11-3.el7.x86_64.rpm


### PR DESCRIPTION
**What this PR does / why we need it**:
installation of NetworkManager during cluster-up is not needed since
it is already installed during kubeivrtci provisioning [1]

[1] https://github.com/kubevirt/kubevirtci/blob/ad214dc8732b9c8729cdfbe302c7820d3f80f26e/cluster-provision/k8s/1.19/provision.sh#L156

**Special notes for your reviewer**:
fixes #741 

**Release note**:

```release-note
NONE
```
