### PR TITLE
manually bump knmstate to v0.53.0

### DIFF
--- a/components.yaml
+++ b/components.yaml
@@ -31,10 +31,10 @@ components:
     metadata: v3.4.2
   nmstate:
     url: https://github.com/nmstate/kubernetes-nmstate
-    commit: 477b4f61576649b38f43cc065a6f5d0a2d8595bf
+    commit: 281e3fa2f223c3a76bcdb94d24622ffbe3767135
     branch: main
     update-policy: tagged
-    metadata: v0.52.5
+    metadata: v0.53.0
   ovs-cni:
     url: https://github.com/k8snetworkplumbingwg/ovs-cni
     commit: cc57521b0d6060e44406e00d30ce21a6aa3b3506

--- a/data/nmstate/operand/nmstate.io_nodenetworkconfigurationenactments.yaml
+++ b/data/nmstate/operand/nmstate.io_nodenetworkconfigurationenactments.yaml
@@ -56,6 +56,8 @@ spec:
                       type: string
                     message:
                       type: string
+                    messageEncoded:
+                      type: string
                     reason:
                       type: string
                     status:
@@ -120,6 +122,8 @@ spec:
                       format: date-time
                       type: string
                     message:
+                      type: string
+                    messageEncoded:
                       type: string
                     reason:
                       type: string

--- a/data/nmstate/operand/nmstate.io_nodenetworkconfigurationpolicies.yaml
+++ b/data/nmstate/operand/nmstate.io_nodenetworkconfigurationpolicies.yaml
@@ -79,6 +79,8 @@ spec:
                       type: string
                     message:
                       type: string
+                    messageEncoded:
+                      type: string
                     reason:
                       type: string
                     status:
@@ -160,6 +162,8 @@ spec:
                       format: date-time
                       type: string
                     message:
+                      type: string
+                    messageEncoded:
                       type: string
                     reason:
                       type: string

--- a/data/nmstate/operand/nmstate.io_nodenetworkstates.yaml
+++ b/data/nmstate/operand/nmstate.io_nodenetworkstates.yaml
@@ -50,6 +50,8 @@ spec:
                       type: string
                     message:
                       type: string
+                    messageEncoded:
+                      type: string
                     reason:
                       type: string
                     status:
@@ -107,6 +109,8 @@ spec:
                       format: date-time
                       type: string
                     message:
+                      type: string
+                    messageEncoded:
                       type: string
                     reason:
                       type: string

--- a/data/nmstate/operand/operator.yaml
+++ b/data/nmstate/operand/operator.yaml
@@ -25,8 +25,8 @@ spec:
         description: kubernetes-nmstate-webhook resets NNCP status
     spec:
       serviceAccountName: {{template "handlerPrefix" .}}nmstate-handler
-      nodeSelector: {{ toYaml .PlacementConfiguration.Infra.NodeSelector | nindent 8 }}
-      tolerations: {{ toYaml .PlacementConfiguration.Infra.Tolerations | nindent 8 }}
+      nodeSelector: {{ toYaml .InfraNodeSelector | nindent 8 }}
+      tolerations: {{ toYaml .InfraTolerations | nindent 8 }}
       affinity: {{ toYaml .PlacementConfiguration.Infra.Affinity | nindent 8 }}
       priorityClassName: system-cluster-critical
       containers:
@@ -109,8 +109,8 @@ spec:
         description: kubernetes-nmstate-webhook rotate webhook certs
     spec:
       serviceAccountName: {{template "handlerPrefix" .}}nmstate-handler
-      nodeSelector: {{ toYaml .PlacementConfiguration.Infra.NodeSelector | nindent 8 }}
-      tolerations: {{ toYaml .PlacementConfiguration.Infra.Tolerations | nindent 8 }}
+      nodeSelector: {{ toYaml .InfraNodeSelector | nindent 8 }}
+      tolerations: {{ toYaml .InfraTolerations | nindent 8 }}
       affinity: {{ toYaml .PlacementConfiguration.Infra.Affinity | nindent 8 }}
       priorityClassName: system-cluster-critical
       containers:
