### PR TITLE
metrics: Use https instead of http

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -161,6 +161,7 @@ gen-manifests: manifest-templator
 	LINUX_BRIDGE_CNI_IMAGE=$(LINUX_BRIDGE_CNI_IMAGE) \
 	KUBEMACPOOL_IMAGE=$(KUBEMACPOOL_IMAGE) \
 	MACVTAP_CNI_IMAGE=$(MACVTAP_CNI_IMAGE) \
+	KUBE_RBAC_PROXY_IMAGE=$(KUBE_RBAC_PROXY_IMAGE) \
 		./hack/generate-manifests.sh
 
 gen-k8s: $(CONTROLLER_GEN) $(apis_sources)

--- a/data/kubemacpool/kubemacpool.yaml
+++ b/data/kubemacpool/kubemacpool.yaml
@@ -391,8 +391,8 @@ spec:
         - --logtostderr
         - --secure-listen-address=:8443
         - --upstream=http://127.0.0.1:8080
-        image: quay.io/openshift/origin-kube-rbac-proxy:4.10.0
-        imagePullPolicy: IfNotPresent
+        image: '{{ .KubeRbacProxyImage }}'
+        imagePullPolicy: '{{ .ImagePullPolicy }}'
         name: kube-rbac-proxy
         ports:
         - containerPort: 8443

--- a/data/monitoring/service.yaml
+++ b/data/monitoring/service.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   ports:
     - name: metrics
-      port: 8080
+      port: 8443
       protocol: TCP
       targetPort: metrics
   selector:

--- a/data/monitoring/service_monitor.yaml
+++ b/data/monitoring/service_monitor.yaml
@@ -15,6 +15,7 @@ spec:
       - {{ .Namespace }}
   endpoints:
     - port: metrics
-      scheme: http
+      bearerTokenFile: "/var/run/secrets/kubernetes.io/serviceaccount/token"
+      scheme: https
       tlsConfig:
         insecureSkipVerify: true

--- a/hack/components/bump-kubemacpool.sh
+++ b/hack/components/bump-kubemacpool.sh
@@ -50,6 +50,9 @@ spec:
       - image: "{{ .KubeMacPoolImage }}"
         imagePullPolicy: "{{ .ImagePullPolicy }}"
         name: manager
+      - image: "{{ .KubeRbacProxyImage }}"
+        imagePullPolicy: "{{ .ImagePullPolicy }}"
+        name: kube-rbac-proxy
 EOF
 
     cat <<EOF > config/cnao/cnao_cert-manager_patch.yaml

--- a/hack/generate-manifests.sh
+++ b/hack/generate-manifests.sh
@@ -25,6 +25,7 @@ for template in $templates; do
 		--container-prefix=${CONTAINER_PREFIX} \
 		--container-tag=${CONTAINER_TAG} \
 		--image-pull-policy=${IMAGE_PULL_POLICY} \
+		--kube-rbac-proxy-image=${KUBE_RBAC_PROXY_IMAGE} \
 		--input-file=${infile} \
 	)
 	if [[ ! -z "$rendered" ]]; then

