### PR TITLE
Add alerts infra and basic alert CnaoDown

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,7 +81,7 @@ whitespace: $(all_sources)
 	./hack/whitespace.sh --fix
 	touch $@
 
-check: whitespace-check vet goimports-check gen-k8s-check test/unit
+check: whitespace-check vet goimports-check gen-k8s-check test/unit prom-rules-verify
 	./hack/check.sh
 
 whitespace-check: $(all_sources)
@@ -120,6 +120,11 @@ docker-push-operator:
 
 docker-push-registry:
 	docker push $(IMAGE_REGISTRY)/$(REGISTRY_IMAGE):$(IMAGE_TAG)
+
+prom-rules-verify:
+	hack/prom-rule-ci/verify-rules.sh \
+	data/monitoring/prom-rule.yaml \
+	hack/prom-rule-ci/prom-rules-tests.yaml
 
 cluster-up:
 	./cluster/up.sh
@@ -221,4 +226,5 @@ bump-all: bump-nmstate bump-kubemacpool bump-macvtap-cni bump-linux-bridge bump-
 	bump-% \
 	bump-all \
 	gen-k8s \
+	prom-rules-verify \
 	release

--- a/cluster/up.sh
+++ b/cluster/up.sh
@@ -18,6 +18,9 @@ set -ex
 
 SCRIPTS_PATH="$(dirname "$(realpath "$0")")"
 source ${SCRIPTS_PATH}/cluster.sh
+
+export KUBEVIRT_DEPLOY_PROMETHEUS=true
+
 cluster::install
 
 $(cluster::path)/cluster-up/up.sh

--- a/data/monitoring/prom-rule.yaml
+++ b/data/monitoring/prom-rule.yaml
@@ -1,0 +1,9 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    prometheus.cnao.io: ""
+  name: prometheus-rules-cluster-network-addons-operator
+  namespace: {{ .Namespace }}
+spec:
+  groups:

--- a/data/monitoring/prom-rule.yaml
+++ b/data/monitoring/prom-rule.yaml
@@ -7,3 +7,15 @@ metadata:
   namespace: {{ .Namespace }}
 spec:
   groups:
+    - name: kubevirt.cnao.rules
+      rules:
+        - expr: sum(up{namespace='{{ .Namespace }}', pod=~'cluster-network-addons-operator-.*'} or vector(0))
+          record: kubevirt_cnao_num_up_operators
+        - alert: CnaoDown
+          annotations:
+            summary: CNAO pod is down.
+            runbook_url: http://kubevirt.io/monitoring/runbooks/CnaoDown
+          expr: kubevirt_cnao_num_up_operators == 0
+          for: 5m
+          labels:
+            severity: warning

