### PR TITLE
nmstate, OVS: Mount OVS socket if enabled

### DIFF
--- a/pkg/network/nmstate.go
+++ b/pkg/network/nmstate.go
@@ -39,6 +39,9 @@ func renderNMState(conf *cnao.NetworkAddonsConfigSpec, manifestDir string, clust
 	data.Data["WebhookReplicas"] = getNumberOfWebhookReplicas(clusterInfo)
 	data.Data["WebhookMinReplicas"] = getMinNumberOfWebhookReplicas(clusterInfo)
 
+	_, enableOVS := os.LookupEnv("NMSTATE_ENABLE_OVS")
+	data.Data["EnableOVS"] = enableOVS
+
 	log.Printf("NMStateOperator == %t", clusterInfo.NmstateOperator)
 	fullManifestDir := filepath.Join(manifestDir, "nmstate", "operand")
 	if clusterInfo.NmstateOperator {


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the master branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it

If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**What this PR does / why we need it**:
The nmstate OVS functionality depends on the OVS socket to be mounted at
the handler container but this is only possible if OVS is installed at
nodes, this change add optional mount to the handler manifests
controlled by the environment variable NMSTATE_ENABLE_OVS on the operator, it
also sets the env variable at the openshift operator dockerfile to have
proper OVS functionality there.

**Special notes for your reviewer**:
Depends-On: https://github.com/nmstate/kubernetes-nmstate/pull/829

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
Mount OVS socket at kubernetes-nmstate-handler when NMSTATE_ENABLE_OVS env var is set
```
