### PR TITLE
[release-0.58] components, change ovs-cni update-policy to static

### DIFF
--- a/components.yaml
+++ b/components.yaml
@@ -39,5 +39,5 @@ components:
     url: https://github.com/k8snetworkplumbingwg/ovs-cni
     commit: 959f619f56c3d309580145968e92a6ef1fcc57b8
     branch: main
-    update-policy: tagged
+    update-policy: static
     metadata: v0.24.0


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR changes ovs-cni update-policy to static

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
