### PR TITLE
Add kubevirt_cnao_cr_ready metric and NetworkAddonsConfigNotReady alert

### DIFF
--- a/data/monitoring/prom-rule.yaml
+++ b/data/monitoring/prom-rule.yaml
@@ -19,3 +19,11 @@ spec:
           for: 5m
           labels:
             severity: warning
+        - alert: NetworkAddonsConfigNotReady
+          annotations:
+            summary: CNAO CR NetworkAddonsConfig is not ready.
+            runbook_url: http://kubevirt.io/monitoring/runbooks/NetworkAddonsConfigNotReady
+          expr: sum(kubevirt_cnao_cr_ready{namespace='{{ .Namespace }}'} or vector(0)) == 0
+          for: 5m
+          labels:
+            severity: warning

--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ require (
 	github.com/openshift/origin v4.1.0+incompatible
 	github.com/operator-framework/operator-sdk v0.18.0
 	github.com/pkg/errors v0.9.1
+	github.com/prometheus/client_golang v1.5.1
 	github.com/spf13/pflag v1.0.5
 	github.com/thanhpk/randstr v1.0.4
 	github.com/tomnomnom/linkheader v0.0.0-20180905144013-02ca5825eb80 // indirect

--- a/hack/prom-rule-ci/prom-rules-tests.yaml
+++ b/hack/prom-rule-ci/prom-rules-tests.yaml
@@ -35,3 +35,36 @@ tests:
       - eval_time: 5m
         alertname: CnaoDown
         exp_alerts:
+
+# NetworkAddonsConfigNotReady positive tests
+  - interval: 1m
+    input_series:
+      - series: "kubevirt_cnao_cr_ready{namespace='{{ .Namespace }}'}"
+        values: "0 0 0 0 0 0"
+
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: NetworkAddonsConfigNotReady
+        exp_alerts:
+          - exp_annotations:
+              summary: "CNAO CR NetworkAddonsConfig is not ready."
+              runbook_url: "http://kubevirt.io/monitoring/runbooks/NetworkAddonsConfigNotReady"
+            exp_labels:
+              severity: "warning"
+
+# NetworkAddonsConfigNotReady negative tests
+  - interval: 1m
+    input_series:
+      - series: "kubevirt_cnao_cr_ready{namespace='{{ .Namespace }}'}"
+        values: "1 1 1 0 1 1"
+      - series: "kubevirt_cnao_cr_ready{namespace='{{ .Namespace }}'}"
+        values: "1 1 1 1 1 1"
+      - series: "kubevirt_cnao_cr_ready{namespace='{{ .Namespace }}'}"
+        values: "0 0 0 0 0 1"
+      - series: "kubevirt_cnao_cr_ready{namespace='other-namespace'}"
+        values: "0 0 0 0 0 0"
+
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: NetworkAddonsConfigNotReady
+        exp_alerts:

--- a/pkg/controller/statusmanager/status_manager.go
+++ b/pkg/controller/statusmanager/status_manager.go
@@ -22,6 +22,7 @@ import (
 	cnao "github.com/kubevirt/cluster-network-addons-operator/pkg/apis/networkaddonsoperator/shared"
 	cnaov1 "github.com/kubevirt/cluster-network-addons-operator/pkg/apis/networkaddonsoperator/v1"
 	eventemitter "github.com/kubevirt/cluster-network-addons-operator/pkg/eventemitter"
+	"github.com/kubevirt/cluster-network-addons-operator/pkg/monitoring"
 	"github.com/kubevirt/cluster-network-addons-operator/pkg/names"
 )
 
@@ -83,6 +84,7 @@ func (status *StatusManager) Set(reachedAvailableLevel bool, conditions ...condi
 	for i := 0; i < conditionsUpdateRetries; i++ {
 		err := status.set(reachedAvailableLevel, conditions...)
 		if err == nil {
+			monitoring.SetReadyGauge(reachedAvailableLevel)
 			log.Print("Successfully updated status conditions")
 			return
 		}

--- a/pkg/monitoring/metrics.go
+++ b/pkg/monitoring/metrics.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 
 	"github.com/pkg/errors"
+	"github.com/prometheus/client_golang/prometheus"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"sigs.k8s.io/controller-runtime/pkg/metrics"
 
@@ -19,8 +20,24 @@ const (
 	defaultServiceAccountName  = "prometheus-k8s"
 )
 
+var (
+	readyGauge = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Name: "kubevirt_cnao_cr_ready",
+			Help: "Cnao CR Ready",
+		})
+)
+
 func init() {
-	metrics.Registry.MustRegister()
+	metrics.Registry.MustRegister(readyGauge)
+}
+
+func SetReadyGauge(isReady bool) {
+	if isReady {
+		readyGauge.Set(1)
+	} else {
+		readyGauge.Set(0)
+	}
 }
 
 func RenderMonitoring(manifestDir string, monitoringAvailable bool) ([]*unstructured.Unstructured, error) {

--- a/test/e2e/workflow/deployment_test.go
+++ b/test/e2e/workflow/deployment_test.go
@@ -281,6 +281,25 @@ var _ = Describe("NetworkAddonsConfig", func() {
 			CreateConfig(gvk, configSpec)
 			CheckConfigCondition(gvk, ConditionAvailable, ConditionTrue, 15*time.Minute, 30*time.Second)
 		})
+		Context("and checking CNAO prometheus endpoint", func() {
+			var err error
+			var scrapedData string
+			BeforeEach(func() {
+				scrapedData, err = GetScrapedDataFromMonitoringEndpoint()
+				Expect(err).ToNot(HaveOccurred())
+			})
+			It("Should report the expected metrics", func() {
+				expectedMetricValueMap := map[string]string{
+					"kubevirt_cnao_cr_ready": "1",
+				}
+
+				for metricName, expectedValue := range expectedMetricValueMap {
+					metricEntry := FindMetric(scrapedData, metricName)
+					Expect(metricEntry).ToNot(BeEmpty(), fmt.Sprintf("metric %s does not appear in endpoint scrape", metricName))
+					Expect(metricEntry).To(Equal(fmt.Sprintf("%s %s", metricName, expectedValue)), fmt.Sprintf("metric %s does not have the expected value %s", metricName, expectedValue))
+				}
+			})
+		})
 	})
 	//2178
 	Context("when kubeMacPool is deployed", func() {


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds the Add kubevirt_cnao_cr_ready metric and NetworkAddonsConfigNotReady alert.

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
