### PR TITLE
bridge-marker, release-0.53, Set source as tagged

### DIFF
--- a/components.yaml
+++ b/components.yaml
@@ -2,8 +2,8 @@ components:
   bridge-marker:
     url: https://github.com/kubevirt/bridge-marker
     commit: 967fd7e43523a12a5c97cde834815522e1515a0d
-    branch: main
-    update-policy: static
+    branch: release-0.6
+    update-policy: tagged
     metadata: 0.6.0
   kubemacpool:
     url: https://github.com/k8snetworkplumbingwg/kubemacpool


### PR DESCRIPTION
A stable branch was created on bridge-marker for
CNAO release-0.53.
Update manifest to use it.

Signed-off-by: Or Shoval <oshoval@redhat.com>

```release-note
None
```