@@ -249,8 +249,6 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
-            - name: INTERFACES_FILTER
-              value: "{veth*,cali*}"
             - name: ENABLE_PROFILER
               value: "False"
             - name: PROFILER_PORT

--- a/data/nmstate/operand/operator.yaml
+++ b/data/nmstate/operand/operator.yaml
@@ -25,8 +25,8 @@ spec:
         description: kubernetes-nmstate-webhook resets NNCP status
     spec:
       serviceAccountName: {{template "handlerPrefix" .}}nmstate-handler
-      nodeSelector: {{ toYaml .InfraNodeSelector | nindent 8 }}
-      tolerations: {{ toYaml .InfraTolerations | nindent 8 }}
+      nodeSelector: {{ toYaml .PlacementConfiguration.Infra.NodeSelector | nindent 8 }}
+      tolerations: {{ toYaml .PlacementConfiguration.Infra.Tolerations | nindent 8 }}
       affinity: {{ toYaml .PlacementConfiguration.Infra.Affinity | nindent 8 }}
       priorityClassName: system-cluster-critical
       containers:
@@ -109,8 +109,8 @@ spec:
         description: kubernetes-nmstate-webhook rotate webhook certs
     spec:
       serviceAccountName: {{template "handlerPrefix" .}}nmstate-handler
-      nodeSelector: {{ toYaml .InfraNodeSelector | nindent 8 }}
-      tolerations: {{ toYaml .InfraTolerations | nindent 8 }}
+      nodeSelector: {{ toYaml .PlacementConfiguration.Infra.NodeSelector | nindent 8 }}
+      tolerations: {{ toYaml .PlacementConfiguration.Infra.Tolerations | nindent 8 }}
       affinity: {{ toYaml .PlacementConfiguration.Infra.Affinity | nindent 8 }}
       priorityClassName: system-cluster-critical
       containers:

--- a/hack/components/bump-nmstate.sh
+++ b/hack/components/bump-nmstate.sh
@@ -36,8 +36,8 @@ echo 'Configure nmstate-webhook and nmstate-handler templates and save the rende
 
     sed -i \
         -e "s#WebhookAffinity#PlacementConfiguration.Infra.Affinity#" \
-        -e "s#WebhookTolerations#PlacementConfiguration.Infra.Tolerations#" \
-        -e "s#WebhookNodeSelector#PlacementConfiguration.Infra.NodeSelector#" \
+        -e "s#InfraTolerations#PlacementConfiguration.Infra.Tolerations#" \
+        -e "s#InfraNodeSelector#PlacementConfiguration.Infra.NodeSelector#" \
         -e "s#HandlerAffinity#PlacementConfiguration.Workloads.Affinity#" \
         -e "s#HandlerTolerations#PlacementConfiguration.Workloads.Tolerations#" \
         -e "s#HandlerNodeSelector#PlacementConfiguration.Workloads.NodeSelector#" \

