### PR TITLE
controller, labels:don't take managed-by from CR

### DIFF
--- a/pkg/controller/networkaddonsconfig/networkaddonsconfig_controller.go
+++ b/pkg/controller/networkaddonsconfig/networkaddonsconfig_controller.go
@@ -530,19 +530,20 @@ func updateObjectsLabels(crLables map[string]string, objs []*unstructured.Unstru
 		// Label objects with version of the operator they were created by
 		labels[cnaov1.SchemeGroupVersion.Group+"/version"] = operatorVersionLabel
 		labels[names.PROMETHEUS_LABEL_KEY] = names.PROMETHEUS_LABEL_VALUE
+		labels[names.MANAGED_BY_LABEL_KEY] = names.MANAGED_BY_LABEL_DEFAULT_VALUE
 		err = updateObjectTemplateLabels(obj, labels, []string{names.PROMETHEUS_LABEL_KEY})
 		if err != nil {
 			return err
 		}
 
-		appLabelKeys := []string{names.COMPONENT_LABEL_KEY, names.PART_OF_LABEL_KEY, names.VERSION_LABEL_KEY, names.MANAGED_BY_LABEL_KEY}
-
+		appLabelKeys := []string{names.COMPONENT_LABEL_KEY, names.PART_OF_LABEL_KEY, names.VERSION_LABEL_KEY}
 		labels = updateLabelsFromCR(labels, crLables, appLabelKeys)
 		if err != nil {
 			return err
 		}
 		obj.SetLabels(labels)
 
+		appLabelKeys = append(appLabelKeys, names.MANAGED_BY_LABEL_KEY)
 		err = updateObjectTemplateLabels(obj, labels, appLabelKeys)
 		if err != nil {
 			return err
@@ -554,7 +555,6 @@ func updateObjectsLabels(crLables map[string]string, objs []*unstructured.Unstru
 
 func updateLabelsFromCR(labels, crLables map[string]string, appLabelKeys []string) map[string]string {
 	labels[names.COMPONENT_LABEL_KEY] = names.COMPONENT_LABEL_DEFAULT_VALUE
-	labels[names.MANAGED_BY_LABEL_KEY] = names.MANAGED_BY_LABEL_DEFAULT_VALUE
 	for _, key := range appLabelKeys {
 		if value, exist := crLables[key]; exist == true {
 			labels[key] = value

--- a/pkg/controller/networkaddonsconfig/networkaddonsconfig_controller_test.go
+++ b/pkg/controller/networkaddonsconfig/networkaddonsconfig_controller_test.go
@@ -66,7 +66,7 @@ var _ = Describe("Networkaddonsconfig", func() {
 		var objs []*unstructured.Unstructured
 		var crLabels map[string]string
 		const expectedComponentLabel = "component_unit_tests"
-		const expectedManagedByLabel = "managed_by_unit_tests"
+		const expectedManagedByLabel = names.MANAGED_BY_LABEL_DEFAULT_VALUE
 		const expectedPartOfLabel = "part_of_unit_tests"
 		const expectedVersionLabel = "version_of_unit_tests"
 

--- a/test/operations/operations.go
+++ b/test/operations/operations.go
@@ -154,3 +154,22 @@ func configSpecToYaml(configSpec cnao.NetworkAddonsConfigSpec) string {
 	// Note that it is empty otherwise
 	return "Empty Spec"
 }
+
+func LabelConfig(gvk schema.GroupVersionKind, newLabels map[string]string) {
+	By(fmt.Sprintf("Labeling NetworkAddonsConfig with:\n%v", newLabels))
+
+	// Get current Config
+	config := GetConfig(gvk)
+
+	// Label the Config with the desired new labels
+	labels := config.GetLabels()
+	if labels == nil {
+		labels = make(map[string]string)
+	}
+	for k, v := range newLabels {
+		labels[k] = v
+	}
+	config.SetLabels(labels)
+	err := framework.Global.Client.Update(context.TODO(), config)
+	Expect(err).NotTo(HaveOccurred(), "Failed to label the Config")
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the master branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it

If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**What this PR does / why we need it**:
When CNAO is deployed by HCO, HCO puts `managed-by` label with HCO value on
networkAddonsConfig. networkAddonsConfig controller then takes this value and inherit it
to the deployed components. This cause a wrong result of a CNAO component labeled
as managed by HCO.

This commit makes that `managed-by` label will not be taken from networkAddonsConfig,
and test it against an example component - ovs.

Signed-off-by: alonsadan <asadan@redhat.com>


Fixes #1051 
**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
