### PR TITLE
tier1, Add informative fail error in case CNAO cr timed out

### DIFF
--- a/automation/components-functests.setup.sh
+++ b/automation/components-functests.setup.sh
@@ -51,7 +51,11 @@ spec:
   imagePullPolicy: Always
 EOF
 
-cluster/kubectl.sh wait networkaddonsconfig cluster --for condition=Available --timeout=13m
+if [[ ! $(cluster/kubectl.sh wait networkaddonsconfig cluster --for condition=Available --timeout=13m) ]]; then
+	echo "Failed to wait for CNAO CR to be ready"
+	cluster/kubectl.sh get networkaddonsconfig -o custom-columns="":.status.conditions[*].message
+	exit 1
+fi
 
 # Clone component repository
 component_url=$(yaml-utils::get_component_url ${COMPONENT})


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds some informative fail info in case CNAO CR fails o be ready on CNAO teir1 lanes.

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
