### PR TITLE
infra: Use PRs to compose release notes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -177,8 +177,10 @@ prepare-minor:
 prepare-major:
 	./hack/prepare-release.sh major
 
+release-notes:
+	hack/render-release-notes.sh $(WHAT)
+
 release: $(GITHUB_RELEASE)
-	DESCRIPTION=version/description \
 	GITHUB_RELEASE=$(GITHUB_RELEASE) \
 	TAG=v$(shell hack/version.sh) \
 	  hack/release.sh \
@@ -198,6 +200,7 @@ bump-all: bump-nmstate bump-kubemacpool bump-macvtap-cni bump-linux-bridge bump-
 
 generate-doc:
 	go run ./tools/metricsdocs > docs/metrics.md
+
 
 .PHONY: \
 	$(E2E_SUITES) \

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,51 @@
+# Release process
+
+The release process for CNAO consist of a pair of manual steps:
+1. Create release PR with github action [Create Version PR](https://github.com/kubevirt/cluster-network-addons-operator/actions/workflows/prepare-version.yaml),
+   it has a pair of fields: versionLevel and baseBranch.
+   versionLevel is the semVer version part to bump to and
+   baseBranch is the branch to release from.
+   To run it:
+   - From the gh UI passing the `versionLevel` or `baseBranch`
+   - With the gh cli like `gh workflow run prepare-version.yaml -s versionLevel=... -s baseBranch=...`
+2. Merge the version PR when continous integration is fine.
+
+After the version PR is merged a prow job will [release-cluster-network-addons-operator](https://github.com/kubevirt/project-infra/blob/main/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-postsubmits.yaml#L2-L28) call the `make release` target that to do the following:
+
+1. Tag the code the version from the version PR.
+2. Generate release notes from the PRs release-notes field at description
+   and the [template](hack/release-notes.tmpl)
+3. Push containers to quay.io.
+4. Create a new github release and upload the artifacts.
+
+
+## Release notes handling
+
+The release notes are generated using the kubernetes [release-notes](https://github.com/kubernetes/release/blob/master/cmd/release-notes/README.md).
+The tool scan all the PRs between the version to release and the previous one
+and look for the following block on the PR description:
+
+````
+```release-note
+Set default placement to os/linux nodes.
+```
+````
+
+To categorize the change use the prow command [/kind](https://prow.k8s.io/command-help) with the
+category you want `/kind bug`, `/kind enhancement`, etc... the kinds understood
+by the tool are listed [here](https://github.com/kubernetes/release/blob/master/pkg/notes/notes.go#L67-L78).
+
+Sometime is needed to add some notes related actions to be done before or after
+an upgrade for that adding the "action requiered" string inside the
+`relase-note` block will add that line to the Urgent Upgrade Notes section on
+the release, like in the example
+
+````
+```release-note
+Set default placement to os/linux nodes.
+[action required]: Be sure that the nodes are linux
+```
+````
+
+
+More information at [k8s release notes workflow](https://github.com/kubernetes/release/blob/d41c86508aac7f0b6d5f701fb2f6d3ae29bf35e0/docs/release-notes.md#kubernetes-release-notes-workflow).

--- a/hack/prepare-release.sh
+++ b/hack/prepare-release.sh
@@ -24,11 +24,3 @@ sed -i "s/Version: \"99.0.0\",/Version: \"${released_version}\",/" test/releases
 
 echo 'Bump versions in Makefile'
 sed -i "s/VERSION_REPLACES ?= .*/VERSION_REPLACES ?= ${released_version}/" Makefile
-
-echo 'Prepare release notes'
-cat << EOF > version/description
-$released_version
-
-$commits
-
-EOF

--- a/hack/release-notes.tmpl
+++ b/hack/release-notes.tmpl
@@ -1,0 +1,39 @@
+{{with .NotesWithActionRequired -}}
+# Urgent Upgrade Notes
+
+{{range .}} {{println "-" .}} {{end}}
+{{end}}
+
+{{- with .Notes -}}
+# Changes
+{{ range .}}
+## {{.Kind | prettyKind}}
+{{range $note := .NoteEntries}}
+ - {{$note}}
+{{- end}}
+{{end}}
+{{- end}}
+
+# Installation
+
+First install the operator itself:
+
+```bash
+kubectl apply -f https://github.com/kubevirt/cluster-network-addons-operator/releases/download/{{ .CurrentRevision }}/namespace.yaml
+kubectl apply -f https://github.com/kubevirt/cluster-network-addons-operator/releases/download/{{ .CurrentRevision }}/network-addons-config.crd.yaml
+kubectl apply -f https://github.com/kubevirt/cluster-network-addons-operator/releases/download/{{ .CurrentRevision }}/operator.yaml
+```
+
+Then you need to create a configuration for the operator example CR:
+
+```bash
+kubectl apply -f https://github.com/kubevirt/cluster-network-addons-operator/releases/download/{{ .CurrentRevision }}/network-addons-config-example.cr.yaml
+```
+
+Finally you can wait for the operator to finish deployment:
+
+```bash
+kubectl wait networkaddonsconfig cluster --for condition=Available
+```
+
+{{- /* This removes any extra line at the end. */ -}}

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -8,7 +8,7 @@ git push https://github.com/kubevirt/cluster-network-addons-operator $TAG
 $GITHUB_RELEASE release -u kubevirt -r cluster-network-addons-operator \
     --tag $TAG \
     --name $TAG \
-    --description "$(cat $DESCRIPTION)"
+    --description "$(./hack/render-release-notes.sh $(./hack/versions.sh -2) $TAG)"
 
 for resource in "$@" ;do
     $GITHUB_RELEASE upload -u kubevirt -r cluster-network-addons-operator \

--- a/hack/render-release-notes.sh
+++ b/hack/render-release-notes.sh
@@ -1,0 +1,27 @@
+#!/bin/bash -e
+script_dir=$(dirname "$(readlink -f "$0")")
+
+old_version=$1
+new_version=$2
+release_notes=$(mktemp)
+
+end() {
+    rm $release_notes
+}
+
+trap end EXIT SIGINT SIGTERM SIGSTOP
+
+GOFLAGS=-mod=readonly go install k8s.io/release/cmd/release-notes@latest
+release-notes \
+    --list-v2 \
+    --go-template go-template:$script_dir/release-notes.tmpl \
+    --required-author "" \
+    --org kubevirt \
+    --dependencies=false \
+    --repo cluster-network-addons-operator \
+    --start-rev $old_version \
+    --end-rev $new_version \
+    --debug true \
+    --output $release_notes > release-notes.log 2>&1
+
+cat $release_notes

--- a/hack/versions.sh
+++ b/hack/versions.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+set -e
+
+git fetch https://github.com/kubevirt/cluster-network-addons-operator --tags > /dev/null 2>&1|| true
+current_branch=$(git rev-parse --abbrev-ref HEAD)
+versions=($(git tag --sort version:refname --merged $current_branch |grep "^v[0-9]*\.[0-9]*\.[0-9]*$"))
+echo ${versions[$1]}

--- a/version/description
+++ b/version/description
@@ -1,5 +1,0 @@
-0.65.2
-
-* bump nmstate to v0.64.5 (#1134)
-* dockerfile: Use quay.io instead of docker.io (#1128)
-* Add default linux OS nodeSelector to nmstate handlers (#1124)


### PR DESCRIPTION
**What this PR does / why we need it**:
Right now the release notes comes from the commits, but the info needed
is the release-note mark from PRs since users decide if they want that
info to appear that the release notes or not.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
