### PR TITLE
Use default at bad old self signed conf

### DIFF
--- a/pkg/network/self_sign_configuration.go
+++ b/pkg/network/self_sign_configuration.go
@@ -99,13 +99,21 @@ func DefaultSelfSignConfiguration() *cnao.SelfSignConfiguration {
 	}
 }
 func fillDefaultsSelfSignConfiguration(conf, previous *cnao.NetworkAddonsConfigSpec) []error {
-	if conf.SelfSignConfiguration == nil || conf.SelfSignConfiguration.CARotateInterval == "" || conf.SelfSignConfiguration.CAOverlapInterval == "" || conf.SelfSignConfiguration.CertRotateInterval == "" || conf.SelfSignConfiguration.CertOverlapInterval == "" {
-		if previous != nil && previous.SelfSignConfiguration != nil {
-			conf.SelfSignConfiguration = previous.SelfSignConfiguration
-			return []error{}
-		}
+	isMissingSelfSignConfiguration := func(confToCheck *cnao.NetworkAddonsConfigSpec) bool {
+		return confToCheck.SelfSignConfiguration == nil ||
+			confToCheck.SelfSignConfiguration.CARotateInterval == "" ||
+			confToCheck.SelfSignConfiguration.CAOverlapInterval == "" ||
+			confToCheck.SelfSignConfiguration.CertRotateInterval == "" ||
+			confToCheck.SelfSignConfiguration.CertOverlapInterval == ""
+	}
 
-		conf.SelfSignConfiguration = DefaultSelfSignConfiguration()
+	if isMissingSelfSignConfiguration(conf) {
+		if previous != nil && !isMissingSelfSignConfiguration(previous) {
+			conf.SelfSignConfiguration = previous.SelfSignConfiguration
+
+		} else {
+			conf.SelfSignConfiguration = DefaultSelfSignConfiguration()
+		}
 	}
 	return []error{}
 }

--- a/pkg/network/self_sign_configuration_test.go
+++ b/pkg/network/self_sign_configuration_test.go
@@ -319,5 +319,53 @@ var _ = Describe("Testing SelfSignConfiguration", func() {
 				CertOverlapInterval: "1h",
 			},
 		}),
+		Entry("When self sign is nil and a previous conf selfSignConfiguration is missing CARotateInterval should return default values", fillDefaultsCase{
+			previousConfig: &cnao.NetworkAddonsConfigSpec{
+				SelfSignConfiguration: &cnao.SelfSignConfiguration{
+					CARotateInterval:    "",
+					CAOverlapInterval:   "1h",
+					CertRotateInterval:  "1h",
+					CertOverlapInterval: "2h",
+				},
+			},
+			currentConfig:  &cnao.NetworkAddonsConfigSpec{},
+			expectedConfig: defaultSelfSignConfiguration,
+		}),
+		Entry("When self sign is nil and a previous conf selfSignConfiguration is missing CAOverlapInterval should return default values", fillDefaultsCase{
+			previousConfig: &cnao.NetworkAddonsConfigSpec{
+				SelfSignConfiguration: &cnao.SelfSignConfiguration{
+					CARotateInterval:    "1h",
+					CAOverlapInterval:   "",
+					CertRotateInterval:  "1h",
+					CertOverlapInterval: "2h",
+				},
+			},
+			currentConfig:  &cnao.NetworkAddonsConfigSpec{},
+			expectedConfig: defaultSelfSignConfiguration,
+		}),
+		Entry("When self sign is nil and a previous conf selfSignConfiguration is missing CertRotateInterval should return default values", fillDefaultsCase{
+			previousConfig: &cnao.NetworkAddonsConfigSpec{
+				SelfSignConfiguration: &cnao.SelfSignConfiguration{
+					CARotateInterval:    "1h",
+					CAOverlapInterval:   "3h",
+					CertRotateInterval:  "",
+					CertOverlapInterval: "2h",
+				},
+			},
+			currentConfig:  &cnao.NetworkAddonsConfigSpec{},
+			expectedConfig: defaultSelfSignConfiguration,
+		}),
+		Entry("When self sign is nil and a previous conf selfSignConfiguration is missing CertOverlapIntervalOverlapInterval  should return default values", fillDefaultsCase{
+			previousConfig: &cnao.NetworkAddonsConfigSpec{
+				SelfSignConfiguration: &cnao.SelfSignConfiguration{
+					CARotateInterval:    "1h",
+					CAOverlapInterval:   "3h",
+					CertRotateInterval:  "4h",
+					CertOverlapInterval: "",
+				},
+			},
+			currentConfig:  &cnao.NetworkAddonsConfigSpec{},
+			expectedConfig: defaultSelfSignConfiguration,
+		}),
 	)
 })


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the master branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it

If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->
**What this PR does / why we need it**:

If previous selfSignConfiguration is missing a field like in the case of
certOverlapInterval (it was not introduced at the beginning) then the
default values are not going to be used and the defaults from the
manifests apply so we can end up with a bad overall configuration. This
change use default values if previous ones were missing one of the
fields.

**Special notes for your reviewer**:

A follow up PR will be done testing that after upgrade certs are not rotated.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
