### PR TITLE
cluster, cluster.sh: add kubeconfig for external

### DIFF
--- a/cluster/cluster.sh
+++ b/cluster/cluster.sh
@@ -49,5 +49,10 @@ function cluster::path() {
 }
 
 function cluster::kubeconfig() {
-    echo -n ${CLUSTER_PATH}/_ci-configs/${KUBEVIRT_PROVIDER}/.kubeconfig
+    if [ ${KUBEVIRT_PROVIDER} != "external" ]; then
+        echo -n ${CLUSTER_PATH}/_ci-configs/${KUBEVIRT_PROVIDER}/.kubeconfig
+    else
+        [[ -n $KUBECONFIG ]] || (echo "missing KUBECONFIG"; exit 1)
+        echo -n ${KUBECONFIG}
+    fi
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the master branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it

If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**What this PR does / why we need it**:
When testing against a cluster that is not kubevirtCI it
make sense that the cluster creadentials will be in place pointed
be the $KUBECONFIG env variable.

This commit makes the script use the cerdentials lies in $KUBECONFIG and
if not set exit with status 1.
**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
