### PR TITLE
Use HCO cert rotation default values

### DIFF
--- a/pkg/network/self_sign_configuration.go
+++ b/pkg/network/self_sign_configuration.go
@@ -9,10 +9,10 @@ import (
 )
 
 const (
-	caRotateIntervalDefault    = 7 * 24 * time.Hour // 7 days
-	caOverlapIntervalDefault   = 24 * time.Hour     // 1 day
-	certRotateIntervalDefault  = 24 * time.Hour     // 1 day
-	certOverlapIntervalDefault = 8 * time.Hour      // 8 hour
+	caRotateIntervalDefault    = 48 * time.Hour
+	caOverlapIntervalDefault   = 24 * time.Hour
+	certRotateIntervalDefault  = 24 * time.Hour
+	certOverlapIntervalDefault = 12 * time.Hour
 )
 
 // validateSelfSignConfiguration validates the following fields


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the master branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it

If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**What this PR does / why we need it**:
CNAO uses different values than the ones used at HCO. This change align
both so we detect issues with that sooner.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
Use rotate cert default configuration from HCO
```
