### PR TITLE
[release-0.42] components, Change kubemacpool to follow stable branch

### DIFF
--- a/components.yaml
+++ b/components.yaml
@@ -20,8 +20,8 @@ components:
   kubemacpool:
     url: "https://github.com/k8snetworkplumbingwg/kubemacpool"
     commit: "932d5f04ee508c9f39516010b40d2170705d2cb7"
-    branch: "master"
-    update-policy: "static"
+    branch: "release-v0.20"
+    update-policy: "tagged"
     metadata: "v0.20.2"
   nmstate:
     url: "https://github.com/nmstate/kubernetes-nmstate"


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR changes kubemacpool to follow stable branch release-v0.20

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
