### PR TITLE
[release-0.42] macvtap-cni, update repo main branch

### DIFF
--- a/components.yaml
+++ b/components.yaml
@@ -38,6 +38,6 @@ components:
   macvtap-cni:
     url: "https://github.com/kubevirt/macvtap-cni"
     commit: "ced0fb4ce9ae9719b21269c7636b7d8ac14a6e6b"
-    branch: "master"
+    branch: "main"
     update-policy: "static"
     metadata: "v0.3.1"


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR updates the components.yaml with macvtap-cni's new main branch

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
