### PR TITLE
kubevirtci: Bump kubevirtci in order to fix rate limits

### DIFF
--- a/cluster/cluster.sh
+++ b/cluster/cluster.sh
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 export KUBEVIRT_PROVIDER=${KUBEVIRT_PROVIDER:-'k8s-1.21'}
-export KUBEVIRTCI_TAG='2106301530-8ce1562'
+export KUBEVIRTCI_TAG='2112201324-5d26105'
 
 KUBEVIRTCI_REPO='https://github.com/kubevirt/kubevirtci.git'
 # The CLUSTER_PATH var is used in cluster folder and points to the _kubevirtci where the cluster is deployed from.


### PR DESCRIPTION
**What this PR does / why we need it**:

Newer kubevirtci mirrors images such as the library/registry
to quay.io instead of using docker.io.
This will fix the docker.io rate limits.

**Special notes for your reviewer**:

**Release note**:

```release-note
None
```
