### PR TITLE
components: Consume CNI Bridge with macspoofchk support

### DIFF
--- a/components.yaml
+++ b/components.yaml
@@ -12,9 +12,9 @@ components:
     update-policy: tagged
     metadata: v0.30.0
   linux-bridge:
-    url: https://github.com/containernetworking/plugins
-    commit: 74a6b28a2c2796a2638ba61a85bb620640bfeb31
-    branch: master
+    url: https://github.com/EdDev/plugins
+    commit: bf36e4c2e3ce64a00ba496d7d91bb768a635469a
+    branch: bridge-macspoofchk
     update-policy: static
     metadata: ""
   macvtap-cni:

--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -27,7 +27,7 @@ var (
 
 const (
 	MultusImageDefault            = "quay.io/kubevirt/cluster-network-addon-multus@sha256:32867c73cda4d605651b898dc85fea67d93191c47f27e1ad9e9f2b9041c518de"
-	LinuxBridgeCniImageDefault    = "quay.io/kubevirt/cni-default-plugins@sha256:a90902cf3e5154424148bf3ba3c1bf90316cc77a54042cf6584fe8aedbe6daec"
+	LinuxBridgeCniImageDefault    = "quay.io/kubevirt/cni-default-plugins@sha256:0dcae9bb69dd7bb56bbd91f5f309ed929f1142a540ab1392b411cf0261226749"
 	LinuxBridgeMarkerImageDefault = "quay.io/kubevirt/bridge-marker@sha256:3cc868fd1cc18e111775f6f00066486e040c481c44e7eecc1b9b385c0d1d1d77"
 	KubeMacPoolImageDefault       = "quay.io/kubevirt/kubemacpool@sha256:ef759a6e8960d895e777621381c3e94d677f1401435bc00c7663dc1b828272cb"
 	NMStateHandlerImageDefault    = "quay.io/nmstate/kubernetes-nmstate-handler@sha256:0e30f69b9568b252d9d86c46292821c76bf8f471fd81e099e55ff613727267be"

--- a/test/releases/99.0.0.go
+++ b/test/releases/99.0.0.go
@@ -24,7 +24,7 @@ func init() {
 				ParentName: "kube-cni-linux-bridge-plugin",
 				ParentKind: "DaemonSet",
 				Name:       "cni-plugins",
-				Image:      "quay.io/kubevirt/cni-default-plugins@sha256:a90902cf3e5154424148bf3ba3c1bf90316cc77a54042cf6584fe8aedbe6daec",
+				Image:      "quay.io/kubevirt/cni-default-plugins@sha256:0dcae9bb69dd7bb56bbd91f5f309ed929f1142a540ab1392b411cf0261226749",
 			},
 			{
 				ParentName: "kubemacpool-mac-controller-manager",


### PR DESCRIPTION
**What this PR does / why we need it**:

As an intermediate and temporary step, consume the changes posted to the
CNI bridge [1].

Once the PR is merged into the original repo, this change will be
reverted.

In case the PR will not be merged into the original repo, we will
proceed with a more formal resolution.

[1] https://github.com/containernetworking/plugins/pull/639

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
Consume CNI Bridge with mac-spoof-check support.
```
