### PR TITLE
monitoring, Collect readyGauge during reconcile

### DIFF
--- a/pkg/controller/networkaddonsconfig/networkaddonsconfig_controller.go
+++ b/pkg/controller/networkaddonsconfig/networkaddonsconfig_controller.go
@@ -302,10 +302,6 @@ func (r *ReconcileNetworkAddonsConfig) Reconcile(request reconcile.Request) (rec
 		return reconcile.Result{}, err
 	}
 
-	if r.clusterInfo.MonitoringAvailable {
-		monitoring.TrackMonitoredComponents(&networkAddonsConfig.Spec)
-	}
-
 	// Everything went smooth, remove failures from NetworkAddonsConfig if there are any from
 	// previous runs.
 	r.statusManager.SetNotFailing(statusmanager.OperatorConfig)
@@ -315,6 +311,10 @@ func (r *ReconcileNetworkAddonsConfig) Reconcile(request reconcile.Request) (rec
 	// deployed, there is nothing that would trigger initial reconciliation. Therefore, let's
 	// perform the first check manually.
 	r.statusManager.SetFromPods()
+
+	if r.clusterInfo.MonitoringAvailable {
+		monitoring.TrackMonitoredComponents(&networkAddonsConfig.Spec, r.statusManager)
+	}
 
 	// Kubernetes sometimes fails to apply objects while we remove and recreate
 	// components, despite reporting success. In order to self-heal after these

--- a/test/e2e/workflow/deployment_test.go
+++ b/test/e2e/workflow/deployment_test.go
@@ -293,16 +293,22 @@ var _ = Describe("NetworkAddonsConfig", func() {
 				CreateConfig(gvk, p.configSpec)
 				CheckConfigCondition(gvk, ConditionAvailable, ConditionTrue, 15*time.Minute, CheckDoNotRepeat)
 
-				By("scraping the monitoring endpoint")
-				scrapedData, err := GetScrapedDataFromMonitoringEndpoint()
-				Expect(err).ToNot(HaveOccurred())
+				Eventually(func() error {
+					By("scraping the monitoring endpoint")
+					scrapedData, err := GetScrapedDataFromMonitoringEndpoint()
+					Expect(err).ToNot(HaveOccurred())
 
-				By("comparing the scraped Data to the expected metrics' values")
-				for metricName, expectedValue := range p.expectedMetricValueMap {
-					metricEntry := FindMetric(scrapedData, metricName)
-					Expect(metricEntry).ToNot(BeEmpty(), fmt.Sprintf("metric %s does not appear in endpoint scrape", metricName))
-					Expect(metricEntry).To(Equal(fmt.Sprintf("%s %s", metricName, expectedValue)), fmt.Sprintf("metric %s does not have the expected value %s", metricName, expectedValue))
-				}
+					By("comparing the scraped Data to the expected metrics' values")
+					for metricName, expectedValue := range p.expectedMetricValueMap {
+						metricEntry := FindMetric(scrapedData, metricName)
+						Expect(metricEntry).ToNot(BeEmpty(), fmt.Sprintf("metric %s does not appear in endpoint scrape", metricName))
+
+						if metricEntry != fmt.Sprintf("%s %s", metricName, expectedValue) {
+							return fmt.Errorf("metric %s does not have the expected value %s", metricName, expectedValue)
+						}
+					}
+					return nil
+				}, 3*time.Minute, time.Minute).Should(Succeed(), "Should scrape the correct metrics")
 			},
 			Entry("should report the expected metrics when deploying all components", prometheusScrapeParams{
 				configSpec: cnao.NetworkAddonsConfigSpec{


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR does some refactoring on the TrackMonitoredComponents routing and gauge polling
Following this change, readyGauge will be polled as part of the regular reconcile loop.

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
