### PR TITLE
certs, Add cert defaults to kubemacpool's bump script and manifest

### DIFF
--- a/automation/check-patch.e2e-lifecycle-k8s.sh
+++ b/automation/check-patch.e2e-lifecycle-k8s.sh
@@ -30,7 +30,7 @@ main() {
         export E2E_TEST_TIMEOUT=4h
     else
         # Don't run all upgrade tests in regular PRs, stick to those released under HCO
-        export RELEASES_SELECTOR="{0.18.0,0.23.0,0.27.7,0.39.3,0.42.4,99.0.0}"
+        export RELEASES_SELECTOR="{0.18.0,0.39.3,0.42.0,0.44.0,99.0.0}"
     fi
 
     make cluster-down

--- a/data/kubemacpool/kubemacpool.yaml
+++ b/data/kubemacpool/kubemacpool.yaml
@@ -280,13 +280,13 @@ spec:
               key: RANGE_END
               name: kubemacpool-mac-range-config
         - name: CA_ROTATE_INTERVAL
-          value: '{{ .CARotateInterval }}'
+          value: '{{ .CARotateInterval | default "8760h0m0s" }}'
         - name: CA_OVERLAP_INTERVAL
-          value: '{{ .CAOverlapInterval }}'
+          value: '{{ .CAOverlapInterval | default "24h0m0s" }}'
         - name: CERT_ROTATE_INTERVAL
-          value: '{{ .CertRotateInterval }}'
+          value: '{{ .CertRotateInterval | default "4380h0m0s" }}'
         - name: CERT_OVERLAP_INTERVAL
-          value: '{{ .CertOverlapInterval }}'
+          value: '{{ .CertOverlapInterval | default "24h0m0s" }}'
         - name: KUBEVIRT_CLIENT_GO_SCHEME_REGISTRATION_VERSION
           value: v1
         image: '{{ .KubeMacPoolImage }}'

--- a/hack/components/bump-kubemacpool.sh
+++ b/hack/components/bump-kubemacpool.sh
@@ -52,13 +52,13 @@ spec:
         name: manager
         env:
           - name: CA_ROTATE_INTERVAL
-            value: "{{ .CARotateInterval }}"
+            value: "{{ .CARotateInterval | default \"8760h0m0s\" }}"
           - name: CA_OVERLAP_INTERVAL
-            value: "{{ .CAOverlapInterval }}"
+            value: "{{ .CAOverlapInterval | default \"24h0m0s\" }}"
           - name: CERT_ROTATE_INTERVAL
-            value: "{{ .CertRotateInterval }}"
+            value: "{{ .CertRotateInterval | default \"4380h0m0s\" }}"
           - name: CERT_OVERLAP_INTERVAL
-            value: "{{ .CertOverlapInterval }}"
+            value: "{{ .CertOverlapInterval | default \"24h0m0s\" }}"
 EOF
 
     cat <<EOF > config/cnao/cnao_placement_patch.yaml


### PR DESCRIPTION
**What this PR does / why we need it**:
The PR adds cert default to kubemacpool's bump script and manifest, to prevent upgrade issues

- **lifecycle test, Add recent releases**
currently during non-release PR we only check old release
Until we insert something more synamic, manually removing
some of the old releases and introducing new ones.

- **certs, add cert default to kubemacpool's bump script and manifest**
add cert defaults in kubemacpool manifest so that during upgrade
the parameters are not reset.

**Special notes for your reviewer**:
The first commit **should fail** standalone until we introduce the cert defaults change in the second commit.

**Release note**:

```release-note
NONE
```
