### PR TITLE
operator, Add Priority class

### DIFF
--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -161,6 +161,7 @@ func GetDeployment(version string, operatorVersion string, namespace string, rep
 					SecurityContext: &corev1.PodSecurityContext{
 						RunAsNonRoot: &runAsNonRoot,
 					},
+					PriorityClassName: "system-cluster-critical",
 					Containers: []corev1.Container{
 						{
 							Name:            Name,


### PR DESCRIPTION
Add system-cluster-critical to CNAO operator.
Since CNAO operator isn't bound to a specific node,
yet its an important pod, assign system-cluster-critical
pc to it.
This will make the control plane less sensitive to preemption
than user workloads.

Signed-off-by: Or Shoval <oshoval@redhat.com>

```release-note
None
```
