### PR TITLE
[release-0.53] macvtap-cni, update repo main branch

### DIFF
--- a/components.yaml
+++ b/components.yaml
@@ -20,7 +20,7 @@ components:
   macvtap-cni:
     url: https://github.com/kubevirt/macvtap-cni
     commit: 0d5eeca624a707faa018678bd906e3c9f838a3bd
-    branch: master
+    branch: main
     update-policy: static
     metadata: v0.4.2
   multus:


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR updates the components.yaml with macvtap-cni's new main branch

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
