### PR TITLE
components: Update CNI Bridge with macspoofchk source

### DIFF
--- a/components.yaml
+++ b/components.yaml
@@ -13,8 +13,8 @@ components:
     metadata: v0.31.0
   linux-bridge:
     url: https://github.com/EdDev/plugins
-    commit: bf36e4c2e3ce64a00ba496d7d91bb768a635469a
-    branch: bridge-macspoofchk
+    commit: cbec9bf876f07f284a9b102f775f97346e341593
+    branch: bridge-macspoofchk-clone
     update-policy: static
     metadata: ""
   macvtap-cni:

--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -29,7 +29,7 @@ var (
 
 const (
 	MultusImageDefault            = "quay.io/kubevirt/cluster-network-addon-multus@sha256:32867c73cda4d605651b898dc85fea67d93191c47f27e1ad9e9f2b9041c518de"
-	LinuxBridgeCniImageDefault    = "quay.io/kubevirt/cni-default-plugins@sha256:828df9e296db6f2772e69671189c68b69c258fdc9c84b4cc08b16866f69c162d"
+	LinuxBridgeCniImageDefault    = "quay.io/kubevirt/cni-default-plugins@sha256:d211830c45bde8608befb04cf2accc91490467f3b8e091b812b76453572c9ab8"
 	LinuxBridgeMarkerImageDefault = "quay.io/kubevirt/bridge-marker@sha256:8e9de03dbf6f35eb88af94e3d93da66d926d002c1574619f63186f1e88bf3c52"
 	KubeMacPoolImageDefault       = "quay.io/kubevirt/kubemacpool@sha256:4e1a54bf29456fd020cd8cbe9ea4b36e84f7f29eb342a469f6fba72da4b450a1"
 	NMStateHandlerImageDefault    = "quay.io/nmstate/kubernetes-nmstate-handler@sha256:18041db3cb27c673121e798b090e54cc42f6591f877ff599fa09f55c6d2388fe"

--- a/test/releases/99.0.0.go
+++ b/test/releases/99.0.0.go
@@ -24,7 +24,7 @@ func init() {
 				ParentName: "kube-cni-linux-bridge-plugin",
 				ParentKind: "DaemonSet",
 				Name:       "cni-plugins",
-				Image:      "quay.io/kubevirt/cni-default-plugins@sha256:828df9e296db6f2772e69671189c68b69c258fdc9c84b4cc08b16866f69c162d",
+				Image:      "quay.io/kubevirt/cni-default-plugins@sha256:d211830c45bde8608befb04cf2accc91490467f3b8e091b812b76453572c9ab8",
 			},
 			{
 				ParentName: "kubemacpool-mac-controller-manager",


### PR DESCRIPTION
**What this PR does / why we need it**:

Replace the source branch of the CNI Bridge with the macspoofchk
support, from the PR branch to a separate branch.

Unlike the PR branch, the new branch is not expected to change. But even
if it does (for fixes), history will be preserved.

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