--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -32,7 +32,7 @@ const (
 	LinuxBridgeCniImageDefault    = "quay.io/kubevirt/cni-default-plugins@sha256:d211830c45bde8608befb04cf2accc91490467f3b8e091b812b76453572c9ab8"
 	LinuxBridgeMarkerImageDefault = "quay.io/kubevirt/bridge-marker@sha256:9d90a5bd051d71429b6d9fc34112081fe64c6d3fb02221e18ebe72d428d58092"
 	KubeMacPoolImageDefault       = "quay.io/kubevirt/kubemacpool@sha256:9c885072d4be4924abe542a008b33492aa81806b950f22634c314d258f9b8789"
-	NMStateHandlerImageDefault    = "quay.io/nmstate/kubernetes-nmstate-handler@sha256:ceae0f1c415afcb3d90d008b2a4905c9dfb93354797b6b231fa342aa43b3f44d"
+	NMStateHandlerImageDefault    = "quay.io/nmstate/kubernetes-nmstate-handler@sha256:b8d1309d39899fc92694b528c489e94e72077d5d9cfd7fab372514390435d677"
 	OvsCniImageDefault            = "quay.io/kubevirt/ovs-cni-plugin@sha256:1e100c9584044c93c78020b4e4d037f26bbc8cc5b04e51c881ee5d7db5b117fe"
 	OvsMarkerImageDefault         = "quay.io/kubevirt/ovs-cni-marker@sha256:abf8d51df5904e7a01743524e75c8abdd41922f75fa0093e9fdd01fdfc22ac72"
 	MacvtapCniImageDefault        = "quay.io/kubevirt/macvtap-cni@sha256:e34cc796dee2e300f866d6f5b563361253ce89226eaf9eb0c3bc792f5481b8df"

--- a/pkg/controller/networkaddonsconfig/networkaddonsconfig_controller.go
+++ b/pkg/controller/networkaddonsconfig/networkaddonsconfig_controller.go
@@ -219,7 +219,7 @@ func (r *ReconcileNetworkAddonsConfig) Reconcile(request reconcile.Request) (rec
 		}
 		r.clusterInfo.IsSingleReplica = isSingleReplica
 	}
-	
+
 	// Fetch the NetworkAddonsConfig instance
 	networkAddonsConfigStorageVersion := &cnaov1.NetworkAddonsConfig{}
 	err = r.client.Get(context.TODO(), request.NamespacedName, networkAddonsConfigStorageVersion)

--- a/test/releases/99.0.0.go
+++ b/test/releases/99.0.0.go
@@ -42,19 +42,19 @@ func init() {
 				ParentName: "nmstate-handler",
 				ParentKind: "DaemonSet",
 				Name:       "nmstate-handler",
-				Image:      "quay.io/nmstate/kubernetes-nmstate-handler@sha256:ceae0f1c415afcb3d90d008b2a4905c9dfb93354797b6b231fa342aa43b3f44d",
+				Image:      "quay.io/nmstate/kubernetes-nmstate-handler@sha256:b8d1309d39899fc92694b528c489e94e72077d5d9cfd7fab372514390435d677",
 			},
 			{
 				ParentName: "nmstate-webhook",
 				ParentKind: "Deployment",
 				Name:       "nmstate-webhook",
-				Image:      "quay.io/nmstate/kubernetes-nmstate-handler@sha256:ceae0f1c415afcb3d90d008b2a4905c9dfb93354797b6b231fa342aa43b3f44d",
+				Image:      "quay.io/nmstate/kubernetes-nmstate-handler@sha256:b8d1309d39899fc92694b528c489e94e72077d5d9cfd7fab372514390435d677",
 			},
 			{
 				ParentName: "nmstate-cert-manager",
 				ParentKind: "Deployment",
 				Name:       "nmstate-cert-manager",
-				Image:      "quay.io/nmstate/kubernetes-nmstate-handler@sha256:ceae0f1c415afcb3d90d008b2a4905c9dfb93354797b6b231fa342aa43b3f44d",
+				Image:      "quay.io/nmstate/kubernetes-nmstate-handler@sha256:b8d1309d39899fc92694b528c489e94e72077d5d9cfd7fab372514390435d677",
 			},
 			{
 				ParentName: "ovs-cni-amd64",


### PR DESCRIPTION
Signed-off-by: Radim Hrazdil <rhrazdil@redhat.com>


**What this PR does / why we need it**:
https://github.com/nmstate/kubernetes-nmstate/pull/802/commits/a3fe803fa42f1075bd59b762f39898144c576c3c introduces 
infraNodeSelector and infraTolerations knobs.
Sync bump-nmstate.sh script to use correct names for these.

**Special notes for your reviewer**:
Depends on https://github.com/nmstate/kubernetes-nmstate/pull/802/commits/a3fe803fa42f1075bd59b762f39898144c576c3c

**Release note**:

```release-note
NONE
```
