### PR TITLE
test/unit, update admissionregistration to v1 in merge_test.go

### DIFF
--- a/pkg/apply/merge_test.go
+++ b/pkg/apply/merge_test.go
@@ -292,7 +292,7 @@ metadata:
 		}
 		var (
 			template = `
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
   name: nmstate


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR updates admissionregistration to v1 in merge_test.go manifest
**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
