### PR TITLE
components, Follow kubemacpool stable branch release-v0.31

### DIFF
--- a/components.yaml
+++ b/components.yaml
@@ -8,7 +8,7 @@ components:
   kubemacpool:
     url: https://github.com/k8snetworkplumbingwg/kubemacpool
     commit: 81e03248c05027aef599d8ae75003615eb7990a4
-    branch: main
+    branch: release-v0.31
     update-policy: tagged
     metadata: v0.31.0
   linux-bridge:


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR sets CNAO on stable branch `release-0.58` to follow kubemacpool's stable branch `release-v0.31`
**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
