### PR TITLE
Bump kubernetes-nmstate to v0.54.0

### DIFF
--- a/components.yaml
+++ b/components.yaml
@@ -31,10 +31,10 @@ components:
     metadata: v3.4.2
   nmstate:
     url: https://github.com/nmstate/kubernetes-nmstate
-    commit: 281e3fa2f223c3a76bcdb94d24622ffbe3767135
+    commit: a781f488cc6d523609ebee6c6005db350d502cae
     branch: main
     update-policy: tagged
-    metadata: v0.53.0
+    metadata: v0.54.0
   ovs-cni:
     url: https://github.com/k8snetworkplumbingwg/ovs-cni
     commit: cc57521b0d6060e44406e00d30ce21a6aa3b3506

--- a/data/nmstate/operand/operator.yaml
+++ b/data/nmstate/operand/operator.yaml
@@ -260,6 +260,10 @@ spec:
               mountPath: /run/dbus/system_bus_socket
             - name: nmstate-lock
               mountPath: /var/k8s_nmstate
+{{if .EnableOVS}}
+            - name: ovs-socket
+              mountPath: /run/openvswitch/db.sock
+{{end}}
           securityContext:
             privileged: true
           readinessProbe:
@@ -278,6 +282,12 @@ spec:
         - name: nmstate-lock
           hostPath:
             path: /var/k8s_nmstate
+{{if .EnableOVS}}
+        - name: ovs-socket
+          hostPath:
+            path: /run/openvswitch/db.sock
+            type: Socket
+{{end}}
 ---
 apiVersion: v1
 kind: Service

--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -32,7 +32,7 @@ const (
 	LinuxBridgeCniImageDefault    = "quay.io/kubevirt/cni-default-plugins@sha256:d211830c45bde8608befb04cf2accc91490467f3b8e091b812b76453572c9ab8"
 	LinuxBridgeMarkerImageDefault = "quay.io/kubevirt/bridge-marker@sha256:9d90a5bd051d71429b6d9fc34112081fe64c6d3fb02221e18ebe72d428d58092"
 	KubeMacPoolImageDefault       = "quay.io/kubevirt/kubemacpool@sha256:9c885072d4be4924abe542a008b33492aa81806b950f22634c314d258f9b8789"
-	NMStateHandlerImageDefault    = "quay.io/nmstate/kubernetes-nmstate-handler@sha256:b8d1309d39899fc92694b528c489e94e72077d5d9cfd7fab372514390435d677"
+	NMStateHandlerImageDefault    = "quay.io/nmstate/kubernetes-nmstate-handler@sha256:f6c61a0c4023e24e39f0c716b0caf8e643647718933d67df6f77c95674343a7d"
 	OvsCniImageDefault            = "quay.io/kubevirt/ovs-cni-plugin@sha256:1e100c9584044c93c78020b4e4d037f26bbc8cc5b04e51c881ee5d7db5b117fe"
 	OvsMarkerImageDefault         = "quay.io/kubevirt/ovs-cni-marker@sha256:abf8d51df5904e7a01743524e75c8abdd41922f75fa0093e9fdd01fdfc22ac72"
 	MacvtapCniImageDefault        = "quay.io/kubevirt/macvtap-cni@sha256:e34cc796dee2e300f866d6f5b563361253ce89226eaf9eb0c3bc792f5481b8df"

--- a/pkg/network/nmstate.go
+++ b/pkg/network/nmstate.go
@@ -39,6 +39,9 @@ func renderNMState(conf *cnao.NetworkAddonsConfigSpec, manifestDir string, clust
 	data.Data["WebhookReplicas"] = getNumberOfWebhookReplicas(clusterInfo)
 	data.Data["WebhookMinReplicas"] = getMinNumberOfWebhookReplicas(clusterInfo)
 
+	_, enableOVS := os.LookupEnv("NMSTATE_ENABLE_OVS")
+	data.Data["EnableOVS"] = enableOVS
+
 	log.Printf("NMStateOperator == %t", clusterInfo.NmstateOperator)
 	fullManifestDir := filepath.Join(manifestDir, "nmstate", "operand")
 	if clusterInfo.NmstateOperator {

--- a/test/releases/99.0.0.go
+++ b/test/releases/99.0.0.go
@@ -42,19 +42,19 @@ func init() {
 				ParentName: "nmstate-handler",
 				ParentKind: "DaemonSet",
 				Name:       "nmstate-handler",
-				Image:      "quay.io/nmstate/kubernetes-nmstate-handler@sha256:b8d1309d39899fc92694b528c489e94e72077d5d9cfd7fab372514390435d677",
+				Image:      "quay.io/nmstate/kubernetes-nmstate-handler@sha256:f6c61a0c4023e24e39f0c716b0caf8e643647718933d67df6f77c95674343a7d",
 			},
 			{
 				ParentName: "nmstate-webhook",
 				ParentKind: "Deployment",
 				Name:       "nmstate-webhook",
-				Image:      "quay.io/nmstate/kubernetes-nmstate-handler@sha256:b8d1309d39899fc92694b528c489e94e72077d5d9cfd7fab372514390435d677",
+				Image:      "quay.io/nmstate/kubernetes-nmstate-handler@sha256:f6c61a0c4023e24e39f0c716b0caf8e643647718933d67df6f77c95674343a7d",
 			},
 			{
 				ParentName: "nmstate-cert-manager",
 				ParentKind: "Deployment",
 				Name:       "nmstate-cert-manager",
-				Image:      "quay.io/nmstate/kubernetes-nmstate-handler@sha256:b8d1309d39899fc92694b528c489e94e72077d5d9cfd7fab372514390435d677",
+				Image:      "quay.io/nmstate/kubernetes-nmstate-handler@sha256:f6c61a0c4023e24e39f0c716b0caf8e643647718933d67df6f77c95674343a7d",
 			},
 			{
 				ParentName: "ovs-cni-amd64",


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the master branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it

If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**What this PR does / why we need it**:
Bump kubernetes-nmstate to v0.54.0

Also now is mandatory to have the "EnableOVS" data field for the handler manifests, this PR also add a way to control using using the environment variable NMSTATE_ENABLE_OVS.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
Bump kubernetes-nmstate to v0.54.0 and add NMSTATE_ENABLE_OVS control env var.
```