--- a/data/monitoring/rbac.yaml
+++ b/data/monitoring/rbac.yaml
@@ -1,0 +1,30 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: cluster-network-addons-operator-monitoring
+  namespace: {{ .Namespace }}
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - services
+      - endpoints
+      - pods
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: cluster-network-addons-operator-monitoring
+  namespace: {{ .Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: cluster-network-addons-operator-monitoring
+subjects:
+  - kind: ServiceAccount
+    name: {{ .MonitoringServiceAccount }}
+    namespace: {{ .MonitoringNamespace }}

--- a/data/monitoring/service.yaml
+++ b/data/monitoring/service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    prometheus.cnao.io: ""
+  name: cluster-network-addons-operator-prometheus-metrics
+  namespace: {{ .Namespace }}
+spec:
+  ports:
+    - name: metrics
+      port: 8080
+      protocol: TCP
+      targetPort: metrics
+  selector:
+    prometheus.cnao.io: ""
+  sessionAffinity: None
+  type: ClusterIP

--- a/data/monitoring/service_monitor.yaml
+++ b/data/monitoring/service_monitor.yaml
@@ -1,0 +1,20 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    openshift.io/cluster-monitoring: ""
+    prometheus.cnao.io: ""
+  name: service-monitor-cluster-network-addons-operator
+  namespace: {{ .Namespace }}
+spec:
+  selector:
+    matchLabels:
+      prometheus.cnao.io: ""
+  namespaceSelector:
+    matchNames:
+      - {{ .Namespace }}
+  endpoints:
+    - port: metrics
+      scheme: http
+      tlsConfig:
+        insecureSkipVerify: true

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ require (
 	github.com/Masterminds/sprig v2.22.0+incompatible
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/coreos/go-semver v0.3.0
+	github.com/coreos/prometheus-operator v0.38.1-0.20200424145508-7e176fda06cc
 	github.com/getlantern/deepcopy v0.0.0-20160317154340-7f45deb8130a
 	github.com/ghodss/yaml v1.0.1-0.20190212211648-25d852aebe32
 	github.com/github-release/github-release v0.8.1

--- a/hack/components/yaml-utils.sh
+++ b/hack/components/yaml-utils.sh
@@ -6,7 +6,7 @@ function __yq() {
   docker run --rm -i -v ${PWD}:/workdir:Z mikefarah/yq:3.3.4 yq "$@"
 }
 
-function __get_parameter_from_yaml() {
+function yaml-utils::get_param() {
 	local yaml_file=$1
 	local arg=$2
 	__yq r ${yaml_file} ${arg}
@@ -28,7 +28,7 @@ function yaml-utils::update_param() {
 	local path=$2
 	local new_value="$3"
 
-	local old_value=$(__get_parameter_from_yaml ${yaml_file} ${path})
+	local old_value=$(yaml-utils::get_param ${yaml_file} ${path})
 	if [ ! -z "${old_value}" ]; then
 		yaml-utils::set_param ${yaml_file} ${path} "${new_value}"
 	else
@@ -50,13 +50,13 @@ function yaml-utils::delete_param() {
 function yaml-utils::get_component_url() {
 	local component=$1
 	arg=components.\"${component}\".url
-	__get_parameter_from_yaml components.yaml ${arg}
+	yaml-utils::get_param components.yaml ${arg}
 }
 
 function yaml-utils::get_component_commit() {
 	local component=$1
 	arg=components.\"${component}\".commit
-	__get_parameter_from_yaml components.yaml ${arg}
+	yaml-utils::get_param components.yaml ${arg}
 }
 
 function yaml-utils::get_component_repo() {
@@ -89,8 +89,8 @@ function yaml-utils::rename_files_by_object() {
 	local output_dir=$1
 
 	for f in ${output_dir}/*; do
-		local kind=$(__get_parameter_from_yaml ${f} kind)
-		local name=$(__get_parameter_from_yaml ${f} metadata.name)
+		local kind=$(yaml-utils::get_param ${f} kind)
+		local name=$(yaml-utils::get_param ${f} metadata.name)
 		mv ${f} ${output_dir}/${kind}_${name}.yaml
 
 	done

--- a/hack/prom-rule-ci/prom-rules-tests.yaml
+++ b/hack/prom-rule-ci/prom-rules-tests.yaml
@@ -1,0 +1,37 @@
+---
+rule_files:
+  - /tmp/rules.verify.yaml
+
+group_eval_order:
+  - kubevirt.cnao.rules
+
+tests:
+# CnaoDown positive tests
+  - interval: 1m
+    input_series:
+      - series: "kubevirt_cnao_num_up_operators"
+        values: "0 0 0 0 0 0"
+
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: CnaoDown
+        exp_alerts:
+          - exp_annotations:
+              summary: "CNAO pod is down."
+              runbook_url: "http://kubevirt.io/monitoring/runbooks/CnaoDown"
+            exp_labels:
+              severity: "warning"
+# CnaoDown negative tests
+  - interval: 1m
+    input_series:
+      - series: "kubevirt_cnao_num_up_operators"
+        values: "1 1 1 0 1 1"
+      - series: "kubevirt_cnao_num_up_operators"
+        values: "1 1 1 1 1 1"
+      - series: "kubevirt_cnao_num_up_operators"
+        values: "0 0 0 0 0 1"
+
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: CnaoDown
+        exp_alerts:

--- a/hack/prom-rule-ci/verify-rules.sh
+++ b/hack/prom-rule-ci/verify-rules.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+
+set -xe
+
+source hack/components/yaml-utils.sh
+
+TMP_PATH=$(mktemp -d -p /tmp -t alerts-test-XXXXXX)
+PROMETHERUS_IMAGE=quay.io/prometheus/prometheus:v2.15.2
+
+teardown() {
+  rm -rf "${TMP_PATH}"
+}
+
+# get_prometheus_rule_spec extracts the spec from the prometheus rule instance
+get_prometheus_rule_spec() {
+  local prom_yaml=$1
+  local output_prom_spec=$2
+
+  prom_rule_spec=$(yaml-utils::get_param ${prom_yaml} spec)
+  echo "${prom_rule_spec}" >${output_prom_spec}
+}
+
+# test_setup prepares all the needed files in the tmp folder
+test_setup() {
+  local prom_yaml=$1
+  local tests_yaml=$2
+  local tmp_prom_spec=$3
+  local tmp_tests_file=$4
+
+  get_prometheus_rule_spec ${prom_yaml} ${tmp_prom_spec}
+  cp ${tests_yaml} ${tmp_tests_file}
+}
+
+verify_prom_spec() {
+  local tmp_prom_spec=$1
+
+  docker run --rm --entrypoint=/bin/promtool \
+  -v ${tmp_prom_spec}:/tmp/rules.verify.yaml:ro \
+  ${PROMETHERUS_IMAGE} \
+  check rules /tmp/rules.verify.yaml
+}
+
+check_rules() {
+  local tmp_prom_spec=$1
+  local tmp_tests_file=$2
+
+  docker run --rm --entrypoint=/bin/promtool \
+  -v ${tmp_prom_spec}:/tmp/rules.verify.yaml:ro \
+  -v ${tmp_tests_file}:/tmp/rules.test.yaml:ro \
+  ${PROMETHERUS_IMAGE} \
+  test rules /tmp/rules.test.yaml
+}
+
+main() {
+  local prom_yaml="${1:?}"
+  local tests_file="${2:?}"
+  local tmp_prom_spec=${TMP_PATH}/prom-spec
+  local tmp_tests_file=${TMP_PATH}/prom-rules-tests.yaml
+
+  trap teardown EXIT SIGINT
+
+  test_setup ${prom_yaml} ${tests_file} ${tmp_prom_spec} ${tmp_tests_file}
+
+  verify_prom_spec ${tmp_prom_spec}
+  check_rules ${tmp_prom_spec} ${tmp_tests_file}
+}
+
+main "$@"

--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -260,6 +260,14 @@ func GetDeployment(version string, operatorVersion string, namespace string, rep
 									Name:  "WATCH_NAMESPACE",
 									Value: "",
 								},
+								{
+									Name:  "MONITORING_NAMESPACE",
+									Value: "openshift-monitoring",
+								},
+								{
+									Name:  "MONITORING_SERVICE_ACCOUNT",
+									Value: "prometheus-k8s",
+								},
 							},
 						},
 					},

--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -13,6 +13,7 @@ import (
 
 	cnao "github.com/kubevirt/cluster-network-addons-operator/pkg/apis/networkaddonsoperator/shared"
 	cnaov1 "github.com/kubevirt/cluster-network-addons-operator/pkg/apis/networkaddonsoperator/v1"
+	"github.com/kubevirt/cluster-network-addons-operator/pkg/names"
 	"github.com/kubevirt/cluster-network-addons-operator/pkg/util/k8s"
 )
 
@@ -137,6 +138,9 @@ func GetDeployment(version string, operatorVersion string, namespace string, rep
 			Annotations: map[string]string{
 				cnaov1.SchemeGroupVersion.Group + "/version": k8s.StringToLabel(operatorVersion),
 			},
+			Labels: map[string]string{
+				names.PROMETHEUS_LABEL_KEY: "",
+			},
 		},
 		Spec: appsv1.DeploymentSpec{
 			Replicas: int32Ptr(1),
@@ -151,7 +155,8 @@ func GetDeployment(version string, operatorVersion string, namespace string, rep
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{
-						"name": Name,
+						"name":                     Name,
+						names.PROMETHEUS_LABEL_KEY: "",
 					},
 					Annotations: map[string]string{
 						"description": "cluster-network-addons-operator manages the lifecycle of different Kubernetes network components on top of Kubernetes cluster",

--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -13,6 +13,7 @@ import (
 
 	cnao "github.com/kubevirt/cluster-network-addons-operator/pkg/apis/networkaddonsoperator/shared"
 	cnaov1 "github.com/kubevirt/cluster-network-addons-operator/pkg/apis/networkaddonsoperator/v1"
+	"github.com/kubevirt/cluster-network-addons-operator/pkg/monitoring"
 	"github.com/kubevirt/cluster-network-addons-operator/pkg/names"
 	"github.com/kubevirt/cluster-network-addons-operator/pkg/util/k8s"
 )
@@ -177,6 +178,13 @@ func GetDeployment(version string, operatorVersion string, namespace string, rep
 								Requests: corev1.ResourceList{
 									corev1.ResourceCPU:    resource.MustParse("50m"),
 									corev1.ResourceMemory: resource.MustParse("30Mi"),
+								},
+							},
+							Ports: []corev1.ContainerPort{
+								corev1.ContainerPort{
+									Name:          "metrics",
+									Protocol:      "TCP",
+									ContainerPort: monitoring.GetMetricsPort(),
 								},
 							},
 							Env: []corev1.EnvVar{

--- a/pkg/controller/networkaddonsconfig/networkaddonsconfig_controller.go
+++ b/pkg/controller/networkaddonsconfig/networkaddonsconfig_controller.go
@@ -504,6 +504,11 @@ func updateObjectsLabels(crLables map[string]string, objs []*unstructured.Unstru
 		}
 		// Label objects with version of the operator they were created by
 		labels[cnaov1.SchemeGroupVersion.Group+"/version"] = operatorVersionLabel
+		labels[names.PROMETHEUS_LABEL_KEY] = ""
+		err = updateObjectTemplateLabels(obj, labels, []string{names.PROMETHEUS_LABEL_KEY})
+		if err != nil {
+			return err
+		}
 
 		appLabelKeys := []string{names.COMPONENT_LABEL_KEY, names.PART_OF_LABEL_KEY, names.VERSION_LABEL_KEY, names.MANAGED_BY_LABEL_KEY}
 

--- a/pkg/controller/networkaddonsconfig/networkaddonsconfig_controller.go
+++ b/pkg/controller/networkaddonsconfig/networkaddonsconfig_controller.go
@@ -92,7 +92,7 @@ func Add(mgr manager.Manager) error {
 	}
 	clusterInfo.SCCAvailable = sccAvailable
 
-	addMonitorServiceResources, err := isMonitoringAvailable(clientset)
+	addMonitorServiceResources, err := IsMonitoringAvailable(clientset)
 	if err != nil {
 		// we don't want CNAO to fail only if monitoring cannot be activated.
 		addMonitorServiceResources = false
@@ -608,7 +608,7 @@ func isSCCAvailable(c kubernetes.Interface) (bool, error) {
 }
 
 // isMonitoringAvailable checks if we can deploy the monitoring component
-func isMonitoringAvailable(c kubernetes.Interface) (bool, error) {
+func IsMonitoringAvailable(c kubernetes.Interface) (bool, error) {
 	prometheusRuleResourceAvailable, err := isResourceAvailable(c, "customresourcedefinitions/prometheusrules.monitoring.coreos.com", "apiextensions.k8s.io", "v1")
 	if err != nil {
 		return false, errors.Wrap(err, "failed to check if prometheusRule resource is available")

--- a/pkg/controller/networkaddonsconfig/networkaddonsconfig_controller.go
+++ b/pkg/controller/networkaddonsconfig/networkaddonsconfig_controller.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	monitoringv1 "github.com/coreos/prometheus-operator/pkg/apis/monitoring/v1"
 	osv1 "github.com/openshift/api/operator/v1"
 	osnetnames "github.com/openshift/cluster-network-operator/pkg/names"
 	"github.com/pkg/errors"
@@ -90,6 +91,14 @@ func Add(mgr manager.Manager) error {
 		return fmt.Errorf("failed to check for availability of SCC: %v", err)
 	}
 	clusterInfo.SCCAvailable = sccAvailable
+
+	addMonitorServiceResources, err := isMonitoringAvailable(clientset)
+	if err != nil {
+		// we don't want CNAO to fail only if monitoring cannot be activated.
+		addMonitorServiceResources = false
+		log.Printf("failed to check for availability of Monitoring namespace: %v", err)
+	}
+	clusterInfo.MonitoringAvailable = addMonitorServiceResources
 
 	return add(mgr, newReconciler(mgr, namespace, clusterInfo))
 }
@@ -596,6 +605,26 @@ func isRunningOnOpenShift4(c kubernetes.Interface) (bool, error) {
 
 func isSCCAvailable(c kubernetes.Interface) (bool, error) {
 	return isResourceAvailable(c, "securitycontextconstraints", "security.openshift.io", "v1")
+}
+
+// isMonitoringAvailable checks if we can deploy the monitoring component
+func isMonitoringAvailable(c kubernetes.Interface) (bool, error) {
+	prometheusRuleResourceAvailable, err := isResourceAvailable(c, "customresourcedefinitions/prometheusrules.monitoring.coreos.com", "apiextensions.k8s.io", "v1")
+	if err != nil {
+		return false, errors.Wrap(err, "failed to check if prometheusRule resource is available")
+	}
+
+	serviceMonitorResourceAvailable, err := isResourceAvailable(c, "customresourcedefinitions/servicemonitors.monitoring.coreos.com", "apiextensions.k8s.io", "v1")
+	if err != nil {
+		return false, errors.Wrap(err, "failed to check if serviceMonitor resource is available")
+	}
+
+	if prometheusRuleResourceAvailable && serviceMonitorResourceAvailable {
+		return true, nil
+	}
+
+	log.Printf("will not deploy monitoring manifests: not all monitoring resources are available: %s: %v, %s, %v", monitoringv1.PrometheusRuleKind, prometheusRuleResourceAvailable, monitoringv1.ServiceMonitorsKind, serviceMonitorResourceAvailable)
+	return false, nil
 }
 
 func isRunningKubernetesNMStateOperator(c k8sclient.Client) (bool, error) {

--- a/pkg/monitoring/metrics.go
+++ b/pkg/monitoring/metrics.go
@@ -1,0 +1,29 @@
+package monitoring
+
+import (
+	"regexp"
+	"strconv"
+
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+const defaultMetricPort = 8080
+
+func init() {
+	metrics.Registry.MustRegister()
+}
+
+func GetMetricsAddress() string {
+	return metrics.DefaultBindAddress
+}
+
+func GetMetricsPort() int32 {
+	re := regexp.MustCompile(`(?m).*:(\d+)`)
+
+	portString := re.ReplaceAllString(metrics.DefaultBindAddress, "$1")
+	portInt64, err := strconv.ParseUint(portString, 10, 32)
+	if err != nil {
+		return defaultMetricPort
+	}
+	return int32(portInt64)
+}

--- a/pkg/names/names.go
+++ b/pkg/names/names.go
@@ -13,6 +13,8 @@ const APPLIED_PREFIX = "cluster-networks-addons-operator-applied-"
 // garbage collection deletion upon NetworkAddonsConfig removal.
 const REJECT_OWNER_ANNOTATION = "networkaddonsoperator.network.kubevirt.io/rejectOwner"
 
+const PROMETHEUS_LABEL_KEY = "prometheus.cnao.io"
+
 // Relationship labels
 const COMPONENT_LABEL_KEY = "app.kubernetes.io/component"
 const PART_OF_LABEL_KEY = "app.kubernetes.io/part-of"

--- a/pkg/network/cluster-info.go
+++ b/pkg/network/cluster-info.go
@@ -1,7 +1,8 @@
 package network
 
 type ClusterInfo struct {
-	SCCAvailable    bool
-	OpenShift4      bool
-	NmstateOperator bool
+	SCCAvailable        bool
+	OpenShift4          bool
+	NmstateOperator     bool
+	MonitoringAvailable bool
 }

--- a/pkg/network/network.go
+++ b/pkg/network/network.go
@@ -7,6 +7,8 @@ import (
 	"reflect"
 	"strings"
 
+	"github.com/kubevirt/cluster-network-addons-operator/pkg/monitoring"
+
 	osv1 "github.com/openshift/api/operator/v1"
 	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -136,6 +138,13 @@ func Render(conf *cnao.NetworkAddonsConfigSpec, manifestDir string, openshiftNet
 
 	// render MacvtapCni
 	o, err = renderMacvtapCni(conf, manifestDir, clusterInfo)
+	if err != nil {
+		return nil, err
+	}
+	objs = append(objs, o...)
+
+	// render Monitoring Service
+	o, err = monitoring.RenderMonitoring(manifestDir, clusterInfo.MonitoringAvailable)
 	if err != nil {
 		return nil, err
 	}

--- a/templates/cluster-network-addons/VERSION/namespace.yaml.in
+++ b/templates/cluster-network-addons/VERSION/namespace.yaml.in
@@ -5,3 +5,4 @@ metadata:
   name: {{.Namespace}}
   labels:
     name: {{.Namespace}}
+    openshift.io/cluster-monitoring: "true"

--- a/test/check/components.go
+++ b/test/check/components.go
@@ -17,6 +17,9 @@ type Component struct {
 	Deployments                  []string
 	Secret                       string
 	MutatingWebhookConfiguration string
+	Service                      string
+	ServiceMonitor               string
+	PrometheusRule               string
 }
 
 var (
@@ -32,6 +35,7 @@ var (
 		ClusterRole:                "bridge-marker-cr",
 		ClusterRoleBinding:         "bridge-marker-crb",
 		SecurityContextConstraints: "linux-bridge",
+		ServiceMonitor:             "",
 		DaemonSets: []string{
 			"bridge-marker",
 			"kube-cni-linux-bridge-plugin",
@@ -76,6 +80,12 @@ var (
 			"macvtap-cni",
 		},
 	}
+	MonitoringComponent = Component{
+		ComponentName:  "Monitoring",
+		Service:        "cluster-network-addons-operator-prometheus-metrics",
+		ServiceMonitor: "service-monitor-cluster-network-addons-operator",
+		PrometheusRule: "prometheus-rules-cluster-network-addons-operator",
+	}
 	AllComponents = []Component{
 		KubeMacPoolComponent,
 		LinuxBridgeComponent,
@@ -83,6 +93,7 @@ var (
 		NMStateComponent,
 		OvsComponent,
 		MacvtapComponent,
+		MonitoringComponent,
 	}
 )
 

--- a/test/e2e/lifecycle/main_test.go
+++ b/test/e2e/lifecycle/main_test.go
@@ -8,6 +8,7 @@ import (
 
 	ginkgoreporters "kubevirt.io/qe-tools/pkg/ginkgo-reporters"
 
+	monitoringv1 "github.com/coreos/prometheus-operator/pkg/apis/monitoring/v1"
 	f "github.com/operator-framework/operator-sdk/pkg/test"
 	framework "github.com/operator-framework/operator-sdk/pkg/test"
 
@@ -39,6 +40,9 @@ var _ = BeforeSuite(func() {
 	By("Adding custom resource scheme to framework")
 	err := framework.AddToFrameworkScheme(apis.AddToScheme, &cnaov1.NetworkAddonsConfigList{})
 	Expect(err).ToNot(HaveOccurred())
+
+	Expect(framework.AddToFrameworkScheme(monitoringv1.AddToScheme, &monitoringv1.ServiceMonitorList{})).To(Succeed())
+	Expect(framework.AddToFrameworkScheme(monitoringv1.AddToScheme, &monitoringv1.PrometheusRuleList{})).To(Succeed())
 })
 
 var _ = AfterEach(func() {

--- a/test/e2e/workflow/deployment_test.go
+++ b/test/e2e/workflow/deployment_test.go
@@ -89,6 +89,9 @@ var _ = Describe("NetworkAddonsConfig", func() {
 				[]Component{MacvtapComponent},
 			),
 		)
+		It("should deploy prometheus if NetworkAddonsConfigSpec is not empty", func() {
+			testConfigCreate(gvk, cnao.NetworkAddonsConfigSpec{MacvtapCni: &cnao.MacvtapCni{}}, []Component{MacvtapComponent, MonitoringComponent})
+		})
 		//2264
 		It("should be able to deploy all components at once", func() {
 			components := []Component{
@@ -245,6 +248,7 @@ var _ = Describe("NetworkAddonsConfig", func() {
 			KubeMacPoolComponent,
 			OvsComponent,
 			MacvtapComponent,
+			MonitoringComponent,
 		}
 		configSpec := cnao.NetworkAddonsConfigSpec{
 			LinuxBridge: &cnao.LinuxBridge{},

--- a/test/e2e/workflow/main_test.go
+++ b/test/e2e/workflow/main_test.go
@@ -10,6 +10,7 @@ import (
 
 	ginkgoreporters "kubevirt.io/qe-tools/pkg/ginkgo-reporters"
 
+	monitoringv1 "github.com/coreos/prometheus-operator/pkg/apis/monitoring/v1"
 	f "github.com/operator-framework/operator-sdk/pkg/test"
 	framework "github.com/operator-framework/operator-sdk/pkg/test"
 	appsv1 "k8s.io/api/apps/v1"
@@ -44,6 +45,9 @@ var _ = BeforeSuite(func() {
 	By("Adding custom resource scheme to framework")
 	err := framework.AddToFrameworkScheme(apis.AddToScheme, &cnaov1.NetworkAddonsConfigList{})
 	Expect(err).ToNot(HaveOccurred())
+
+	Expect(framework.AddToFrameworkScheme(monitoringv1.AddToScheme, &monitoringv1.ServiceMonitorList{})).To(Succeed())
+	Expect(framework.AddToFrameworkScheme(monitoringv1.AddToScheme, &monitoringv1.PrometheusRuleList{})).To(Succeed())
 
 	By("Detecting operator version")
 	operatorVersion, err = getRunningOperatorVersion()


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR add infra support and basic alert `CnaoDown` to CNAO 

**Special notes for your reviewer**:
manually tested with CRC:
metric:
![monitoring-graph](https://user-images.githubusercontent.com/48101085/126952703-353344e5-f19f-4b74-82e9-16ba3511e5dd.jpeg)
you can see that CNAO being down for >5 minutes is casuing the alert below
alert:
![alarm fired](https://user-images.githubusercontent.com/48101085/126952736-d0799238-699d-4971-a0bc-3b884ae8e551.jpeg)

**Release note**:

```release-note
NONE
```
