### PR TITLE
bumper: Use kubevirt-bot token

### DIFF
--- a/.github/workflows/component-bumper-main.yml
+++ b/.github/workflows/component-bumper-main.yml
@@ -27,4 +27,4 @@ jobs:
       run:  git pull --ff-only --rebase origin ${{ env.BASE_BRANCH }}
 
     - name: Run bumper script
-      run: make ARGS="-config-path=components.yaml -token=${{ secrets.GITHUB_TOKEN }} -base-branch=${{ env.BASE_BRANCH }}" auto-bumper
+      run: make ARGS="-config-path=components.yaml -token=${{ secrets.KUBEVIRT_BOT_TOKEN }} -base-branch=${{ env.BASE_BRANCH }}" auto-bumper

--- a/.github/workflows/component-bumper-release-0.42.yml
+++ b/.github/workflows/component-bumper-release-0.42.yml
@@ -27,4 +27,4 @@ jobs:
       run:  git pull --ff-only --rebase origin ${{ env.BASE_BRANCH }}
 
     - name: Run bumper script
-      run: make ARGS="-config-path=components.yaml -token=${{ secrets.GITHUB_TOKEN }} -base-branch=${{ env.BASE_BRANCH }}" auto-bumper
+      run: make ARGS="-config-path=components.yaml -token=${{ secrets.KUBEVIRT_BOT_TOKEN }} -base-branch=${{ env.BASE_BRANCH }}" auto-bumper

--- a/.github/workflows/component-bumper-release-0.44.yml
+++ b/.github/workflows/component-bumper-release-0.44.yml
@@ -27,4 +27,4 @@ jobs:
       run:  git pull --ff-only --rebase origin ${{ env.BASE_BRANCH }}
 
     - name: Run bumper script
-      run: make ARGS="-config-path=components.yaml -token=${{ secrets.GITHUB_TOKEN }} -base-branch=${{ env.BASE_BRANCH }}" auto-bumper
+      run: make ARGS="-config-path=components.yaml -token=${{ secrets.KUBEVIRT_BOT_TOKEN }} -base-branch=${{ env.BASE_BRANCH }}" auto-bumper

--- a/.github/workflows/component-bumper-release-0.53.yml
+++ b/.github/workflows/component-bumper-release-0.53.yml
@@ -27,4 +27,4 @@ jobs:
       run:  git pull --ff-only --rebase origin ${{ env.BASE_BRANCH }}
 
     - name: Run bumper script
-      run: make ARGS="-config-path=components.yaml -token=${{ secrets.GITHUB_TOKEN }} -base-branch=${{ env.BASE_BRANCH }}" auto-bumper
+      run: make ARGS="-config-path=components.yaml -token=${{ secrets.KUBEVIRT_BOT_TOKEN }} -base-branch=${{ env.BASE_BRANCH }}" auto-bumper

--- a/.github/workflows/component-bumper-release-0.58.yml
+++ b/.github/workflows/component-bumper-release-0.58.yml
@@ -27,4 +27,4 @@ jobs:
       run:  git pull --ff-only --rebase origin ${{ env.BASE_BRANCH }}
 
     - name: Run bumper script
-      run: make ARGS="-config-path=components.yaml -token=${{ secrets.GITHUB_TOKEN }} -base-branch=${{ env.BASE_BRANCH }}" auto-bumper
+      run: make ARGS="-config-path=components.yaml -token=${{ secrets.KUBEVIRT_BOT_TOKEN }} -base-branch=${{ env.BASE_BRANCH }}" auto-bumper


### PR DESCRIPTION
**What this PR does / why we need it**:
The autobumper create PRs when one of the subcomponents release a new
version but it's using github-tokens this force to put comment
/ok-to-test on those PRs to check CI. This change use a new token that
will directly run CI on those PRs.

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
