### PR TITLE
[Release-0.53] resources, Update minimum resources request

### DIFF
--- a/data/linux-bridge/002-linux-bridge.yaml
+++ b/data/linux-bridge/002-linux-bridge.yaml
@@ -46,8 +46,8 @@ spec:
               sleep infinity
           resources:
             requests:
-              cpu: "5m"
-              memory: "5Mi"
+              cpu: "10m"
+              memory: "15Mi"
           securityContext:
             privileged: true
           volumeMounts:

--- a/data/linux-bridge/002-linux-bridge.yaml
+++ b/data/linux-bridge/002-linux-bridge.yaml
@@ -46,8 +46,8 @@ spec:
               sleep infinity
           resources:
             requests:
-              cpu: "60m"
-              memory: "30Mi"
+              cpu: "5m"
+              memory: "5Mi"
           securityContext:
             privileged: true
           volumeMounts:

--- a/data/multus/001-multus.yaml
+++ b/data/multus/001-multus.yaml
@@ -113,11 +113,8 @@ spec:
             - "--cni-version=0.3.1"
           resources:
             requests:
-              cpu: "100m"
-              memory: "50Mi"
-            limits:
-              cpu: "100m"
-              memory: "50Mi"
+              cpu: "5m"
+              memory: "10Mi"
           securityContext:
             privileged: true
           volumeMounts:

--- a/data/multus/001-multus.yaml
+++ b/data/multus/001-multus.yaml
@@ -113,8 +113,8 @@ spec:
             - "--cni-version=0.3.1"
           resources:
             requests:
-              cpu: "5m"
-              memory: "10Mi"
+              cpu: "10m"
+              memory: "15Mi"
           securityContext:
             privileged: true
           volumeMounts:

--- a/hack/components/bump-multus.sh
+++ b/hack/components/bump-multus.sh
@@ -30,6 +30,9 @@ function __parametize_by_object() {
 				yaml-utils::update_param ${f} spec.template.spec.volumes[0].hostPath.path '{{ .CNIConfigDir }}'
 				yaml-utils::update_param ${f} spec.template.spec.volumes[1].hostPath.path '{{ .CNIBinDir }}'
 				yaml-utils::delete_param ${f} spec.template.spec.volumes[2]
+				yaml-utils::delete_param ${f} spec.template.spec.containers[0].resources.limits
+				yaml-utils::update_param ${f} spec.template.spec.containers[0].resources.requests.cpu '"5m"'
+				yaml-utils::update_param ${f} spec.template.spec.containers[0].resources.requests.memory '"10Mi"'
 				yaml-utils::update_param ${f} spec.template.spec.nodeSelector '{{ toYaml .Placement.NodeSelector | nindent 8 }}'
 				yaml-utils::set_param ${f} spec.template.spec.affinity '{{ toYaml .Placement.Affinity | nindent 8 }}'
 				yaml-utils::update_param ${f} spec.template.spec.tolerations '{{ toYaml .Placement.Tolerations | nindent 8 }}'

--- a/hack/components/bump-multus.sh
+++ b/hack/components/bump-multus.sh
@@ -31,8 +31,8 @@ function __parametize_by_object() {
 				yaml-utils::update_param ${f} spec.template.spec.volumes[1].hostPath.path '{{ .CNIBinDir }}'
 				yaml-utils::delete_param ${f} spec.template.spec.volumes[2]
 				yaml-utils::delete_param ${f} spec.template.spec.containers[0].resources.limits
-				yaml-utils::update_param ${f} spec.template.spec.containers[0].resources.requests.cpu '"5m"'
-				yaml-utils::update_param ${f} spec.template.spec.containers[0].resources.requests.memory '"10Mi"'
+				yaml-utils::update_param ${f} spec.template.spec.containers[0].resources.requests.cpu '"10m"'
+				yaml-utils::update_param ${f} spec.template.spec.containers[0].resources.requests.memory '"15Mi"'
 				yaml-utils::update_param ${f} spec.template.spec.nodeSelector '{{ toYaml .Placement.NodeSelector | nindent 8 }}'
 				yaml-utils::set_param ${f} spec.template.spec.affinity '{{ toYaml .Placement.Affinity | nindent 8 }}'
 				yaml-utils::update_param ${f} spec.template.spec.tolerations '{{ toYaml .Placement.Tolerations | nindent 8 }}'

--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -8,6 +8,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	cnao "github.com/kubevirt/cluster-network-addons-operator/pkg/apis/networkaddonsoperator/shared"
@@ -167,6 +168,12 @@ func GetDeployment(version string, operatorVersion string, namespace string, rep
 							Name:            Name,
 							Image:           image,
 							ImagePullPolicy: corev1.PullPolicy(imagePullPolicy),
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("50m"),
+									corev1.ResourceMemory: resource.MustParse("20Mi"),
+								},
+							},
 							Env: []corev1.EnvVar{
 								{
 									Name:  "MULTUS_IMAGE",

--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -171,7 +171,7 @@ func GetDeployment(version string, operatorVersion string, namespace string, rep
 							Resources: corev1.ResourceRequirements{
 								Requests: corev1.ResourceList{
 									corev1.ResourceCPU:    resource.MustParse("50m"),
-									corev1.ResourceMemory: resource.MustParse("20Mi"),
+									corev1.ResourceMemory: resource.MustParse("30Mi"),
 								},
 							},
 							Env: []corev1.EnvVar{


### PR DESCRIPTION
Cherry-pick of 
https://github.com/kubevirt/cluster-network-addons-operator/pull/920
https://github.com/kubevirt/cluster-network-addons-operator/pull/921
https://github.com/kubevirt/cluster-network-addons-operator/pull/922
https://github.com/kubevirt/cluster-network-addons-operator/pull/924
https://github.com/kubevirt/cluster-network-addons-operator/pull/925
https://github.com/kubevirt/cluster-network-addons-operator/pull/926

This PR updates minimum requests of:
- CNAO container
- multus container (also removes limits)
- linux bridge container

```release-note
None
```
