### PR TITLE
Add common labels into alert definitions

### DIFF
--- a/data/monitoring/prom-rule.yaml
+++ b/data/monitoring/prom-rule.yaml
@@ -19,6 +19,8 @@ spec:
           for: 5m
           labels:
             severity: warning
+            kubernetes_operator_part_of: kubevirt
+            kubernetes_operator_component: cluster-network-addons-operator
         - alert: NetworkAddonsConfigNotReady
           annotations:
             summary: CNAO CR NetworkAddonsConfig is not ready.
@@ -27,6 +29,8 @@ spec:
           for: 5m
           labels:
             severity: warning
+            kubernetes_operator_part_of: kubevirt
+            kubernetes_operator_component: cluster-network-addons-operator
         - expr: sum(kubevirt_kmp_duplicate_macs{namespace='{{ .Namespace }}'} or vector(0))
           record: kubevirt_kubemacpool_duplicate_macs_total
         - alert: KubeMacPoolDuplicateMacsFound
@@ -37,6 +41,8 @@ spec:
           for: 5m
           labels:
             severity: warning
+            kubernetes_operator_part_of: kubevirt
+            kubernetes_operator_component: cluster-network-addons-operator
         - expr: sum(up{namespace='{{ .Namespace }}', pod=~'kubemacpool-mac-controller-manager-.*'} or vector(0))
           record: kubevirt_cnao_kubemacpool_manager_num_up_pods_total
         - expr: sum(kubevirt_cnao_cr_kubemacpool_deployed{namespace='{{ .Namespace }}'} or vector(0))
@@ -49,3 +55,5 @@ spec:
           for: 5m
           labels:
             severity: critical
+            kubernetes_operator_part_of: kubevirt
+            kubernetes_operator_component: cluster-network-addons-operator

--- a/hack/prom-rule-ci/prom-rules-tests.yaml
+++ b/hack/prom-rule-ci/prom-rules-tests.yaml
@@ -21,6 +21,8 @@ tests:
               runbook_url: "http://kubevirt.io/monitoring/runbooks/CnaoDown"
             exp_labels:
               severity: "warning"
+              kubernetes_operator_part_of: "kubevirt"
+              kubernetes_operator_component: "cluster-network-addons-operator"
 # CnaoDown negative tests
   - interval: 1m
     input_series:
@@ -51,6 +53,8 @@ tests:
               runbook_url: "http://kubevirt.io/monitoring/runbooks/NetworkAddonsConfigNotReady"
             exp_labels:
               severity: "warning"
+              kubernetes_operator_part_of: "kubevirt"
+              kubernetes_operator_component: "cluster-network-addons-operator"
 
 # NetworkAddonsConfigNotReady negative tests
   - interval: 1m
@@ -84,6 +88,8 @@ tests:
               runbook_url: "http://kubevirt.io/monitoring/runbooks/KubeMacPoolDuplicateMacsFound"
             exp_labels:
               severity: "warning"
+              kubernetes_operator_part_of: "kubevirt"
+              kubernetes_operator_component: "cluster-network-addons-operator"
 
 # KubeMacPoolDuplicateMacsFound negative tests
   - interval: 1m
@@ -115,6 +121,8 @@ tests:
               runbook_url: "http://kubevirt.io/monitoring/runbooks/KubemacpoolDown"
             exp_labels:
               severity: "critical"
+              kubernetes_operator_part_of: "kubevirt"
+              kubernetes_operator_component: "cluster-network-addons-operator"
 
   # KubemacpoolDown negative tests
   - interval: 1m


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the master branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it

If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**What this PR does / why we need it**:
We want to be able to list all kubevirt alerts so we added labels to differentiate them.

Signed-off-by: assafad aadmi@redhat.com


**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
Added common labels into alert definitions
```
