### PR TITLE
multus, Add Priority class

### DIFF
--- a/data/multus/001-multus.yaml
+++ b/data/multus/001-multus.yaml
@@ -133,6 +133,7 @@ spec:
         - name: cnibin
           hostPath:
             path: {{ .CNIBinDir }}
+      priorityClassName: system-cluster-critical
       affinity: {{ toYaml .Placement.Affinity | nindent 8 }}
 {{ if .EnableSCC }}
 ---

--- a/hack/components/bump-multus.sh
+++ b/hack/components/bump-multus.sh
@@ -25,6 +25,7 @@ function __parametize_by_object() {
 				yaml-utils::update_param ${f} spec.template.metadata.labels.name 'kube-multus-ds-amd64'
 				yaml-utils::update_param ${f} spec.template.spec.containers[0].image '{{ .MultusImage }}'
 				yaml-utils::set_param ${f} spec.template.spec.containers[0].imagePullPolicy '{{ .ImagePullPolicy }}'
+				yaml-utils::set_param ${f} spec.template.spec.priorityClassName 'system-cluster-critical'
 				yaml-utils::delete_param ${f} spec.template.spec.containers[0].volumeMounts[2]
 				yaml-utils::update_param ${f} spec.template.spec.volumes[0].hostPath.path '{{ .CNIConfigDir }}'
 				yaml-utils::update_param ${f} spec.template.spec.volumes[1].hostPath.path '{{ .CNIBinDir }}'


### PR DESCRIPTION
As part of https://bugzilla.redhat.com/show_bug.cgi?id=1953482
We are adding Priority Class to each network component.

The motivation is to make the control plane pods less sensitive to preemption
than user workloads.

Add `system-cluster-critical` to multus DaemonSet.
Since multus isn't bound to a specific node,
yet its an important pod, assign `system-cluster-critical` pc to it.

Signed-off-by: Or Shoval <oshoval@redhat.com>

```release-note
None
```
