### PR TITLE
kubevirt, Increase kubevirt deploy timeout

### DIFF
--- a/hack/deploy-kubevirt.sh
+++ b/hack/deploy-kubevirt.sh
@@ -26,6 +26,6 @@ until ./cluster/kubectl.sh -n kubevirt get kv kubevirt; do
     sleep 1
 done
 
-./cluster/kubectl.sh wait -n kubevirt kv kubevirt --for condition=Available --timeout 180s || (echo "KubeVirt not ready in time" && exit 1)
+./cluster/kubectl.sh wait -n kubevirt kv kubevirt --for condition=Available --timeout 360s || (echo "KubeVirt not ready in time" && exit 1)
 
 echo "basename -- $0 done"


### PR DESCRIPTION
**What this PR does / why we need it**:
sometimes automation tests fail on kubevirt not being ready.
increasing timeout to 360s, and by that aligning to [HCO](https://github.com/kubevirt/hyperconverged-cluster-operator/blob/c8c49f989ab8ff5415dae8c4f1063fc08ff76963/tests/travis-tests/test.sh#L9) and [KMP](https://github.com/k8snetworkplumbingwg/kubemacpool/pull/283)

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
