### PR TITLE
[release-0.42] automation, add missing unit-test script

### DIFF
--- a/automation/check-patch.unit-test.sh
+++ b/automation/check-patch.unit-test.sh
@@ -1,0 +1,15 @@
+#!/bin/bash -e
+
+# This script should be able to execute functional tests against Kubernetes
+# cluster on any environment with basic dependencies listed in
+# check-patch.packages installed and docker running.
+
+main() {
+    source automation/check-patch.setup.sh
+    cd ${TMP_PROJECT_PATH}
+    make bump-all
+    make check
+    make docker-build
+}
+
+[[ "${BASH_SOURCE[0]}" == "$0" ]] && main "$@"


### PR DESCRIPTION
**What this PR does / why we need it**:
Ths PR adds a missing script needed for the `pull-cluster-network-addons-operator-unit-test` lane

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
