### PR TITLE
release-0.53, Update k8s-nmstate to use tagged policy

### DIFF
--- a/components.yaml
+++ b/components.yaml
@@ -33,7 +33,7 @@ components:
     url: https://github.com/nmstate/kubernetes-nmstate
     commit: 27eef45a9bb2552d05fab4dd37c3c2ff892bdc66
     branch: release-0.47
-    update-policy: static
+    update-policy: tagged
     metadata: v0.47.1
   ovs-cni:
     url: https://github.com/k8snetworkplumbingwg/ovs-cni


### PR DESCRIPTION
Since k8s-nmstate has a stable branch,
we can use tagged policy instead of static.
This way, each new release of k8s-nmstate release-0.47
will be auto consumed by CNAO bumper.

Signed-off-by: Or Shoval <oshoval@redhat.com>

```release-note
None
```
