### PR TITLE
knmstate: Reduce the number of e2e tests

### DIFF
--- a/automation/check-patch.e2e-nmstate-functests.sh
+++ b/automation/check-patch.e2e-nmstate-functests.sh
@@ -53,7 +53,7 @@ main() {
     make test-e2e-handler \
         E2E_TEST_TIMEOUT=$TIMEOUT \
         e2e_test_args="-noColor" \
-        E2E_TEST_SUITE_ARGS="-ginkgo.skip='parallel' --junit-output=$ARTIFACTS/junit.functest.xml" \
+        E2E_TEST_SUITE_ARGS="-ginkgo.focus='.*nmpolicy.*|.*bonding.*default.*|.*ovs.*|.*Webhook.*' --junit-output=$ARTIFACTS/junit.functest.xml" \
         OPERATOR_NAMESPACE=$NAMESPACE \
         CLUSTER_PATH=$CLUSTER_PATH \
         KUBECONFIG=$KUBECONFIG \


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the main branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it

If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**What this PR does / why we need it**:
Running all the kubernetes-nmstate tests takes a lot of time and does
not bring much value. This change runs the following tests:
- Webhooks
- OVS
- NMPolicy
- default bridge and bond

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
