### PR TITLE
status-manager, Fix bad compare of status

### DIFF
--- a/pkg/apis/networkaddonsoperator/shared/networkaddonsconfig_operators.go
+++ b/pkg/apis/networkaddonsoperator/shared/networkaddonsconfig_operators.go
@@ -1,0 +1,7 @@
+package shared
+
+import "reflect"
+
+func (s NetworkAddonsConfigStatus) DeepEqual(statusToCompare NetworkAddonsConfigStatus) bool {
+	return reflect.DeepEqual(s, statusToCompare)
+}

--- a/pkg/controller/statusmanager/status_manager.go
+++ b/pkg/controller/statusmanager/status_manager.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"log"
 	"os"
-	"reflect"
 	"strings"
 	"sync"
 	"time"
@@ -178,7 +177,7 @@ func (status *StatusManager) set(reachedAvailableLevel bool, conditions ...condi
 	// Failing condition had been replaced by Degraded in 0.12.0, drop it from CR if needed
 	conditionsv1.RemoveStatusCondition(&config.Status.Conditions, conditionsv1.ConditionType("Failing"))
 
-	if reflect.DeepEqual(oldStatus, config.Status) {
+	if (*oldStatus).DeepEqual(config.Status) {
 		return nil
 	}
 


### PR DESCRIPTION
When comparing statuses to see if the status has changed, there is a bug
since oldStatus is a pointer and config.Status is not, hence the
DeepEqual() will always return true

**Note** that this fix will not reduce status issues, since the heartbeat of statuses `Degraded` and `Available` are updated every reconcile.

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
