### PR TITLE
manager: Remove leader election

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"context"
 	"flag"
 	"log"
 	"os"
@@ -9,7 +8,6 @@ import (
 
 	osv1 "github.com/openshift/api/operator/v1"
 	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
-	"github.com/operator-framework/operator-sdk/pkg/leader"
 	sdkVersion "github.com/operator-framework/operator-sdk/version"
 	"github.com/spf13/pflag"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
@@ -47,15 +45,6 @@ func main() {
 	cfg, err := config.GetConfig()
 	if err != nil {
 		log.Printf("failed to get apiserver config: %v", err)
-		os.Exit(1)
-	}
-
-	ctx := context.TODO()
-
-	// Become the leader before proceeding
-	err = leader.Become(ctx, "cluster-network-addons-operator-lock")
-	if err != nil {
-		log.Printf("failed to become operator leader: %v", err)
 		os.Exit(1)
 	}
 


### PR DESCRIPTION
/kind enhancement

**What this PR does / why we need it**:
Now CNAO is using Recreate as the upgrade strategy so there is always
only one CNAO pod active, leader election is not needed anymore.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
Remove leader election
```
