### PR TITLE
hack/components, Move docker-utils to podman

### DIFF
--- a/hack/components/bump-bridge-marker.sh
+++ b/hack/components/bump-bridge-marker.sh
@@ -4,7 +4,7 @@ set -xeo pipefail
 
 source hack/components/yaml-utils.sh
 source hack/components/git-utils.sh
-source hack/components/docker-utils.sh
+source hack/components/podman-utils.sh
 
 #here we do all the object specific parametizing
 function __parametize_by_object() {
@@ -96,7 +96,7 @@ echo 'Get bridge-marker image name and update it under CNAO'
 BRIDGE_MARKER_TAG=$(git-utils::get_component_tag ${BRIDGE_MARKER_PATH})
 BRIDGE_MARKER_IMAGE=quay.io/kubevirt/bridge-marker
 BRIDGE_MARKER_IMAGE_TAGGED=${BRIDGE_MARKER_IMAGE}:${BRIDGE_MARKER_TAG}
-BRIDGE_MARKER_IMAGE_DIGEST="$(docker-utils::get_image_digest "${BRIDGE_MARKER_IMAGE_TAGGED}" "${BRIDGE_MARKER_IMAGE}")"
+BRIDGE_MARKER_IMAGE_DIGEST="$(podman-utils::get_image_digest "${BRIDGE_MARKER_IMAGE_TAGGED}" "${BRIDGE_MARKER_IMAGE}")"
 
 sed -i -r "s#\"${BRIDGE_MARKER_IMAGE}(@sha256)?:.*\"#\"${BRIDGE_MARKER_IMAGE_DIGEST}\"#" pkg/components/components.go
 sed -i -r "s#\"${BRIDGE_MARKER_IMAGE}(@sha256)?:.*\"#\"${BRIDGE_MARKER_IMAGE_DIGEST}\"#" test/releases/${CNAO_VERSION}.go

--- a/hack/components/bump-kubemacpool.sh
+++ b/hack/components/bump-kubemacpool.sh
@@ -4,7 +4,7 @@ set -xeo pipefail
 
 source hack/components/yaml-utils.sh
 source hack/components/git-utils.sh
-source hack/components/docker-utils.sh
+source hack/components/podman-utils.sh
 
 echo 'Bumping kubemacpool'
 KUBEMACPOOL_URL=$(yaml-utils::get_component_url kubemacpool)
@@ -118,7 +118,7 @@ echo 'Get kubemacpool image name and update it under CNAO'
 KUBEMACPOOL_TAG=$(git-utils::get_component_tag ${KUBEMACPOOL_PATH})
 KUBEMACPOOL_IMAGE=quay.io/kubevirt/kubemacpool
 KUBEMACPOOL_IMAGE_TAGGED=${KUBEMACPOOL_IMAGE}:${KUBEMACPOOL_TAG}
-KUBEMACPOOL_IMAGE_DIGEST="$(docker-utils::get_image_digest "${KUBEMACPOOL_IMAGE_TAGGED}" "${KUBEMACPOOL_IMAGE}")"
+KUBEMACPOOL_IMAGE_DIGEST="$(podman-utils::get_image_digest "${KUBEMACPOOL_IMAGE_TAGGED}" "${KUBEMACPOOL_IMAGE}")"
 
 sed -i -r "s#\"${KUBEMACPOOL_IMAGE}(@sha256)?:.*\"#\"${KUBEMACPOOL_IMAGE_DIGEST}\"#" pkg/components/components.go
 sed -i -r "s#\"${KUBEMACPOOL_IMAGE}(@sha256)?:.*\"#\"${KUBEMACPOOL_IMAGE_DIGEST}\"#" test/releases/${CNAO_VERSION}.go

--- a/hack/components/bump-linux-bridge.sh
+++ b/hack/components/bump-linux-bridge.sh
@@ -4,7 +4,7 @@ set -xe
 
 source hack/components/yaml-utils.sh
 source hack/components/git-utils.sh
-source hack/components/docker-utils.sh
+source hack/components/podman-utils.sh
 
 echo Bumping linux-bridge
 LINUX_BRIDGE_URL=$(yaml-utils::get_component_url linux-bridge)
@@ -56,8 +56,8 @@ echo 'Push the image to KubeVirt repo'
     fi
 )
 
