### PR TITLE
automation, Update CNAO CR to v1 in tier1 setup

### DIFF
--- a/automation/components-functests.setup.sh
+++ b/automation/components-functests.setup.sh
@@ -35,7 +35,7 @@ make cluster-operator-install
 
 # Deploy all network addons components with CNAO
     cat <<EOF | cluster/kubectl.sh apply -f -
-apiVersion: networkaddonsoperator.network.kubevirt.io/v1alpha1
+apiVersion: networkaddonsoperator.network.kubevirt.io/v1
 kind: NetworkAddonsConfig
 metadata:
   name: cluster


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixed the tier1 automation setup to run NetworkAddonsConfig with v1, which is the latest supported version

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
