### PR TITLE
Bump CNI plugins version

### DIFF
--- a/components.yaml
+++ b/components.yaml
@@ -13,10 +13,9 @@ components:
     metadata: v0.22.0
   linux-bridge:
     url: https://github.com/containernetworking/plugins
-    commit: e13bab99e54b4a34375450518d7db7a3da825e44
+    commit: 74a6b28a2c2796a2638ba61a85bb620640bfeb31
     branch: master
-    update-policy: tagged
-    metadata: v0.9.0
+    update-policy: static
   macvtap-cni:
     url: https://github.com/kubevirt/macvtap-cni
     commit: 0d5eeca624a707faa018678bd906e3c9f838a3bd

--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -26,7 +26,7 @@ var (
 
 const (
 	MultusImageDefault            = "quay.io/kubevirt/cluster-network-addon-multus@sha256:32867c73cda4d605651b898dc85fea67d93191c47f27e1ad9e9f2b9041c518de"
-	LinuxBridgeCniImageDefault    = "quay.io/kubevirt/cni-default-plugins@sha256:606eaa06262ad6edd5aa809491c7e46b9ddbc9c52ba8c47e89e734e3e80cd311"
+	LinuxBridgeCniImageDefault    = "quay.io/kubevirt/cni-default-plugins@sha256:a90902cf3e5154424148bf3ba3c1bf90316cc77a54042cf6584fe8aedbe6daec"
 	LinuxBridgeMarkerImageDefault = "quay.io/kubevirt/bridge-marker@sha256:799459f8509a06ea643aa2f6ac02826721a641333aacab07e53166139a5a66c3"
 	KubeMacPoolImageDefault       = "quay.io/kubevirt/kubemacpool@sha256:3efeba40b46b41c8361bf0f247cf98471e70e0dae36fc43eb15d5dbd2e61946e"
 	NMStateHandlerImageDefault    = "quay.io/nmstate/kubernetes-nmstate-handler@sha256:3e9748a805d723fef24bc08e0830acec9718f2c7920d7aef6b6eee2e01630e48"

--- a/test/releases/99.0.0.go
+++ b/test/releases/99.0.0.go
@@ -24,7 +24,7 @@ func init() {
 				ParentName: "kube-cni-linux-bridge-plugin",
 				ParentKind: "DaemonSet",
 				Name:       "cni-plugins",
-				Image:      "quay.io/kubevirt/cni-default-plugins@sha256:606eaa06262ad6edd5aa809491c7e46b9ddbc9c52ba8c47e89e734e3e80cd311",
+				Image:      "quay.io/kubevirt/cni-default-plugins@sha256:a90902cf3e5154424148bf3ba3c1bf90316cc77a54042cf6584fe8aedbe6daec",
 			},
 			{
 				ParentName: "kubemacpool-mac-controller-manager",


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the master branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it

If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**What this PR does / why we need it**:

    Update linux bridge CNI to the current master:   
    The last release was quite a long time ago and the branch now contains
    many bugfixes.
    
    Build our own binaries for CNI plugins:   
    With this we are not dependent on CNI plugins releases and can pin to
    the latest patches any time.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
Bump CNI plugins to 74a6b2
```
