### PR TITLE
bumper: Don't cancel jobs if one fail

### DIFF
--- a/.github/workflows/component-bumper.yaml
+++ b/.github/workflows/component-bumper.yaml
@@ -10,6 +10,7 @@ jobs:
     if: (github.repository == 'kubevirt/cluster-network-addons-operator')
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         branch:
           - main


### PR DESCRIPTION
**What this PR does / why we need it**:
At github actions matrix by default it fail fast, if one of the job
fails the rest of job is cancel, this does not make sense for auto
bumper.
At github actions matrix by default it fail fast, if one of the job
fails the rest of job is cancel, this does not make sense for auto
bumper.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
