### PR TITLE
dockerfile: Use quay.io instead of docker.io

### DIFF
--- a/build/operator/Dockerfile
+++ b/build/operator/Dockerfile
@@ -1,4 +1,4 @@
-FROM centos:centos7
+FROM quay.io/centos/centos:centos7
 ENV ENTRYPOINT=/entrypoint \
     OPERATOR=/cluster-network-addons-operator \
     MANIFEST_TEMPLATOR=/manifest-templator \


### PR DESCRIPTION
**What this PR does / why we need it**:

In order to avoid docker.io rate limits,
use the official centos quay.io repository.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
None
```
