### PR TITLE
docker-utils, Remove seccomp to avoid pthread permission error

### DIFF
--- a/hack/components/docker-utils.sh
+++ b/hack/components/docker-utils.sh
@@ -13,7 +13,7 @@ set -xo pipefail
 # The image digest
 #
 function docker-utils::get_image_digest() {
-  echo "${2}@$(docker run --rm quay.io/skopeo/stable:latest inspect "docker://${1}" | jq -r '.Digest')"
+  echo "${2}@$(docker run --rm --security-opt seccomp=unconfined quay.io/skopeo/stable:latest inspect "docker://${1}" | jq -r '.Digest')"
 }
 
 # The check_image_exists function checks if an image already exists in the registry.
@@ -25,5 +25,5 @@ function docker-utils::get_image_digest() {
 # returns the image tag if found; else, returns an empty result
 #
 function docker-utils::check_image_exists() {
-  docker run --rm quay.io/skopeo/stable:latest list-tags "docker://${1}" | grep "\"${2}\""
+  docker run --rm --security-opt seccomp=unconfined quay.io/skopeo/stable:latest list-tags "docker://${1}" | grep "\"${2}\""
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
seccomp is a sandboxing facility in the Linux kernel that acts
like a firewall for system calls (syscalls).
in recent quay.io/skopeo/stable:v1.5.*, certain commands were
added to the pthread_create function, that is not allowed by the
default seccomp profile.
to avoid pthread permission error on docker skopeo application,
and to avoid handeling of seccomp profile, disable the seccomp
policy entirely.
Since docker-utils is only used for bump scripts, and not the
actual binary, there is no need to use seccomp

**Special notes for your reviewer**:
fixes https://github.com/kubevirt/cluster-network-addons-operator/issues/1080

**Release note**:

```release-note
NONE
```
