### PR TITLE
placement: Set linux as default OS

### DIFF
--- a/pkg/network/placement_configuration.go
+++ b/pkg/network/placement_configuration.go
@@ -53,6 +53,7 @@ func GetDefaultPlacementConfiguration() cnao.PlacementConfiguration {
 		Workloads: &cnao.Placement{
 			NodeSelector: map[string]string{
 				"beta.kubernetes.io/arch": "amd64",
+				"kubernetes.io/os":        "linux",
 			},
 			Tolerations: []corev1.Toleration{
 				corev1.Toleration{


### PR DESCRIPTION
**What this PR does / why we need it**:
All the components at CNAO should deploy at linux node is not specified
differently. This change add the node selector that specify that at the
default placement.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
Set default placement to os/linux nodes.
```
