### PR TITLE
resources, Update multus resources section

### DIFF
--- a/data/multus/001-multus.yaml
+++ b/data/multus/001-multus.yaml
@@ -113,11 +113,8 @@ spec:
             - "--cni-version=0.3.1"
           resources:
             requests:
-              cpu: "100m"
-              memory: "50Mi"
-            limits:
-              cpu: "100m"
-              memory: "50Mi"
+              cpu: "5m"
+              memory: "10Mi"
           securityContext:
             privileged: true
           volumeMounts:

--- a/hack/components/bump-multus.sh
+++ b/hack/components/bump-multus.sh
@@ -30,6 +30,9 @@ function __parametize_by_object() {
 				yaml-utils::update_param ${f} spec.template.spec.volumes[0].hostPath.path '{{ .CNIConfigDir }}'
 				yaml-utils::update_param ${f} spec.template.spec.volumes[1].hostPath.path '{{ .CNIBinDir }}'
 				yaml-utils::delete_param ${f} spec.template.spec.volumes[2]
+				yaml-utils::delete_param ${f} spec.template.spec.containers[0].resources.limits
+				yaml-utils::update_param ${f} spec.template.spec.containers[0].resources.requests.cpu '"5m"'
+				yaml-utils::update_param ${f} spec.template.spec.containers[0].resources.requests.memory '"10Mi"'
 				yaml-utils::update_param ${f} spec.template.spec.nodeSelector '{{ toYaml .Placement.NodeSelector | nindent 8 }}'
 				yaml-utils::set_param ${f} spec.template.spec.affinity '{{ toYaml .Placement.Affinity | nindent 8 }}'
 				yaml-utils::update_param ${f} spec.template.spec.tolerations '{{ toYaml .Placement.Tolerations | nindent 8 }}'


### PR DESCRIPTION
Remove resources limits for multus, as limits should not
be set for the control plane.

Update resources requests according to empiric use cases.

See https://bugzilla.redhat.com/show_bug.cgi?id=1935218

Signed-off-by: Or Shoval <oshoval@redhat.com>

```release-note
None
```
