### PR TITLE
[release-0.42] kubemacpool, bump kubemacpool to v0.20.2-1-gf6c5fc0d

### DIFF
--- a/components.yaml
+++ b/components.yaml
@@ -19,10 +19,10 @@ components:
     metadata: "0.3.0"
   kubemacpool:
     url: "https://github.com/k8snetworkplumbingwg/kubemacpool"
-    commit: "932d5f04ee508c9f39516010b40d2170705d2cb7"
+    commit: "f6c5fc0db8a28fc2cb5c9c586dbc56d5a7aabaab"
     branch: "release-v0.20"
-    update-policy: "tagged"
-    metadata: "v0.20.2"
+    update-policy: "static"
+    metadata: "v0.20.2-1-gf6c5fc0d"
   nmstate:
     url: "https://github.com/nmstate/kubernetes-nmstate"
     commit: "8de6a0202b5d4a7313abed22ac13a70b0e9761b6"

--- a/data/kubemacpool/kubemacpool.yaml
+++ b/data/kubemacpool/kubemacpool.yaml
@@ -301,9 +301,6 @@ spec:
           initialDelaySeconds: 10
           periodSeconds: 10
         resources:
-          limits:
-            cpu: 300m
-            memory: 600Mi
           requests:
             cpu: 100m
             memory: 300Mi

--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -28,7 +28,7 @@ const (
 	MultusImageDefault            = "nfvpe/multus@sha256:167722b954355361bd69829466f27172b871dbdbf86b85a95816362885dc0aba"
 	LinuxBridgeCniImageDefault    = "quay.io/kubevirt/cni-default-plugins@sha256:3dd438117076016d6d2acd508b93f106ca80a28c0af6e2e914d812f9a1d55142"
 	LinuxBridgeMarkerImageDefault = "quay.io/kubevirt/bridge-marker@sha256:e55f73526468fee46a35ae41aa860f492d208b8a7a132832c5b9a76d4a51566a"
-	KubeMacPoolImageDefault       = "quay.io/kubevirt/kubemacpool@sha256:79c4534d418c4a350a663e38499c22d54dc68c400f517aead4479f6d862b408e"
+	KubeMacPoolImageDefault       = "quay.io/kubevirt/kubemacpool@sha256:a9308e7da500dabd596ae04448d1c925ef4692ff051355f0cffb579abbe604f1"
 	NMStateHandlerImageDefault    = "quay.io/nmstate/kubernetes-nmstate-handler@sha256:3feeb377a4a89caf37fdab45d13f93620e1cf5ff8cbc91aa19ae32cd5cfa3a32"
 	OvsCniImageDefault            = "quay.io/kubevirt/ovs-cni-plugin@sha256:4101c52617efb54a45181548c257a08e3689f634b79b9dfcff42bffd8b25af53"
 	OvsMarkerImageDefault         = "quay.io/kubevirt/ovs-cni-marker@sha256:0f08d6b1550a90c9f10221f2bb07709d1090e7c675ee1a711981bd429074d620"

--- a/test/releases/99.0.0.go
+++ b/test/releases/99.0.0.go
@@ -30,7 +30,7 @@ func init() {
 				ParentName: "kubemacpool-mac-controller-manager",
 				ParentKind: "Deployment",
 				Name:       "manager",
-				Image:      "quay.io/kubevirt/kubemacpool@sha256:79c4534d418c4a350a663e38499c22d54dc68c400f517aead4479f6d862b408e",
+				Image:      "quay.io/kubevirt/kubemacpool@sha256:a9308e7da500dabd596ae04448d1c925ef4692ff051355f0cffb579abbe604f1",
 			},
 			{
 				ParentName: "nmstate-handler",


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR pins kubemacpool to a specific commit and tag v0.20.2-1-gf6c5fc0d.

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
