### PR TITLE
actions: Prepare versioon from github

### DIFF
--- a/.github/workflows/prepare-version.yaml
+++ b/.github/workflows/prepare-version.yaml
@@ -1,0 +1,40 @@
+name: Create Version PR
+
+on:
+  workflow_dispatch:
+     inputs:
+      versionLevel:
+        description: 'The semVer level of the version'
+        required: true
+        default: 'minor'
+        type: choice
+        options:
+        - major
+        - minor
+        - patch
+      baseBranch:
+        description: 'Test CNAO branch to release from'
+        required: true
+        type: choice
+        default: 'main'
+        options:
+        - main
+        - release-0.65
+        - release-0.58
+        - release-0.53
+
+jobs:
+  prepare-release:
+    runs-on: ubuntu-latest
+    steps:
+    
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v2
+      with:
+        ref: ${{ github.event.inputs.baseBranch }}
+    
+    - name: Pull latest of latest branch
+      run:  git pull --ff-only --rebase origin ${{ github.event.inputs.baseBranch }}
+    
+    - name: Run make to prepare the PR
+      run: make prepare-{{ github.event.inputs.versionLevel }}


### PR DESCRIPTION
With the new workflow_dispatch event from github is possible to put some
UI at gihub to run actions. This changes add a pair of fields to call
`make prepare-{major, minor, patch}` from github.

Signed-off-by: Quique Llorente <ellorent@redhat.com>



```release-note
NONE
```
