### PR TITLE
[DNM] check-patch.e2e, Install and upgrade prior to run

### DIFF
--- a/automation/check-patch.setup.sh
+++ b/automation/check-patch.setup.sh
@@ -27,3 +27,6 @@ export ARTIFACTS=${ARTIFACTS-$tmp_dir/artifacts}
 mkdir -p $ARTIFACTS
 
 rsync -rt --links --filter=':- .gitignore' $(pwd)/ $TMP_PROJECT_PATH
+
+cat ${TMP_PROJECT_PATH}/automation/check-patch.e2e.packages | xargs dnf -y install
+cat ${TMP_PROJECT_PATH}/automation/check-patch.e2e.packages | xargs dnf -y upgrade


### PR DESCRIPTION
Currently e2e tests do not account to the required tools
needed to run the tests.
This change makes sure to install and upgrade them to the latest.

This commit also fixes this (TBD)

Signed-off-by: Ram Lavi <ralavi@redhat.com>

<!-- Thanks for sending a pull request!

Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the master branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it

If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note

```
