### PR TITLE
tests, Add missing condition of labels check

### DIFF
--- a/test/check/check.go
+++ b/test/check/check.go
@@ -384,8 +384,10 @@ func checkForGenericDeployment(name, namespace string, checkLabels bool) error {
 		labels := deployment.GetLabels()
 		if labels != nil {
 			if _, operatorLabelSet := labels[cnaov1.SchemeGroupVersion.Group+"/version"]; !operatorLabelSet {
-				return fmt.Errorf("Deployment %s/%s is missing operator label", components.Namespace, name)
+				return fmt.Errorf("Deployment %s/%s is missing operator label", namespace, name)
 			}
+		} else {
+			return fmt.Errorf("Deployment %s/%s is missing meta labels", namespace, name)
 		}
 	}
 


### PR DESCRIPTION
In case `checkForGenericDeployment` required to check
metadata labels, it should fail in case the labels
doesn't exists at all.

* Add the missing else statement.
* Fix using of namespace arg instead of global
components.Namespace for the prints.

Signed-off-by: Or Shoval <oshoval@redhat.com>

```release-note
None
```
