### PR TITLE
nmstate: Check operator pods not deployment

### DIFF
--- a/pkg/controller/networkaddonsconfig/networkaddonsconfig_controller.go
+++ b/pkg/controller/networkaddonsconfig/networkaddonsconfig_controller.go
@@ -640,18 +640,15 @@ func IsMonitoringAvailable(c kubernetes.Interface) (bool, error) {
 }
 
 func isRunningKubernetesNMStateOperator(c k8sclient.Client) (bool, error) {
-	deployments := &appsv1.DeploymentList{}
-	err := c.List(context.TODO(), deployments, k8sclient.MatchingLabels{"app": "kubernetes-nmstate-operator"})
+	pods := &v1.PodList{}
+	err := c.List(context.TODO(), pods, k8sclient.MatchingLabels{"app": "kubernetes-nmstate-operator"})
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			return false, nil
 		}
 		return false, err
 	}
-	if len(deployments.Items) == 0 {
-		return false, nil
-	}
-	return true, nil
+	return len(pods.Items) != 0, nil
 }
 
 func isResourceAvailable(kubeClient kubernetes.Interface, name string, group string, version string) (bool, error) {


### PR DESCRIPTION

/kind bug

**What this PR does / why we need it**:
When installing knmstate CNAO try to find kubernetes-nmstate-operator on
the system and if it's there it will do the installation with it, to do
the search it filter the deployment by the "app" label, but this label
is not at deployment but at the pods. This change search for pods
instead of deployment to find if the NMState operator is installed.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
Check nmstate-operator looking for its pods.
```
