### PR TITLE
Fix installation of bridge and tuning CNIs

### DIFF
--- a/data/linux-bridge/002-linux-bridge.yaml
+++ b/data/linux-bridge/002-linux-bridge.yaml
@@ -35,8 +35,9 @@ spec:
             - /bin/bash
             - -c
             - |
-              cp -rf /usr/src/containernetworking/plugins/bin/*bridge /opt/cni/bin/
-              cp -rf /usr/src/containernetworking/plugins/bin/*tuning /opt/cni/bin/
+              echo 'Installing bridge and tuning CNIs'
+              cp -f /usr/src/containernetworking/plugins/bin/*bridge /opt/cni/bin/ || exit 1
+              cp -f /usr/src/containernetworking/plugins/bin/*tuning /opt/cni/bin/ || exit 1
               # Some projects (e.g. openshift/console) use cnv- prefix to distinguish between
               # binaries shipped by OpenShift and those shipped by KubeVirt (D/S matters).
               # Following two lines make sure we will provide both names when needed.

--- a/data/linux-bridge/002-linux-bridge.yaml
+++ b/data/linux-bridge/002-linux-bridge.yaml
@@ -36,14 +36,15 @@ spec:
             - -c
             - |
               echo 'Installing bridge and tuning CNIs'
-              cp -f /usr/src/containernetworking/plugins/bin/*bridge /opt/cni/bin/ || exit 1
-              cp -f /usr/src/containernetworking/plugins/bin/*tuning /opt/cni/bin/ || exit 1
+              cni_mount_dir=/opt/cni/bin
+              cp -f /usr/src/github.com/containernetworking/plugins/bin/bridge ${cni_mount_dir}/cnv-bridge || exit 1
+              cp -f /usr/src/github.com/containernetworking/plugins/bin/tuning ${cni_mount_dir}/cnv-tuning || exit 1
               # Some projects (e.g. openshift/console) use cnv- prefix to distinguish between
               # binaries shipped by OpenShift and those shipped by KubeVirt (D/S matters).
               # Following two lines make sure we will provide both names when needed.
-              find /opt/cni/bin/cnv-bridge || ln -s /opt/cni/bin/bridge /opt/cni/bin/cnv-bridge
-              find /opt/cni/bin/cnv-tuning || ln -s /opt/cni/bin/tuning /opt/cni/bin/cnv-tuning
-              echo "Entering sleep... (success)"
+              find ${cni_mount_dir}/bridge &>/dev/null || ln -s ${cni_mount_dir}/cnv-bridge ${cni_mount_dir}/bridge
+              find ${cni_mount_dir}/tuning &>/dev/null || ln -s ${cni_mount_dir}/cnv-tuning ${cni_mount_dir}/tuning
+              echo 'Entering sleep... (success)'
               sleep infinity
           resources:
             requests:

--- a/hack/components/bump-linux-bridge.sh
+++ b/hack/components/bump-linux-bridge.sh
@@ -23,7 +23,6 @@ LINUX_BRIDGE_TAG=$(git-utils::get_component_tag ${LINUX_BRIDGE_PATH})
 
 echo 'Build container image with linux-bridge binaries'
 LINUX_BRIDGE_TAR_CONTAINER_DIR=/usr/src/github.com/containernetworking/plugins/bin
-LINUX_BRIDGE_TAR_FILE=cni-plugins-linux-amd64-${LINUX_BRIDGE_TAG}.tgz
 LINUX_BRIDGE_IMAGE=quay.io/kubevirt/cni-default-plugins
 LINUX_BRIDGE_IMAGE_TAGGED=${LINUX_BRIDGE_IMAGE}:${LINUX_BRIDGE_TAG}
 (
@@ -40,10 +39,10 @@ RUN GOFLAGS=-mod=vendor ./build_linux.sh
 
 FROM registry.access.redhat.com/ubi8/ubi-minimal
 ENV SOURCE_DIR=${REMOTE_SOURCE_DIR}/app
-RUN mkdir -p /usr/src/containernetworking/plugins/bin
+RUN mkdir -p ${LINUX_BRIDGE_TAR_CONTAINER_DIR}
 RUN microdnf install -y findutils
-COPY --from=builder ${LINUX_BRIDGE_PATH}/bin/bridge /usr/src/github.com/containernetworking/plugins/bin/bridge
-COPY --from=builder ${LINUX_BRIDGE_PATH}/bin/tuning /usr/src/github.com/containernetworking/plugins/bin/tuning
+COPY --from=builder ${LINUX_BRIDGE_PATH}/bin/bridge ${LINUX_BRIDGE_TAR_CONTAINER_DIR}/bridge
+COPY --from=builder ${LINUX_BRIDGE_PATH}/bin/tuning ${LINUX_BRIDGE_TAR_CONTAINER_DIR}/tuning
 EOF
     docker build -t ${LINUX_BRIDGE_IMAGE_TAGGED} .
 )


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR is based on #595, and fixed a bug where the binaries are not deployed on the node by linux-bridge pod

- **data/linux-bridge, Change copy command to be fail-able**
Currently if one of the copy commands fail then the pod is
considered not failing.
Fix that by making sure the script fails upon copy failure.
- **bump-linux-bridge, refactor env vars**
Removed unused LINUX_BRIDGE_TAR_FILE
Used currently unused LINUX_BRIDGE_TAR_CONTAINER_DIR
- **data/linux-bridge, Fix installation of bridge and tuning CNIs**
There is a bug where the linux-bridge pods never installed the bridge
and tuning CNI, since the source address of the copy was not matching
directories used in the CNI plugins container image.
The only reason why this worked so far is that these plugins are
deployed by other CNI intallations used by kubevirtci cluster-up.

**Special notes for your reviewer**:
The desired behavior is:
1. CNAO's linux-bridge pod deploys it's own binaries with the `cnv` prefix
2. if there are no old `bridge`/`tuning`binaries, it will create a symlink to the cnv-prefixed binaries

**Release note**:

```release-note
changed CNAO's linux-bridge deployed bridge&tuning binaries name to `cnv-{bridge,tuning}` to avoid race with other CNIs
```