--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -35,6 +35,7 @@ const (
 	OvsCniImageDefault            = "quay.io/kubevirt/ovs-cni-plugin@sha256:fd766d39f74528f94978b116908e9b86cbdfea30a53493043405c08d9d1e6527"
 	OvsMarkerImageDefault         = "quay.io/kubevirt/ovs-cni-marker@sha256:6d506c66a779827659709d1c7253f96f3ad493e5fff23b549942a537f6304be4"
 	MacvtapCniImageDefault        = "quay.io/kubevirt/macvtap-cni@sha256:bfaf7b1c4840e27cce20887ba3e8c24f94ff1c36f09acaa8fa195ea431b9bfd1"
+	KubeRbacProxyImageDefault     = "quay.io/openshift/origin-kube-rbac-proxy@sha256:baedb268ac66456018fb30af395bb3d69af5fff3252ff5d549f0231b1ebb6901"
 )
 
 type AddonsImages struct {
@@ -46,6 +47,7 @@ type AddonsImages struct {
 	OvsCni            string
 	OvsMarker         string
 	MacvtapCni        string
+	KubeRbacProxy     string
 }
 
 type RelatedImage struct {
@@ -94,6 +96,9 @@ func (ai *AddonsImages) FillDefaults() *AddonsImages {
 	if ai.MacvtapCni == "" {
 		ai.MacvtapCni = MacvtapCniImageDefault
 	}
+	if ai.KubeRbacProxy == "" {
+		ai.KubeRbacProxy = KubeRbacProxyImageDefault
+	}
 	return ai
 }
 
@@ -107,6 +112,7 @@ func (ai AddonsImages) ToRelatedImages() RelatedImages {
 		ai.OvsCni,
 		ai.OvsMarker,
 		ai.MacvtapCni,
+		ai.KubeRbacProxy,
 	)
 }
 
@@ -213,6 +219,10 @@ func GetDeployment(version string, operatorVersion string, namespace string, rep
 									Value: addonsImages.MacvtapCni,
 								},
 								{
+									Name:  "KUBE_RBAC_PROXY_IMAGE",
+									Value: addonsImages.KubeRbacProxy,
+								},
+								{
 									Name:  "OPERATOR_IMAGE",
 									Value: image,
 								},
@@ -264,7 +274,7 @@ func GetDeployment(version string, operatorVersion string, namespace string, rep
 						},
 						{
 							Name:            "kube-rbac-proxy",
-							Image:           "quay.io/openshift/origin-kube-rbac-proxy:4.10.0",
+							Image:           addonsImages.KubeRbacProxy,
 							ImagePullPolicy: corev1.PullPolicy(imagePullPolicy),
 							Ports: []corev1.ContainerPort{
 								corev1.ContainerPort{

--- a/pkg/network/kubemacpool.go
+++ b/pkg/network/kubemacpool.go
@@ -104,6 +104,7 @@ func renderKubeMacPool(conf *cnao.NetworkAddonsConfigSpec, manifestDir string) (
 	data := render.MakeRenderData()
 	data.Data["Namespace"] = os.Getenv("OPERAND_NAMESPACE")
 	data.Data["KubeMacPoolImage"] = os.Getenv("KUBEMACPOOL_IMAGE")
+	data.Data["KubeRbacProxyImage"] = os.Getenv("KUBE_RBAC_PROXY_IMAGE")
 	data.Data["ImagePullPolicy"] = conf.ImagePullPolicy
 	data.Data["RangeStart"] = conf.KubeMacPool.RangeStart
 	data.Data["RangeEnd"] = conf.KubeMacPool.RangeEnd

--- a/test/check/check.go
+++ b/test/check/check.go
@@ -708,7 +708,14 @@ func getMonitoringEndpoint() (*corev1.Endpoints, error) {
 }
 
 func ScrapeEndpointAddress(epAddress *corev1.EndpointAddress, epPort int32) (string, error) {
-	stdout, _, err := Kubectl("exec", "-n", epAddress.TargetRef.Namespace, epAddress.TargetRef.Name, "--", "curl", "-L", "-s", "-k", fmt.Sprintf("http://%s:%d/metrics", epAddress.IP, epPort))
+	token, err := getPrometheusToken()
+	if err != nil {
+		return "", err
+	}
+
+	bearer := "Authorization: Bearer " + token
+	stdout, _, err := Kubectl("exec", "-n", epAddress.TargetRef.Namespace, epAddress.TargetRef.Name, "--", "curl", "-s", "-k",
+		"--header", bearer, fmt.Sprintf("https://%s:%d/metrics", epAddress.IP, epPort))
 	if err != nil {
 		return "", err
 	}
@@ -894,4 +901,20 @@ func CheckNoWarningEvents(gvk schema.GroupVersionKind, rv string) {
 	stopChan := make(chan struct{})
 	defer close(stopChan)
 	objectEventWatcher.WaitNotForType(stopChan, WarningEvent)
+}
+
+func getPrometheusToken() (string, error) {
+	const (
+		monitoringNamespace = "monitoring"
+		prometheusPod       = "prometheus-k8s-0"
+		container           = "prometheus"
+		tokenPath           = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+	)
+
+	stdout, stderr, err := Kubectl("exec", "-n", monitoringNamespace, prometheusPod, "-c", container, "--", "cat", tokenPath)
+	if err != nil {
+		return "", fmt.Errorf("failed getting prometheus token: %w\nstderr: %s", err, stderr)
+	}
+
+	return stdout, nil
 }

--- a/test/check/check.go
+++ b/test/check/check.go
@@ -55,7 +55,7 @@ func CheckComponentsDeployment(components []Component) {
 
 func CheckCrdExplainable() {
 	By("Checking crd is explainable")
-	explain, err := Kubectl("explain", "networkaddonsconfigs")
+	explain, _, err := Kubectl("explain", "networkaddonsconfigs")
 	Expect(err).NotTo(HaveOccurred(), "explain should not return error")
 
 	Expect(explain).ToNot(BeEmpty(), "explain output should not be empty")
@@ -708,7 +708,7 @@ func getMonitoringEndpoint() (*corev1.Endpoints, error) {
 }
 
 func ScrapeEndpointAddress(epAddress *corev1.EndpointAddress, epPort int32) (string, error) {
-	stdout, err := Kubectl("exec", "-n", epAddress.TargetRef.Namespace, epAddress.TargetRef.Name, "--", "curl", "-L", "-s", "-k", fmt.Sprintf("http://%s:%d/metrics", epAddress.IP, epPort))
+	stdout, _, err := Kubectl("exec", "-n", epAddress.TargetRef.Namespace, epAddress.TargetRef.Name, "--", "curl", "-L", "-s", "-k", fmt.Sprintf("http://%s:%d/metrics", epAddress.IP, epPort))
 	if err != nil {
 		return "", err
 	}
@@ -781,13 +781,13 @@ func gatherClusterInfo() string {
 }
 
 func cnaoPodsStatus() string {
-	podsStatus, err := Kubectl("-n", components.Namespace, "get", "pods")
-	return fmt.Sprintf("CNAO pods Status:\n%v\nerror:\n%v", podsStatus, err)
+	podsStatus, stderr, err := Kubectl("-n", components.Namespace, "get", "pods")
+	return fmt.Sprintf("CNAO pods Status:\n%v\nerror:\n%v", podsStatus+stderr, err)
 }
 
 func describeAll() string {
-	description, err := Kubectl("-n", components.Namespace, "describe", "all")
-	return fmt.Sprintf("describe all CNAO components:\n%v\nerror:\n%v", description, err)
+	description, stderr, err := Kubectl("-n", components.Namespace, "describe", "all")
+	return fmt.Sprintf("describe all CNAO components:\n%v\nerror:\n%v", description+stderr, err)
 }
 
 func isNotSupportedKind(err error) bool {

--- a/test/e2e/workflow/deployment_test.go
+++ b/test/e2e/workflow/deployment_test.go
@@ -509,8 +509,8 @@ func installNMStateOperator() {
 	componentSource, err := GetComponentSource("nmstate")
 	Expect(err).ToNot(HaveOccurred(), "Error getting the component source")
 
-	result, err := kubectl.Kubectl("apply", "-f", fmt.Sprintf("https://raw.githubusercontent.com/nmstate/kubernetes-nmstate/%s/deploy/crds/nmstate.io_nmstates.yaml", componentSource.Metadata))
-	Expect(err).ToNot(HaveOccurred(), "Error applying CRD: %s", result)
+	result, stderr, err := kubectl.Kubectl("apply", "-f", fmt.Sprintf("https://raw.githubusercontent.com/nmstate/kubernetes-nmstate/%s/deploy/crds/nmstate.io_nmstates.yaml", componentSource.Metadata))
+	Expect(err).ToNot(HaveOccurred(), "Error applying CRD: %s", result+stderr)
 
 	// Create temp directory
 	tmpdir, err := ioutil.TempDir("", "operator-test")
@@ -522,8 +522,8 @@ func installNMStateOperator() {
 
 		yamlFile := filepath.Join(tmpdir, fmt.Sprintf("%s.yaml", manifest))
 		ioutil.WriteFile(yamlFile, []byte(yamlString), 0666)
-		result, err = kubectl.Kubectl("apply", "-f", yamlFile)
-		Expect(err).ToNot(HaveOccurred(), fmt.Sprintf("Error when running kubectl: %s", result))
+		result, stderr, err = kubectl.Kubectl("apply", "-f", yamlFile)
+		Expect(err).ToNot(HaveOccurred(), fmt.Sprintf("Error when running kubectl: %s", result+stderr))
 	}
 }
 
@@ -542,11 +542,11 @@ func uninstallNMStateOperator() {
 
 		yamlFile := filepath.Join(tmpdir, fmt.Sprintf("%s.yaml", manifest))
 		ioutil.WriteFile(yamlFile, []byte(yamlString), 0666)
-		result, err := kubectl.Kubectl("delete", "-f", yamlFile)
-		Expect(err).ToNot(HaveOccurred(), fmt.Sprintf("Error when running kubectl: %s", result))
+		result, stderr, err := kubectl.Kubectl("delete", "-f", yamlFile)
+		Expect(err).ToNot(HaveOccurred(), fmt.Sprintf("Error when running kubectl: %s", result+stderr))
 	}
-	result, err := kubectl.Kubectl("delete", "-f", fmt.Sprintf("https://raw.githubusercontent.com/nmstate/kubernetes-nmstate/%s/deploy/crds/nmstate.io_nmstates.yaml", componentSource.Metadata))
-	Expect(err).ToNot(HaveOccurred(), "Error deleting CRD: %s", result)
+	result, stderr, err := kubectl.Kubectl("delete", "-f", fmt.Sprintf("https://raw.githubusercontent.com/nmstate/kubernetes-nmstate/%s/deploy/crds/nmstate.io_nmstates.yaml", componentSource.Metadata))
+	Expect(err).ToNot(HaveOccurred(), "Error deleting CRD: %s", result+stderr)
 }
 
 func parseManifest(url string, tag string) (string, error) {

--- a/test/kubectl/kubectl.go
+++ b/test/kubectl/kubectl.go
@@ -6,11 +6,11 @@ import (
 	"os/exec"
 )
 
-func Kubectl(command ...string) (string, error) {
+func Kubectl(command ...string) (string, string, error) {
 	var stdout, stderr bytes.Buffer
 	cmd := exec.Command(os.Getenv("KUBECTL"), command...)
 	cmd.Stderr = &stderr
 	cmd.Stdout = &stdout
 	err := cmd.Run()
-	return stdout.String() + stderr.String(), err
+	return stdout.String(), stderr.String(), err
 }

--- a/test/releases/99.0.0.go
+++ b/test/releases/99.0.0.go
@@ -2,6 +2,7 @@ package releases
 
 import (
 	cnao "github.com/kubevirt/cluster-network-addons-operator/pkg/apis/networkaddonsoperator/shared"
+	"github.com/kubevirt/cluster-network-addons-operator/pkg/components"
 )
 
 func init() {
@@ -36,7 +37,7 @@ func init() {
 				ParentName: "kubemacpool-mac-controller-manager",
 				ParentKind: "Deployment",
 				Name:       "kube-rbac-proxy",
-				Image:      "quay.io/openshift/origin-kube-rbac-proxy:4.10.0",
+				Image:      components.KubeRbacProxyImageDefault,
 			},
 			{
 				ParentName: "kubemacpool-cert-manager",

--- a/test/releases/releases.go
+++ b/test/releases/releases.go
@@ -99,8 +99,8 @@ func LatestRelease() Release {
 func InstallRelease(release Release) {
 	By(fmt.Sprintf("Installing release %s", release.Version))
 	for _, manifestName := range release.Manifests {
-		out, err := Kubectl("apply", "-f", "_out/cluster-network-addons/"+release.Version+"/"+manifestName)
-		Expect(err).NotTo(HaveOccurred(), out)
+		out, stderr, err := Kubectl("apply", "-f", "_out/cluster-network-addons/"+release.Version+"/"+manifestName)
+		Expect(err).NotTo(HaveOccurred(), out+stderr)
 	}
 }
 
@@ -108,13 +108,13 @@ func InstallRelease(release Release) {
 func UninstallRelease(release Release) {
 	By(fmt.Sprintf("Uninstalling release %s", release.Version))
 	for _, manifestName := range release.Manifests {
-		out, err := Kubectl("delete", "--ignore-not-found", "-f", "_out/cluster-network-addons/"+release.Version+"/"+manifestName)
-		Expect(err).NotTo(HaveOccurred(), out)
+		out, stderr, err := Kubectl("delete", "--ignore-not-found", "-f", "_out/cluster-network-addons/"+release.Version+"/"+manifestName)
+		Expect(err).NotTo(HaveOccurred(), out+stderr)
 	}
 
 	for _, crdInstance := range release.CrdCleanUp {
-		out, err := Kubectl("delete", "crd", "--ignore-not-found", crdInstance)
-		Expect(err).NotTo(HaveOccurred(), out)
+		out, stderr, err := Kubectl("delete", "crd", "--ignore-not-found", crdInstance)
+		Expect(err).NotTo(HaveOccurred(), out+stderr)
 	}
 
 }
@@ -123,16 +123,16 @@ func UninstallRelease(release Release) {
 func InstallOperator(release Release) {
 	manifestName := "operator.yaml"
 	By(fmt.Sprintf("Installing operator %s", release.Version))
-	out, err := Kubectl("apply", "-f", "_out/cluster-network-addons/"+release.Version+"/"+manifestName)
-	Expect(err).NotTo(HaveOccurred(), out)
+	out, stderr, err := Kubectl("apply", "-f", "_out/cluster-network-addons/"+release.Version+"/"+manifestName)
+	Expect(err).NotTo(HaveOccurred(), out+stderr)
 }
 
 // Removes given release from cluster
 func UninstallOperator(release Release) {
 	manifestName := "operator.yaml"
 	By(fmt.Sprintf("Uninstalling operator %s", release.Version))
-	out, err := Kubectl("delete", "--ignore-not-found", "-f", "_out/cluster-network-addons/"+release.Version+"/"+manifestName)
-	Expect(err).NotTo(HaveOccurred(), out)
+	out, stderr, err := Kubectl("delete", "--ignore-not-found", "-f", "_out/cluster-network-addons/"+release.Version+"/"+manifestName)
+	Expect(err).NotTo(HaveOccurred(), out+stderr)
 }
 
 // Make sure that container images currently used (reported in NetworkAddonsConfig)

--- a/tools/manifest-templator/manifest-templator.go
+++ b/tools/manifest-templator/manifest-templator.go
@@ -248,6 +248,7 @@ func main() {
 	ovsCniImage := flag.String("ovs-cni-image", components.OvsCniImageDefault, "The ovs cni image managed by CNA")
 	ovsMarkerImage := flag.String("ovs-marker-image", components.OvsMarkerImageDefault, "The ovs marker image managed by CNA")
 	macvtapCniImage := flag.String("macvtap-cni-image", components.MacvtapCniImageDefault, "The macvtap cni image managed by CNA")
+	kubeRbacProxyImage := flag.String("kube-rbac-proxy-image", components.KubeRbacProxyImageDefault, "The kube rbac proxy used by CNA")
 	dumpOperatorCRD := flag.Bool("dump-crds", false, "Append operator CRD to bottom of template. Used for csv-generator")
 	inputFile := flag.String("input-file", "", "Not used for csv-generator")
 	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
@@ -272,6 +273,7 @@ func main() {
 			OvsCni:            *ovsCniImage,
 			OvsMarker:         *ovsMarkerImage,
 			MacvtapCni:        *macvtapCniImage,
+			KubeRbacProxy:     *kubeRbacProxyImage,
 		}).FillDefaults(),
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
CNAO uses controller runtime which creates an http
end point for /metrics.
In order to support https, we deploy rbac-proxy container
in the same pod of CNAO.
The new container exposes https end point,
and connects internally to the http end point.
    
It is self signed, and protected with rbac rules.

The reporter was updated to report all containers for each pod.
CSV generator was updated to include a new variable
`kube-rbac-proxy-image`, in order to be able to provide the required
kube-rbac-proxy image when using CSV.

**Special notes for your reviewer**:
Depends on https://github.com/k8snetworkplumbingwg/kubemacpool/pull/353
KMP bump
https://github.com/kubevirt/cluster-network-addons-operator/pull/1236

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=2029349

**Release note**:

```release-note
None
```
