### PR TITLE
multus: Fix quay.io SHA

### DIFF
--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -28,7 +28,7 @@ var (
 )
 
 const (
-	MultusImageDefault            = "quay.io/kubevirt/cluster-network-addon-multus@sha256:32867c73cda4d605651b898dc85fea67d93191c47f27e1ad9e9f2b9041c518de"
+	MultusImageDefault            = "quay.io/kubevirt/cluster-network-addon-multus@sha256:f7350c519d18b2f0fe3ec7acef556b7c42ccdb482ac929a13eb6e66615911da4"
 	LinuxBridgeCniImageDefault    = "quay.io/kubevirt/cni-default-plugins@sha256:5d9442c26f8750d44f97175f36dbd74bef503f782b9adefcfd08215d065c437a"
 	LinuxBridgeMarkerImageDefault = "quay.io/kubevirt/bridge-marker@sha256:9d90a5bd051d71429b6d9fc34112081fe64c6d3fb02221e18ebe72d428d58092"
 	KubeMacPoolImageDefault       = "quay.io/kubevirt/kubemacpool@sha256:0a17307e05176451491f9eb88a8e4be341959906e6565a62e62f4bf37b0dad42"

--- a/test/releases/99.0.0.go
+++ b/test/releases/99.0.0.go
@@ -12,7 +12,7 @@ func init() {
 				ParentName: "multus",
 				ParentKind: "DaemonSet",
 				Name:       "kube-multus",
-				Image:      "quay.io/kubevirt/cluster-network-addon-multus@sha256:32867c73cda4d605651b898dc85fea67d93191c47f27e1ad9e9f2b9041c518de",
+				Image:      "quay.io/kubevirt/cluster-network-addon-multus@sha256:f7350c519d18b2f0fe3ec7acef556b7c42ccdb482ac929a13eb6e66615911da4",
 			},
 			{
 				ParentName: "bridge-marker",


### PR DESCRIPTION
**What this PR does / why we need it**:
Looks like the quay.io tag for multus has being re-generated. This
changes put the SHA to the correct pointer.


**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
Fix multus quay.io SHA pin for v3.4.2
```
