### PR TITLE
hack/components: Support build on SELinux enabled platforms

### DIFF
--- a/hack/components/yaml-utils.sh
+++ b/hack/components/yaml-utils.sh
@@ -3,7 +3,7 @@
 set -xeo pipefail
 
 function __yq() {
-  docker run --rm -i -v ${PWD}:/workdir mikefarah/yq:3.3.4 yq "$@"
+  docker run --rm -i -v ${PWD}:/workdir:Z mikefarah/yq:3.3.4 yq "$@"
 }
 
 function __get_parameter_from_yaml() {


### PR DESCRIPTION
**What this PR does / why we need it**:

When SELinux is enabled on a build machine, running the components bump
scripts fail due to a missing re-labeling of files when mounting a
volume to a container.

This change enables re-labeling of the files in the shared volume by
adding the `Z` option to the volume mount.

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```