### PR TITLE
Add relationship labels to all directly deployed components

### DIFF
--- a/pkg/controller/networkaddonsconfig/networkaddonsconfig_controller_suite_test.go
+++ b/pkg/controller/networkaddonsconfig/networkaddonsconfig_controller_suite_test.go
@@ -1,0 +1,13 @@
+package networkaddonsconfig_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestNetwork(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Networkaddonsconfig Suite")
+}

--- a/pkg/controller/networkaddonsconfig/networkaddonsconfig_controller_test.go
+++ b/pkg/controller/networkaddonsconfig/networkaddonsconfig_controller_test.go
@@ -1,0 +1,163 @@
+package networkaddonsconfig
+
+import (
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/kubevirt/cluster-network-addons-operator/pkg/names"
+	"github.com/kubevirt/cluster-network-addons-operator/pkg/render"
+)
+
+type checkUnit struct {
+	key           string
+	shouldExist   bool
+	expectedValue string
+}
+
+var _ = Describe("Networkaddonsconfig", func() {
+	const testDataFile = "testdata/data.yaml"
+
+	Context("When CR is not labeled", func() {
+		var objs []*unstructured.Unstructured
+
+		BeforeEach(func() {
+			var err error
+			renderData := render.MakeRenderData()
+			objs, err = render.RenderTemplate(testDataFile, &renderData)
+			Expect(err).NotTo(HaveOccurred())
+
+			crLabels := map[string]string{}
+			err = updateObjectsLabels(crLabels, objs)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("Should find only default relationship labels", func() {
+			appLabelKeys := []checkUnit{
+				{
+					key:           names.COMPONENT_LABEL_KEY,
+					shouldExist:   true,
+					expectedValue: names.COMPONENT_LABEL_DEFAULT_VALUE,
+				},
+				{
+					key:           names.MANAGED_BY_LABEL_KEY,
+					shouldExist:   true,
+					expectedValue: names.MANAGED_BY_LABEL_DEFAULT_VALUE,
+				},
+				{
+					key:           names.PART_OF_LABEL_KEY,
+					shouldExist:   false,
+					expectedValue: "Invalid",
+				},
+				{
+					key:           names.VERSION_LABEL_KEY,
+					shouldExist:   false,
+					expectedValue: "Invalid",
+				},
+			}
+
+			checkObjectsRelationshipLabels(objs, appLabelKeys)
+		})
+	})
+	Context("When CR is labeled", func() {
+		var objs []*unstructured.Unstructured
+		var crLabels map[string]string
+		const expectedComponentLabel = "component_unit_tests"
+		const expectedManagedByLabel = "managed_by_unit_tests"
+		const expectedPartOfLabel = "part_of_unit_tests"
+		const expectedVersionLabel = "version_of_unit_tests"
+
+		BeforeEach(func() {
+			var err error
+			renderData := render.MakeRenderData()
+			objs, err = render.RenderTemplate(testDataFile, &renderData)
+			Expect(err).NotTo(HaveOccurred())
+
+			crLabels = map[string]string{}
+			crLabels[names.COMPONENT_LABEL_KEY] = expectedComponentLabel
+			crLabels[names.MANAGED_BY_LABEL_KEY] = expectedManagedByLabel
+			crLabels[names.PART_OF_LABEL_KEY] = expectedPartOfLabel
+			crLabels[names.VERSION_LABEL_KEY] = expectedVersionLabel
+			err = updateObjectsLabels(crLabels, objs)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("Should find all labels, overridden by CR labels", func() {
+			appLabelKeys := []checkUnit{
+				{
+					key:           names.COMPONENT_LABEL_KEY,
+					shouldExist:   true,
+					expectedValue: expectedComponentLabel,
+				},
+				{
+					key:           names.MANAGED_BY_LABEL_KEY,
+					shouldExist:   true,
+					expectedValue: expectedManagedByLabel,
+				},
+				{
+					key:           names.PART_OF_LABEL_KEY,
+					shouldExist:   true,
+					expectedValue: expectedPartOfLabel,
+				},
+				{
+					key:           names.VERSION_LABEL_KEY,
+					shouldExist:   true,
+					expectedValue: expectedVersionLabel,
+				},
+			}
+
+			checkObjectsRelationshipLabels(objs, appLabelKeys)
+		})
+	})
+})
+
+func checkObjectsRelationshipLabels(objs []*unstructured.Unstructured, appLabelKeys []checkUnit) {
+	appLabelsNotExists := []checkUnit{
+		{
+			key:           names.COMPONENT_LABEL_KEY,
+			shouldExist:   false,
+			expectedValue: "Invalid",
+		},
+		{
+			key:           names.MANAGED_BY_LABEL_KEY,
+			shouldExist:   false,
+			expectedValue: "Invalid",
+		},
+		{
+			key:           names.PART_OF_LABEL_KEY,
+			shouldExist:   false,
+			expectedValue: "Invalid",
+		},
+		{
+			key:           names.VERSION_LABEL_KEY,
+			shouldExist:   false,
+			expectedValue: "Invalid",
+		},
+	}
+
+	for _, obj := range objs {
+		labels := obj.GetLabels()
+		checkLabels(labels, appLabelKeys)
+
+		kind := obj.GetKind()
+		templateLabels, _, _ := unstructured.NestedStringMap(obj.Object, "spec", "template", "metadata", "labels")
+		if kind == "DaemonSet" || kind == "ReplicaSet" || kind == "Deployment" || kind == "StatefulSet" {
+			checkLabels(templateLabels, appLabelKeys)
+		} else {
+			checkLabels(templateLabels, appLabelsNotExists)
+		}
+	}
+}
+
+func checkLabels(labels map[string]string, units []checkUnit) {
+	for _, unit := range units {
+		value, found := labels[unit.key]
+		Expect(found).To(Equal(unit.shouldExist), fmt.Sprintf("%s exist test", unit.key))
+		if unit.shouldExist {
+			Expect(value).To(Equal(unit.expectedValue), fmt.Sprintf("%s value test", unit.key))
+		}
+	}
+}

--- a/pkg/controller/networkaddonsconfig/testdata/data.yaml
+++ b/pkg/controller/networkaddonsconfig/testdata/data.yaml
@@ -1,0 +1,70 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    control-plane: mac-controller-manager
+    controller-tools.k8s.io: "1.0"
+  name: kubemacpool-mac-controller-manager
+  namespace: test-ns
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      control-plane: mac-controller-manager
+      controller-tools.k8s.io: "1.0"
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      annotations:
+        description: KubeMacPool manages MAC allocation to Pods and VMs
+      labels:
+        app: kubemacpool
+        control-plane: mac-controller-manager
+        controller-tools.k8s.io: "1.0"
+    spec:
+        image: dummy
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    control-plane: mac-controller-manager
+    controller-tools.k8s.io: "1.0"
+  name: kubemacpool-mac-range-config
+  namespace: cluster-network-addons
+data:
+  RANGE_START: 00:00:00:00:00:04
+  RANGE_END: 00:00:00:00:00:05
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  labels:
+    component: kubernetes-nmstate-handler
+    networkaddonsoperator.network.kubevirt.io/version: 99.0.0
+  name: nmstate-handler
+  namespace: cluster-network-addons
+spec:
+  selector:
+    matchLabels:
+      name: nmstate-handler
+  template:
+    metadata:
+      labels:
+        app: kubernetes-nmstate
+        component: kubernetes-nmstate-handler
+        name: nmstate-handler
+    spec:
+        image: dummy
+        imagePullPolicy: IfNotPresent
+        name: nmstate-handler
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  annotations:
+    kubernetes.io/service-account.name: cluster-network-addons-operator
+  name: cluster-network-addons-operator-token-test
+  namespace: cluster-network-addons
+type: kubernetes.io/service-account-token

--- a/pkg/names/names.go
+++ b/pkg/names/names.go
@@ -12,3 +12,11 @@ const APPLIED_PREFIX = "cluster-networks-addons-operator-applied-"
 // assigned with NetworkAddonsConfig as their owner. This can be used to prevent
 // garbage collection deletion upon NetworkAddonsConfig removal.
 const REJECT_OWNER_ANNOTATION = "networkaddonsoperator.network.kubevirt.io/rejectOwner"
+
+// Relationship labels
+const COMPONENT_LABEL_KEY = "app.kubernetes.io/component"
+const PART_OF_LABEL_KEY = "app.kubernetes.io/part-of"
+const VERSION_LABEL_KEY = "app.kubernetes.io/version"
+const MANAGED_BY_LABEL_KEY = "app.kubernetes.io/managed-by"
+const COMPONENT_LABEL_DEFAULT_VALUE = "network"
+const MANAGED_BY_LABEL_DEFAULT_VALUE = "cnao-operator"


### PR DESCRIPTION
Each component deployed by CNAO should have labels on its resources.

The labels are called relationship labels (app.kubernetes.io/*),
and are used in order to create a relationship graph in the UI.

The labels are:
`app.kubernetes.io/component`
`app.kubernetes.io/managed-by`
`app.kubernetes.io/version`
`app.kubernetes.io/part-of`

This PR adapts Render function to add those labels to all the directly deployed components.
Follow PRs on each component repository will handle its own internal deployed components.

Signed-off-by: Or Shoval <oshoval@redhat.com>

```release-note
None
```
