### PR TITLE
[release-0.58] cluster: Enable just ovs repo (#1163)

### DIFF
--- a/cluster/up.sh
+++ b/cluster/up.sh
@@ -35,10 +35,11 @@ fi
 if [[ "$KUBEVIRT_PROVIDER" =~ k8s- ]]; then
     echo 'Installing Open vSwitch on nodes'
     for node in $(./cluster/kubectl.sh get nodes --no-headers | awk '{print $1}'); do
-        ./cluster/cli.sh ssh ${node} -- sudo yum config-manager --set-enabled powertools
-        ./cluster/cli.sh ssh ${node} -- sudo yum install -y epel-release centos-release-openstack-wallaby epel-release centos-release-openstack-train https://rdoproject.org/repos/rdo-release.rpm
-        ./cluster/cli.sh ssh ${node} -- sudo yum install -y openvswitch libibverbs
+        ./cluster/cli.sh ssh ${node} -- sudo dnf install -y centos-release-nfv-openvswitch
+        ./cluster/cli.sh ssh ${node} -- sudo dnf install -y openvswitch2.16 libibverbs NetworkManager-1.34.0 NetworkManager-ovs-1.34.0
+        ./cluster/cli.sh ssh ${node} -- sudo systemctl daemon-reload
         ./cluster/cli.sh ssh ${node} -- sudo systemctl enable --now openvswitch
         ./cluster/cli.sh ssh ${node} -- sudo systemctl restart openvswitch
+        ./cluster/cli.sh ssh ${node} -- sudo systemctl restart NetworkManager
     done
 fi


### PR DESCRIPTION
**What this PR does / why we need it**:
Some openstack repos does not support centos 8 stream yet. This change
point directly to the centos 8 stream ovs repo.



**Special notes for your reviewer**:
(cherry picked from commit 152a52e78f453e766e42fb590207ec4eb90cb3fe)

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
