### PR TITLE
Update Dockerfile to use centos:stream9

### DIFF
--- a/build/operator/Dockerfile
+++ b/build/operator/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/centos/centos:centos7
+FROM quay.io/centos/centos:stream9
 ENV ENTRYPOINT=/entrypoint \
     OPERATOR=/cluster-network-addons-operator \
     MANIFEST_TEMPLATOR=/manifest-templator \


### PR DESCRIPTION

Signed-off-by: João Vilaça <jvilaca@redhat.com>

<!-- Thanks for sending a pull request!

Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the main branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it

If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**What this PR does / why we need it**:

CentOS 7 is scheduled for EOL as stated in https://wiki.centos.org/About/Product, and already exited the Full Updates phase.
Therefore this PR updates CentOS version in Dockerfile for new builds to use CentOS Stream 9, which is in the full support phase (https://www.centos.org/centos-stream/).

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
Update Dockerfile to use CentOS Stream 9
```
