### PR TITLE
ovs-cni, release-0.53, Set source as tagged

### DIFF
--- a/components.yaml
+++ b/components.yaml
@@ -38,6 +38,6 @@ components:
   ovs-cni:
     url: https://github.com/k8snetworkplumbingwg/ovs-cni
     commit: 95d453c97fa7d68af8b6f63fd9697689d68b5bf5
-    branch: main
-    update-policy: static
+    branch: release-0.19
+    update-policy: tagged
     metadata: v0.19.1


### PR DESCRIPTION
A stable branch was created on ovs-cni for
CNAO release-0.53.
Update manifest to use it.

Signed-off-by: Or Shoval <oshoval@redhat.com>

```release-note
None
```
