### PR TITLE
open Vswitch: Remove RDO from open Vswitch install

### DIFF
--- a/cluster/up.sh
+++ b/cluster/up.sh
@@ -36,7 +36,7 @@ if [[ "$KUBEVIRT_PROVIDER" =~ k8s- ]]; then
     echo 'Installing Open vSwitch on nodes'
     for node in $(./cluster/kubectl.sh get nodes --no-headers | awk '{print $1}'); do
         ./cluster/cli.sh ssh ${node} -- sudo yum config-manager --set-enabled powertools
-        ./cluster/cli.sh ssh ${node} -- sudo yum install -y epel-release centos-release-openstack-wallaby epel-release centos-release-openstack-train https://rdoproject.org/repos/rdo-release.rpm
+        ./cluster/cli.sh ssh ${node} -- sudo yum install -y epel-release centos-release-openstack-wallaby epel-release centos-release-openstack-train
         ./cluster/cli.sh ssh ${node} -- sudo yum install -y openvswitch libibverbs NetworkManager-ovs
         ./cluster/cli.sh ssh ${node} -- sudo systemctl daemon-reload
         ./cluster/cli.sh ssh ${node} -- sudo systemctl enable --now openvswitch


### PR DESCRIPTION
**What this PR does / why we need it**:

Deploying CNAO fails because https://rdoproject.org is not accessible.
rdoproject is used when installing open Vswitch.
    
We are using already another version centos-release-openstack-wallaby
so we can remove rdoproject.
    
K8s-nmstate has tests of open Vswitch as part of CNAO gating,
and those tests are passing.

**Special notes for your reviewer**:

**Release note**:

```release-note
None
```
