### PR TITLE
labels: Do not label operator namespace with unneeded labels

### DIFF
--- a/pkg/names/names.go
+++ b/pkg/names/names.go
@@ -23,3 +23,5 @@ const VERSION_LABEL_KEY = "app.kubernetes.io/version"
 const MANAGED_BY_LABEL_KEY = "app.kubernetes.io/managed-by"
 const COMPONENT_LABEL_DEFAULT_VALUE = "network"
 const MANAGED_BY_LABEL_DEFAULT_VALUE = "cnao-operator"
+
+const KUBEMACPOOL_CONTROL_PLANE_KEY = "control-plane"

--- a/pkg/util/k8s/labels.go
+++ b/pkg/util/k8s/labels.go
@@ -3,6 +3,9 @@ package k8s
 import (
 	"log"
 	"regexp"
+
+	cnaov1 "github.com/kubevirt/cluster-network-addons-operator/pkg/apis/networkaddonsoperator/v1"
+	"github.com/kubevirt/cluster-network-addons-operator/pkg/names"
 )
 
 var labelAntiSelector *regexp.Regexp
@@ -28,4 +31,24 @@ func StringToLabel(s string) string {
 	}
 
 	return s
+}
+
+// RelationLabels returns the list of the relationship labels
+func RelationLabels() []string {
+	return []string{
+		names.COMPONENT_LABEL_KEY,
+		names.PART_OF_LABEL_KEY,
+		names.VERSION_LABEL_KEY,
+		names.MANAGED_BY_LABEL_KEY,
+	}
+}
+
+// RemovedLabels returns the list of the labels we remove for backward compatibility
+func RemovedLabels() []string {
+	labels := RelationLabels()
+	labels = append(labels, []string{
+		names.PROMETHEUS_LABEL_KEY,
+		names.KUBEMACPOOL_CONTROL_PLANE_KEY,
+		cnaov1.SchemeGroupVersion.Group + "/version"}...)
+	return labels
 }

--- a/test/e2e/lifecycle/upgrade_test.go
+++ b/test/e2e/lifecycle/upgrade_test.go
@@ -54,6 +54,7 @@ var _ = Context("Cluster Network Addons Operator", func() {
 
 					By("Checking for leftover objects from the previous version")
 					CheckForLeftoverObjects(newRelease.Version)
+					CheckForLeftoverLabels()
 				})
 			})
 


### PR DESCRIPTION
**What this PR does / why we need it**:

CNAO labels the components it deploys with miscellaneous labels, for example relationship labels.
In case the component is in the same namespace as the CNA operator itself,
it will be labeled as well.

Since K8s logs are labeled with `kubernetes.namespace_name` according
the labels the namespace has, all the cnv logs in the namespace
would appear as their `kubernetes.io/component` equal the value CNAO sets.
Same for the other labels that CNAO adds to the namespace.

Therefore:

Do not add labels to the namespace of the operator itself.

In order to guarantee backward compatibility, CNAO will also remove
those labels from the operator namespace according to their key.
It is safe to do that, because those labels should not be added by anyone,
else the problem will reoccur.

Affected labels:

Relationship labels:
* `app.kubernetes.io/component`
* `app.kubernetes.io/part-of`
* `app.kubernetes.io/version`
* `app.kubernetes.io/managed-by`

Other labels:
* `prometheus.cnao.io`
* `networkaddonsoperator.network.kubevirt.io/version`
* `control-plane` (added because it exists on kubemacpool namespace)

Note:
Once there will be no more supported versions that added those labels to the namespace
it will be safe to remove `cleanUpNamespaceRelationLables`.

Fixes
https://bugzilla.redhat.com/show_bug.cgi?id=2033385

**Special notes for your reviewer**:
Fixed typo (crLables -> crLabels)

**Release note**:
```release-note
None
```
