### PR TITLE
monitoring, Adding a new alert KubemacpoolDown

### DIFF
--- a/data/monitoring/prom-rule.yaml
+++ b/data/monitoring/prom-rule.yaml
@@ -37,3 +37,15 @@ spec:
           for: 5m
           labels:
             severity: warning
+        - expr: sum(up{namespace='{{ .Namespace }}', pod=~'kubemacpool-mac-controller-manager-.*'} or vector(0))
+          record: kubevirt_cnao_kubemacpool_manager_num_up_pods_total
+        - expr: sum(kubevirt_cnao_cr_kubemacpool_deployed{namespace='{{ .Namespace }}'} or vector(0))
+          record: kubevirt_cnao_cr_kubemacpool_deployed_total
+        - alert: KubemacpoolDown
+          annotations:
+            summary: Kubemacpool is deployed by CNAO CR but kubemacpool pod is down.
+            runbook_url: http://kubevirt.io/monitoring/runbooks/KubemacpoolDown
+          expr: kubevirt_cnao_cr_kubemacpool_deployed_total == 1 and kubevirt_cnao_kubemacpool_manager_num_up_pods_total == 0
+          for: 5m
+          labels:
+            severity: critical

--- a/hack/prom-rule-ci/prom-rules-tests.yaml
+++ b/hack/prom-rule-ci/prom-rules-tests.yaml
@@ -97,3 +97,58 @@ tests:
       - eval_time: 5m
         alertname: KubeMacPoolDuplicateMacsFound
         exp_alerts:
+
+# KubemacpoolDown positive tests
+  - interval: 1m
+    input_series:
+      - series: "kubevirt_cnao_kubemacpool_manager_num_up_pods_total"
+        values: "0 0 0 0 0 0"
+      - series: "kubevirt_cnao_cr_kubemacpool_deployed_total"
+        values: "1 1 1 1 1 1"
+
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: KubemacpoolDown
+        exp_alerts:
+          - exp_annotations:
+              summary: "Kubemacpool is deployed by CNAO CR but kubemacpool pod is down."
+              runbook_url: "http://kubevirt.io/monitoring/runbooks/KubemacpoolDown"
+            exp_labels:
+              severity: "critical"
+
+  # KubemacpoolDown negative tests
+  - interval: 1m
+    input_series:
+      - series: "kubevirt_cnao_kubemacpool_manager_num_up_pods_total"
+        values: "0 0 0 0 1 0"
+      - series: "kubevirt_cnao_cr_kubemacpool_deployed_total"
+        values: "1 1 1 1 1 1"
+
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: KubemacpoolDown
+        exp_alerts:
+
+  - interval: 1m
+    input_series:
+      - series: "kubevirt_cnao_kubemacpool_manager_num_up_pods_total"
+        values: "0 0 0 0 0 0"
+      - series: "kubevirt_cnao_cr_kubemacpool_deployed_total"
+        values: "1 1 1 1 0 1"
+
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: KubemacpoolDown
+        exp_alerts:
+
+  - interval: 1m
+    input_series:
+      - series: "kubevirt_cnao_kubemacpool_manager_num_up_pods_total"
+        values: "1 1 1 1 1 1"
+      - series: "kubevirt_cnao_cr_kubemacpool_deployed_total"
+        values: "0 0 0 0 0 0"
+
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: KubemacpoolDown
+        exp_alerts:


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR Adds a new alert KubemacpoolDown
This alert will fire only when KMP is configured and for some reason the kubemacool-manager pod is not running.
The alert priority is set to critical, as if KMP is down, vms cannot be created/updated from the cluster.

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
