### PR TITLE
auto-bumper, set release-0.53 workflow to hourly

### DIFF
--- a/.github/workflows/component-bumper-release-0.53.yml
+++ b/.github/workflows/component-bumper-release-0.53.yml
@@ -2,7 +2,7 @@ name: Auto-Bump Components' Versions
 
 on:
   schedule:
-    - cron:  '0 5 * * *'
+    - cron:  '0 * * * *'
 
 jobs:
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR sets the auto-bumper to run hourly on the release-0.53 branch,
similarly to all the other workflows.

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
