### PR TITLE
linux-bridge, Add Priority class

### DIFF
--- a/data/linux-bridge/002-linux-bridge.yaml
+++ b/data/linux-bridge/002-linux-bridge.yaml
@@ -26,6 +26,7 @@ spec:
       affinity: {{ toYaml .Placement.Affinity | nindent 8 }}
       nodeSelector: {{ toYaml .Placement.NodeSelector | nindent 8 }}
       tolerations: {{ toYaml .Placement.Tolerations | nindent 8 }}
+      priorityClassName: system-cluster-critical
       containers:
         - name: cni-plugins
           image: {{ .LinuxBridgeImage }}


### PR DESCRIPTION
Add `system-cluster-critical` to `linux-bridge-plugin` DaemonSet.
Since linux bridge's pod isn't bound to a specific node,
(it mostly copies some binaries to the node)
yet its an important pod, assign `system-cluster-critical`
pc to it.
This will make the control plane less sensitive to preemption
than user workloads.

Signed-off-by: Or Shoval <oshoval@redhat.com>

```release-note
None
```
