### PR TITLE
[release-0.53] Change ovs-cni repo to k8snetworkplumbing

### DIFF
--- a/components.yaml
+++ b/components.yaml
@@ -36,7 +36,7 @@ components:
     update-policy: static
     metadata: v0.47.0
   ovs-cni:
-    url: https://github.com/kubevirt/ovs-cni
+    url: https://github.com/k8snetworkplumbingwg/ovs-cni
     commit: 95d453c97fa7d68af8b6f63fd9697689d68b5bf5
     branch: master
     update-policy: static


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR changes ovs-cni repo to k8snetworkplumbing

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
