### PR TITLE
Don't run etcd in memory by default

### DIFF
--- a/cluster/cluster.sh
+++ b/cluster/cluster.sh
@@ -13,9 +13,9 @@
 # limitations under the License.
 
 export KUBEVIRT_PROVIDER=${KUBEVIRT_PROVIDER:-'k8s-1.19'}
-export KUBEVIRTCI_TAG='2012111613-af55d4f'
+export KUBEVIRTCI_TAG='2102031339-9306210'
 
-KUBEVIRTCI_VERSION='af55d4ff8553d54463bc99452af744f0dd9e8f46'
+KUBEVIRTCI_VERSION="9306210cbf3905b7df2e11a62a30a0c3bc60c470"
 KUBEVIRTCI_REPO='https://github.com/kubevirt/kubevirtci.git'
 # The CLUSTER_PATH var is used in cluster folder and points to the _kubevirtci where the cluster is deployed from.
 CLUSTER_PATH=${CLUSTER_PATH:-"${PWD}/_kubevirtci/"}


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the master branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it

If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**What this PR does / why we need it**:
Current kubevirtci version runs etcd in memory looks like at some
release branches we reach the ramdisk size limit also the last
kubevirtci disable etcd in memory by default. This change bumps
kubevirtci so we use the sane defaults.

**Special notes for your reviewer**:
kubevirtci commit that disable etcd in memory by default https://github.com/kubevirt/kubevirtci/commit/54dfc80fc5eb11d92e534f6948208fb28b7735f0

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