-if [[ -n "$(docker-utils::check_image_exists "${LINUX_BRIDGE_IMAGE}" "${LINUX_BRIDGE_TAG}")" ]]; then
-    LINUX_BRIDGE_IMAGE_DIGEST="$(docker-utils::get_image_digest "${LINUX_BRIDGE_IMAGE_TAGGED}" "${LINUX_BRIDGE_IMAGE}")"
+if [[ -n "$(podman-utils::check_image_exists "${LINUX_BRIDGE_IMAGE}" "${LINUX_BRIDGE_TAG}")" ]]; then
+    LINUX_BRIDGE_IMAGE_DIGEST="$(podman-utils::get_image_digest "${LINUX_BRIDGE_IMAGE_TAGGED}" "${LINUX_BRIDGE_IMAGE}")"
 else
     LINUX_BRIDGE_IMAGE_DIGEST=${LINUX_BRIDGE_IMAGE_TAGGED}
 fi

--- a/hack/components/bump-macvtap-cni.sh
+++ b/hack/components/bump-macvtap-cni.sh
@@ -4,7 +4,7 @@ set -xeo pipefail
 
 source hack/components/yaml-utils.sh
 source hack/components/git-utils.sh
-source hack/components/docker-utils.sh
+source hack/components/podman-utils.sh
 
 function __parametize_by_object() {
   for f in ./*; do
@@ -61,7 +61,7 @@ echo 'Get macvtap-cni image name and update it under CNAO'
 MACVTAP_TAG=$(git-utils::get_component_tag ${MACVTAP_PATH})
 MACVTAP_IMAGE=quay.io/kubevirt/macvtap-cni
 MACVTAP_IMAGE_TAGGED=${MACVTAP_IMAGE}:${MACVTAP_TAG}
-MACVTAP_IMAGE_DIGEST="$(docker-utils::get_image_digest "${MACVTAP_IMAGE_TAGGED}" "${MACVTAP_IMAGE}")"
+MACVTAP_IMAGE_DIGEST="$(podman-utils::get_image_digest "${MACVTAP_IMAGE_TAGGED}" "${MACVTAP_IMAGE}")"
 
 sed -i -r "s#\"${MACVTAP_IMAGE}(@sha256)?:.*\"#\"${MACVTAP_IMAGE_DIGEST}\"#" pkg/components/components.go
 # TODO: uncomment the following line *once* there is macvtap upgrade is supported

--- a/hack/components/bump-multus.sh
+++ b/hack/components/bump-multus.sh
@@ -4,7 +4,7 @@ set -xeo pipefail
 
 source hack/components/yaml-utils.sh
 source hack/components/git-utils.sh
-source hack/components/docker-utils.sh
+source hack/components/podman-utils.sh
 
 #here we do all the object specific parametizing
 function __parametize_by_object() {
@@ -140,8 +140,8 @@ if [ ! -z ${PUSH_IMAGES} ]; then
     docker push "${MULTUS_IMAGE_TAGGED}"
 fi
 
-if [[ -n "$(docker-utils::check_image_exists "${MULTUS_IMAGE}" "${MULTUS_TAG}")" ]]; then
-    MULTUS_IMAGE_DIGEST="$(docker-utils::get_image_digest "${MULTUS_IMAGE_TAGGED}" "${MULTUS_IMAGE}")"
+if [[ -n "$(podman-utils::check_image_exists "${MULTUS_IMAGE}" "${MULTUS_TAG}")" ]]; then
+    MULTUS_IMAGE_DIGEST="$(podman-utils::get_image_digest "${MULTUS_IMAGE_TAGGED}" "${MULTUS_IMAGE}")"
 else
     MULTUS_IMAGE_DIGEST=${MULTUS_IMAGE_TAGGED}
 fi

--- a/hack/components/bump-nmstate.sh
+++ b/hack/components/bump-nmstate.sh
@@ -4,7 +4,7 @@ set -xeo pipefail
 
 source hack/components/yaml-utils.sh
 source hack/components/git-utils.sh
-source hack/components/docker-utils.sh
+source hack/components/podman-utils.sh
 
 echo 'Bumping kubernetes-nmstate'
 NMSTATE_URL=$(yaml-utils::get_component_url nmstate)
@@ -22,7 +22,7 @@ echo 'Get kubernetes-nmstate image name and update it under CNAO'
 NMSTATE_TAG=$(git-utils::get_component_tag ${NMSTATE_PATH})
 NMSTATE_IMAGE=quay.io/nmstate/kubernetes-nmstate-handler
 NMSTATE_IMAGE_TAGGED=${NMSTATE_IMAGE}:${NMSTATE_TAG}
-NMSTATE_IMAGE_DIGEST="$(docker-utils::get_image_digest "${NMSTATE_IMAGE_TAGGED}" "${NMSTATE_IMAGE}")"
+NMSTATE_IMAGE_DIGEST="$(podman-utils::get_image_digest "${NMSTATE_IMAGE_TAGGED}" "${NMSTATE_IMAGE}")"
 
 sed -i -r "s#\"${NMSTATE_IMAGE}(@sha256)?:.*\"#\"${NMSTATE_IMAGE_DIGEST}\"#" pkg/components/components.go
 sed -i -r "s#\"${NMSTATE_IMAGE}(@sha256)?:.*\"#\"${NMSTATE_IMAGE_DIGEST}\"#" "test/releases/${CNAO_VERSION}.go"

--- a/hack/components/bump-ovs-cni.sh
+++ b/hack/components/bump-ovs-cni.sh
@@ -4,7 +4,7 @@ set -xeo pipefail
 
 source hack/components/yaml-utils.sh
 source hack/components/git-utils.sh
-source hack/components/docker-utils.sh
+source hack/components/podman-utils.sh
 
 #here we do all the object specific parametizing
 function __parametize_by_object() {
@@ -111,7 +111,7 @@ OVS_TAG=$(git-utils::get_component_tag ${OVS_PATH})
 echo 'Get ovs-cni-plugin image name and update it under CNAO'
 OVS_PLUGIN_IMAGE=quay.io/kubevirt/ovs-cni-plugin
 OVS_PLUGIN_IMAGE_TAGGED=${OVS_PLUGIN_IMAGE}:${OVS_TAG}
-OVS_PLUGIN_IMAGE_DIGEST="$(docker-utils::get_image_digest "${OVS_PLUGIN_IMAGE_TAGGED}" "${OVS_PLUGIN_IMAGE}")"
+OVS_PLUGIN_IMAGE_DIGEST="$(podman-utils::get_image_digest "${OVS_PLUGIN_IMAGE_TAGGED}" "${OVS_PLUGIN_IMAGE}")"
 
 sed -i -r "s#\"${OVS_PLUGIN_IMAGE}(@sha256)?:.*\"#\"${OVS_PLUGIN_IMAGE_DIGEST}\"#" pkg/components/components.go
 sed -i -r "s#\"${OVS_PLUGIN_IMAGE}(@sha256)?:.*\"#\"${OVS_PLUGIN_IMAGE_DIGEST}\"#" test/releases/${CNAO_VERSION}.go
@@ -119,7 +119,7 @@ sed -i -r "s#\"${OVS_PLUGIN_IMAGE}(@sha256)?:.*\"#\"${OVS_PLUGIN_IMAGE_DIGEST}\"
 echo 'Get ovs-cni-marker image name and update it under CNAO'
 OVS_MARKER_IMAGE=quay.io/kubevirt/ovs-cni-marker
 OVS_MARKER_IMAGE_TAGGED=${OVS_MARKER_IMAGE}:${OVS_TAG}
-OVS_MARKER_IMAGE_DIGEST="$(docker-utils::get_image_digest "${OVS_MARKER_IMAGE_TAGGED}" "${OVS_MARKER_IMAGE}")"
+OVS_MARKER_IMAGE_DIGEST="$(podman-utils::get_image_digest "${OVS_MARKER_IMAGE_TAGGED}" "${OVS_MARKER_IMAGE}")"
 
 sed -i -r "s#\"${OVS_MARKER_IMAGE}(@sha256)?:.*\"#\"${OVS_MARKER_IMAGE_DIGEST}\"#" pkg/components/components.go
 sed -i -r "s#\"${OVS_MARKER_IMAGE}(@sha256)?:.*\"#\"${OVS_MARKER_IMAGE_DIGEST}\"#" test/releases/${CNAO_VERSION}.go

--- a/hack/components/podman-utils.sh
+++ b/hack/components/podman-utils.sh
@@ -12,8 +12,8 @@ set -xo pipefail
 # Returns
 # The image digest
 #
-function docker-utils::get_image_digest() {
-  echo "${2}@$(docker run --rm quay.io/skopeo/stable:latest inspect "docker://${1}" | jq -r '.Digest')"
+function podman-utils::get_image_digest() {
+  echo "${2}@$(podman run --rm quay.io/skopeo/stable:latest inspect "podman://${1}" | jq -r '.Digest')"
 }
 
 # The check_image_exists function checks if an image already exists in the registry.
@@ -24,6 +24,6 @@ function docker-utils::get_image_digest() {
 #
 # returns the image tag if found; else, returns an empty result
 #
-function docker-utils::check_image_exists() {
-  docker run --rm quay.io/skopeo/stable:latest list-tags "docker://${1}" | grep "\"${2}\""
+function podman-utils::check_image_exists() {
+  podman run --rm quay.io/skopeo/stable:latest list-tags "podman://${1}" | grep "\"${2}\""
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Recent skopeo releaeses updated the OS and moved to
use more advanced syscalls, ones that are currently
filtered by docker (issue [0]).
In order to move past this issue, moving to Podman.

[0] https://github.com/containers/skopeo/issues/1501

**Special notes for your reviewer**:
fixed #1081 

**Release note**:

```release-note
NONE
```
