### PR TITLE
prometheus, Add rule for KubeMacPoolDuplicateMacsFound

### DIFF
--- a/data/monitoring/prom-rule.yaml
+++ b/data/monitoring/prom-rule.yaml
@@ -27,3 +27,13 @@ spec:
           for: 5m
           labels:
             severity: warning
+        - expr: sum(kubevirt_kmp_duplicate_macs{namespace='{{ .Namespace }}'} or vector(0))
+          record: kubevirt_kubemacpool_duplicate_macs_total
+        - alert: KubeMacPoolDuplicateMacsFound
+          annotations:
+            summary: Duplicate macs found.
+            runbook_url: http://kubevirt.io/monitoring/runbooks/KubeMacPoolDuplicateMacsFound
+          expr: kubevirt_kubemacpool_duplicate_macs_total != 0
+          for: 5m
+          labels:
+            severity: warning

--- a/hack/prom-rule-ci/prom-rules-tests.yaml
+++ b/hack/prom-rule-ci/prom-rules-tests.yaml
@@ -68,3 +68,32 @@ tests:
       - eval_time: 5m
         alertname: NetworkAddonsConfigNotReady
         exp_alerts:
+
+# KubeMacPoolDuplicateMacsFound positive tests
+  - interval: 1m
+    input_series:
+      - series: "kubevirt_kmp_duplicate_macs{namespace='{{ .Namespace }}'}"
+        values: "1 1 1 1 1 1"
+
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: KubeMacPoolDuplicateMacsFound
+        exp_alerts:
+          - exp_annotations:
+              summary: "Duplicate macs found."
+              runbook_url: "http://kubevirt.io/monitoring/runbooks/KubeMacPoolDuplicateMacsFound"
+            exp_labels:
+              severity: "warning"
+
+# KubeMacPoolDuplicateMacsFound negative tests
+  - interval: 1m
+    input_series:
+      - series: "kubevirt_kmp_duplicate_macs{namespace='{{ .Namespace }}'}"
+        values: "1 0 0 0 0 0"
+      - series: "kubevirt_kmp_duplicate_macs{namespace='other-namespace'}"
+        values: "1 1 1 1 1 1"
+
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: KubeMacPoolDuplicateMacsFound
+        exp_alerts:


### PR DESCRIPTION
`KubeMacPoolDuplicateMacsFound` will alert when duplicate mac
addresses were found by kubemacpool.

Signed-off-by: Or Shoval <oshoval@redhat.com>

```release-note
None
```
