### PR TITLE
data/linux-bridge, Fix copying over symlink

### DIFF
--- a/data/linux-bridge/002-linux-bridge.yaml
+++ b/data/linux-bridge/002-linux-bridge.yaml
@@ -37,8 +37,8 @@ spec:
             - |
               echo 'Installing bridge and tuning CNIs'
               cni_mount_dir=/opt/cni/bin
-              cp -f /usr/src/github.com/containernetworking/plugins/bin/bridge ${cni_mount_dir}/cnv-bridge || exit 1
-              cp -f /usr/src/github.com/containernetworking/plugins/bin/tuning ${cni_mount_dir}/cnv-tuning || exit 1
+              cp --remove-destination /usr/src/github.com/containernetworking/plugins/bin/bridge ${cni_mount_dir}/cnv-bridge || exit 1
+              cp --remove-destination /usr/src/github.com/containernetworking/plugins/bin/tuning ${cni_mount_dir}/cnv-tuning || exit 1
               # Some projects (e.g. openshift/console) use cnv- prefix to distinguish between
               # binaries shipped by OpenShift and those shipped by KubeVirt (D/S matters).
               # Following two lines make sure we will provide both names when needed.


### PR DESCRIPTION
**What this PR does / why we need it**:
When we upgrade there is already the cnv-{bridge,tuning}
files in the node. In this case, 'cp -f' does not copy
the new binaries over the old symlinks.
To Fix that, changed the flag to '--remove-destination'
```
      --remove-destination     remove each existing destination file before
                                 attempting to open it (contrast with --force)
```
**Special notes for your reviewer**:

**Release note**:

```release-note
fix symlink in linux-bridge during upgrade
```
