### PR TITLE
Remove Secret leftover checks at lifecycle test

### DIFF
--- a/test/check/check.go
+++ b/test/check/check.go
@@ -196,14 +196,6 @@ func CheckForLeftoverObjects(currentVersion string) {
 	Expect(err).NotTo(HaveOccurred())
 	Expect(namespaces.Items).To(BeEmpty(), "Found leftover objects from the previous operator version")
 
-	secrets := corev1.SecretList{}
-	err = framework.Global.Client.List(context.Background(), &secrets, &listOptions)
-	Expect(err).NotTo(HaveOccurred())
-	for _, secret := range secrets.Items {
-		_, ok := secret.GetAnnotations()[names.REJECT_OWNER_ANNOTATION]
-		Expect(ok).To(BeTrue(), "Found leftover secret objects from the previous operator version")
-	}
-
 	clusterRoles := rbacv1.ClusterRoleList{}
 	err = framework.Global.Client.List(context.Background(), &clusterRoles, &listOptions)
 	Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the master branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it

If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**What this PR does / why we need it**:
Depending on the CNAO version the Secret has different annotations and
sometimes they are removed and sometimes not, this change just remove
the check since Secret is something managed by kube-admission-webhook
and not CNAO.


**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
