### PR TITLE
[release-0.42] Change ovs-cni repo to k8snetworkplumbing

### DIFF
--- a/components.yaml
+++ b/components.yaml
@@ -30,7 +30,7 @@ components:
     update-policy: "tagged"
     metadata: "v0.31.1"
   ovs-cni:
-    url: "https://github.com/kubevirt/ovs-cni"
+    url: "https://github.com/k8snetworkplumbingwg/ovs-cni"
     commit: "edb4754d08f49be54c399c938895fe82aab6aa5a"
     branch: "release-0.12"
     update-policy: "static"


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR changes ovs-cni repo to k8snetworkplumbing

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
