### PR TITLE
linux-bridge, Add shasum check in linux-bridge pod

### DIFF
--- a/data/linux-bridge/002-linux-bridge.yaml
+++ b/data/linux-bridge/002-linux-bridge.yaml
@@ -37,8 +37,16 @@ spec:
             - |
               echo 'Installing bridge and tuning CNIs'
               cni_mount_dir=/opt/cni/bin
-              cp --remove-destination /usr/src/github.com/containernetworking/plugins/bin/bridge ${cni_mount_dir}/cnv-bridge || exit 1
-              cp --remove-destination /usr/src/github.com/containernetworking/plugins/bin/tuning ${cni_mount_dir}/cnv-tuning || exit 1
+              sourcebinpath=/usr/src/github.com/containernetworking/plugins/bin
+              cp --remove-destination ${sourcebinpath}/bridge ${cni_mount_dir}/cnv-bridge || exit 1
+              cp --remove-destination ${sourcebinpath}/tuning ${cni_mount_dir}/cnv-tuning || exit 1
+
+              echo 'Checking bridge and tuning CNIs deployment on node'
+              printf -v bridgechecksum "%s" "$(<$sourcebinpath/bridge.checksum)"
+              printf -v tuningchecksum "%s" "$(<$sourcebinpath/tuning.checksum)"
+              printf "%s %s" "${bridgechecksum% *}" "${cni_mount_dir}/cnv-bridge" | sha256sum --check || exit 1
+              printf "%s %s" "${tuningchecksum% *}" "${cni_mount_dir}/cnv-tuning" | sha256sum --check || exit 1
+
               # Some projects (e.g. openshift/console) use cnv- prefix to distinguish between
               # binaries shipped by OpenShift and those shipped by KubeVirt (D/S matters).
               # Following two lines make sure we will provide both names when needed.

--- a/data/linux-bridge/002-linux-bridge.yaml
+++ b/data/linux-bridge/002-linux-bridge.yaml
@@ -33,19 +33,19 @@ spec:
           imagePullPolicy: {{ .ImagePullPolicy }}
           command:
             - /bin/bash
-            - -c
+            - -ce
             - |
               echo 'Installing bridge and tuning CNIs'
               cni_mount_dir=/opt/cni/bin
               sourcebinpath=/usr/src/github.com/containernetworking/plugins/bin
-              cp --remove-destination ${sourcebinpath}/bridge ${cni_mount_dir}/cnv-bridge || exit 1
-              cp --remove-destination ${sourcebinpath}/tuning ${cni_mount_dir}/cnv-tuning || exit 1
+              cp --remove-destination ${sourcebinpath}/bridge ${cni_mount_dir}/cnv-bridge
+              cp --remove-destination ${sourcebinpath}/tuning ${cni_mount_dir}/cnv-tuning
 
               echo 'Checking bridge and tuning CNIs deployment on node'
               printf -v bridgechecksum "%s" "$(<$sourcebinpath/bridge.checksum)"
               printf -v tuningchecksum "%s" "$(<$sourcebinpath/tuning.checksum)"
-              printf "%s %s" "${bridgechecksum% *}" "${cni_mount_dir}/cnv-bridge" | sha256sum --check || exit 1
-              printf "%s %s" "${tuningchecksum% *}" "${cni_mount_dir}/cnv-tuning" | sha256sum --check || exit 1
+              printf "%s %s" "${bridgechecksum% *}" "${cni_mount_dir}/cnv-bridge" | sha256sum --check
+              printf "%s %s" "${tuningchecksum% *}" "${cni_mount_dir}/cnv-tuning" | sha256sum --check
 
               # Some projects (e.g. openshift/console) use cnv- prefix to distinguish between
               # binaries shipped by OpenShift and those shipped by KubeVirt (D/S matters).

--- a/hack/components/bump-linux-bridge.sh
+++ b/hack/components/bump-linux-bridge.sh
@@ -43,6 +43,8 @@ RUN mkdir -p ${LINUX_BRIDGE_TAR_CONTAINER_DIR}
 RUN microdnf install -y findutils
 COPY --from=builder ${LINUX_BRIDGE_PATH}/bin/bridge ${LINUX_BRIDGE_TAR_CONTAINER_DIR}/bridge
 COPY --from=builder ${LINUX_BRIDGE_PATH}/bin/tuning ${LINUX_BRIDGE_TAR_CONTAINER_DIR}/tuning
+RUN sha256sum ${LINUX_BRIDGE_TAR_CONTAINER_DIR}/bridge >${LINUX_BRIDGE_TAR_CONTAINER_DIR}/bridge.checksum
+RUN sha256sum ${LINUX_BRIDGE_TAR_CONTAINER_DIR}/tuning >${LINUX_BRIDGE_TAR_CONTAINER_DIR}/tuning.checksum
 EOF
     docker build -t ${LINUX_BRIDGE_IMAGE_TAGGED} .
 )

--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -29,7 +29,7 @@ var (
 
 const (
 	MultusImageDefault            = "quay.io/kubevirt/cluster-network-addon-multus@sha256:32867c73cda4d605651b898dc85fea67d93191c47f27e1ad9e9f2b9041c518de"
-	LinuxBridgeCniImageDefault    = "quay.io/kubevirt/cni-default-plugins@sha256:0dcae9bb69dd7bb56bbd91f5f309ed929f1142a540ab1392b411cf0261226749"
+	LinuxBridgeCniImageDefault    = "quay.io/kubevirt/cni-default-plugins@sha256:828df9e296db6f2772e69671189c68b69c258fdc9c84b4cc08b16866f69c162d"
 	LinuxBridgeMarkerImageDefault = "quay.io/kubevirt/bridge-marker@sha256:8e9de03dbf6f35eb88af94e3d93da66d926d002c1574619f63186f1e88bf3c52"
 	KubeMacPoolImageDefault       = "quay.io/kubevirt/kubemacpool@sha256:ef759a6e8960d895e777621381c3e94d677f1401435bc00c7663dc1b828272cb"
 	NMStateHandlerImageDefault    = "quay.io/nmstate/kubernetes-nmstate-handler@sha256:0e30f69b9568b252d9d86c46292821c76bf8f471fd81e099e55ff613727267be"

--- a/test/releases/99.0.0.go
+++ b/test/releases/99.0.0.go
@@ -24,7 +24,7 @@ func init() {
 				ParentName: "kube-cni-linux-bridge-plugin",
 				ParentKind: "DaemonSet",
 				Name:       "cni-plugins",
-				Image:      "quay.io/kubevirt/cni-default-plugins@sha256:0dcae9bb69dd7bb56bbd91f5f309ed929f1142a540ab1392b411cf0261226749",
+				Image:      "quay.io/kubevirt/cni-default-plugins@sha256:828df9e296db6f2772e69671189c68b69c258fdc9c84b4cc08b16866f69c162d",
 			},
 			{
 				ParentName: "kubemacpool-mac-controller-manager",


### PR DESCRIPTION
**What this PR does / why we need it**:
The linux-bridge pod is mainly copying bridge and tuning
binaries to the node.
Added tier1 test that makes sure these binareis are copied.

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
