### PR TITLE
autobumper: Increase to 100 the commits lookup

### DIFF
--- a/tools/bumper/component_commands.go
+++ b/tools/bumper/component_commands.go
@@ -202,7 +202,7 @@ func (componentOps *gitComponent) getLatestTaggedFromBranch(repo, owner, branch,
 		return "", "", errors.Wrap(err, "Failed to get release tag refs from github client API")
 	}
 
-	branchCommits, _, err := componentOps.githubInterface.listCommits(owner, repo, &github.CommitsListOptions{SHA: branch})
+	branchCommits, _, err := componentOps.githubInterface.listCommits(owner, repo, &github.CommitsListOptions{ListOptions: github.ListOptions{PerPage: 100}, SHA: branch})
 	if err != nil {
 		return "", "", errors.Wrap(err, "Failed to get release tag refs from github client API")
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
The last multus tag v3.8 was at commit 33 from HEAD, the autobumper uses
by default 30 commits so it were not found. This change increments it to
100.


**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
