### PR TITLE
macvtap, release-0.53, Bump to version 0.5.0

### DIFF
--- a/components.yaml
+++ b/components.yaml
@@ -19,10 +19,10 @@ components:
     metadata: ""
   macvtap-cni:
     url: https://github.com/kubevirt/macvtap-cni
-    commit: 0d5eeca624a707faa018678bd906e3c9f838a3bd
+    commit: cf906de886cf7dfd7e4091b869609f7237976c60
     branch: main
     update-policy: static
-    metadata: v0.4.2
+    metadata: v0.5.0
   multus:
     url: https://github.com/k8snetworkplumbingwg/multus-cni
     commit: 4eac660359f223d34bcaf0fddbc42fd542f02ba1

--- a/data/macvtap/002-macvtap-daemonset.yaml
+++ b/data/macvtap/002-macvtap-daemonset.yaml
@@ -24,6 +24,7 @@ spec:
     spec:
       hostNetwork: true
       hostPID: true
+      priorityClassName: system-node-critical
       containers:
         - name: macvtap-cni
           command: ["/macvtap-deviceplugin", "-v", "3", "-logtostderr"]

--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -32,7 +32,7 @@ const (
 	NMStateHandlerImageDefault    = "quay.io/nmstate/kubernetes-nmstate-handler@sha256:d5d29fd6bb273340f2f8a44c077f4587114e39e7a8560a8e2cfdf0f0b8406024"
 	OvsCniImageDefault            = "quay.io/kubevirt/ovs-cni-plugin@sha256:9ea002a51fd6cd706064a13e4eb79618e286f31be291ea4485de92675f26daa1"
 	OvsMarkerImageDefault         = "quay.io/kubevirt/ovs-cni-marker@sha256:dca0d0432eacb1e97ea49c755df1c232159fe4267e7f872222ef0ef77e3d8915"
-	MacvtapCniImageDefault        = "quay.io/kubevirt/macvtap-cni@sha256:f20d5e56f8b8c1ab7e5a64e536b66f65aa688b2d1dc0b37e3c26c2af2b481266"
+	MacvtapCniImageDefault        = "quay.io/kubevirt/macvtap-cni@sha256:375af0a38e07281d6018ad92a63d115f3e78f2b30d53f728891073ac0510cee9"
 )
 
 type AddonsImages struct {


### PR DESCRIPTION
See https://github.com/kubevirt/macvtap-cni/releases/tag/v0.5.0

Signed-off-by: Or Shoval <oshoval@redhat.com>

```release-note
None
```
