### PR TITLE
multus: Bump to 3.8

### DIFF
--- a/automation/check-patch.e2e-multus-functests.sh
+++ b/automation/check-patch.e2e-multus-functests.sh
@@ -64,12 +64,6 @@ spec:
 EOF
 }
 
-function __remove-test-manifests() {
-    echo "Remove test manifests"
-    $KUBECTL delete -f ${TEST_YAML}
-    $KUBECTL delete -f ${CNI_PLUGIN_YAML}
-}
-
 main() {
     # Setup CNAO and artifacts temp directory
     source automation/check-patch.setup.sh
@@ -91,8 +85,6 @@ main() {
 
         echo "Run multus macvlan test"
         ./test-simple-macvlan1.sh
-
-        __remove-test-manifests
     )
 }
 

--- a/components.yaml
+++ b/components.yaml
@@ -25,10 +25,10 @@ components:
     metadata: v0.6.1
   multus:
     url: https://github.com/k8snetworkplumbingwg/multus-cni
-    commit: 4eac660359f223d34bcaf0fddbc42fd542f02ba1
+    commit: efdc0a5c7d1ea4bb236d638403420448b48782b3
     branch: master
     update-policy: tagged
-    metadata: v3.4.2
+    metadata: v3.8
   nmstate:
     url: https://github.com/nmstate/kubernetes-nmstate
     commit: 09067b48a7814f384b2c20fa7a62ada3f5cd3ccf

--- a/data/multus/001-multus.yaml
+++ b/data/multus/001-multus.yaml
@@ -23,6 +23,19 @@ spec:
             networks. More information available at: https://github.com/k8snetworkplumbingwg/multi-net-spec'
           type: object
           properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this represen
+                tation of an object. Servers should convert recognized schemas to the
+                latest internal value, and may reject unrecognized values. More info:
+                https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this
+                object represents. Servers may infer this from the endpoint the client
+                submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
             spec:
               description: 'NetworkAttachmentDefinition spec defines the desired state of a network attachment'
               type: object
@@ -101,7 +114,6 @@ spec:
         name: kube-multus-ds-amd64
     spec:
       hostNetwork: true
-      nodeSelector: {{ toYaml .Placement.NodeSelector | nindent 8 }}
       tolerations: {{ toYaml .Placement.Tolerations | nindent 8 }}
       serviceAccountName: multus
       containers:
@@ -123,6 +135,7 @@ spec:
             - name: cnibin
               mountPath: /host/opt/cni/bin
           imagePullPolicy: {{ .ImagePullPolicy }}
+      terminationGracePeriodSeconds: 10
       volumes:
         - name: cni
           hostPath:
@@ -131,6 +144,7 @@ spec:
           hostPath:
             path: {{ .CNIBinDir }}
       priorityClassName: system-cluster-critical
+      nodeSelector: {{ toYaml .Placement.NodeSelector | nindent 8 }}
       affinity: {{ toYaml .Placement.Affinity | nindent 8 }}
 {{ if .EnableSCC }}
 ---

--- a/data/multus/001-multus.yaml
+++ b/data/multus/001-multus.yaml
@@ -135,6 +135,10 @@ spec:
             - name: cnibin
               mountPath: /host/opt/cni/bin
           imagePullPolicy: {{ .ImagePullPolicy }}
+          lifecycle:
+            preStop:
+              exec:
+                command: ["/bin/sh", "-c", "rm -f /host/etc/cni/net.d/00-multus.conf"]
       terminationGracePeriodSeconds: 10
       volumes:
         - name: cni

--- a/hack/components/bump-multus.sh
+++ b/hack/components/bump-multus.sh
@@ -18,7 +18,7 @@ function __parametize_by_object() {
 				yaml-utils::update_param ${f} metadata.namespace '{{ .Namespace }}'
 				yaml-utils::remove_single_quotes_from_yaml ${f}
 				;;
-			./DaemonSet_kube-multus-ds-amd64.yaml)
+			./DaemonSet_kube-multus-ds.yaml)
 				yaml-utils::update_param ${f} metadata.name 'multus'
 				yaml-utils::update_param ${f} metadata.namespace '{{ .Namespace }}'
 				yaml-utils::update_param ${f} spec.selector.matchLabels.name 'kube-multus-ds-amd64'
@@ -33,7 +33,7 @@ function __parametize_by_object() {
 				yaml-utils::delete_param ${f} spec.template.spec.containers[0].resources.limits
 				yaml-utils::update_param ${f} spec.template.spec.containers[0].resources.requests.cpu '"10m"'
 				yaml-utils::update_param ${f} spec.template.spec.containers[0].resources.requests.memory '"15Mi"'
-				yaml-utils::update_param ${f} spec.template.spec.nodeSelector '{{ toYaml .Placement.NodeSelector | nindent 8 }}'
+				yaml-utils::set_param ${f} spec.template.spec.nodeSelector '{{ toYaml .Placement.NodeSelector | nindent 8 }}'
 				yaml-utils::set_param ${f} spec.template.spec.affinity '{{ toYaml .Placement.Affinity | nindent 8 }}'
 				yaml-utils::update_param ${f} spec.template.spec.tolerations '{{ toYaml .Placement.Tolerations | nindent 8 }}'
 				yaml-utils::remove_single_quotes_from_yaml ${f}
@@ -101,7 +101,7 @@ EOF
 		cat ClusterRole_multus.yaml >> ${YAML_FILE} &&
 		cat ClusterRoleBinding_multus.yaml >> ${YAML_FILE} &&
 		cat ServiceAccount_multus.yaml >> ${YAML_FILE} &&
-		cat DaemonSet_kube-multus-ds-amd64.yaml >> ${YAML_FILE} &&
+		cat DaemonSet_kube-multus-ds.yaml >> ${YAML_FILE} &&
 		cat SecurityContextConstraints_multus.yaml >> ${YAML_FILE}
 )
 
@@ -110,43 +110,15 @@ rm -rf data/multus/*
 cp ${MULTUS_PATH}/config/cnao/000-ns.yaml data/multus/
 cp ${MULTUS_PATH}/config/cnao/001-multus.yaml data/multus/
 
-echo 'Build multus image, push it to quay.io and update it under CNAO'
+echo 'Get multus image name'
 MULTUS_TAG=$(git-utils::get_component_tag ${MULTUS_PATH})
-MULTUS_IMAGE=quay.io/kubevirt/cluster-network-addon-multus
+MULTUS_IMAGE=ghcr.io/k8snetworkplumbingwg/multus-cni
 MULTUS_IMAGE_TAGGED=${MULTUS_IMAGE}:${MULTUS_TAG}
-(
-    cd ${MULTUS_PATH}
-    cat <<EOF > Dockerfile
-
-FROM openshift/origin-release:golang-1.15 as builder
-
-ADD . /usr/src/multus-cni
-
-WORKDIR /usr/src/multus-cni
-RUN ./build
-
-FROM registry.access.redhat.com/ubi8/ubi-minimal
-RUN mkdir -p /usr/src/multus-cni/images && mkdir -p /usr/src/multus-cni/bin
-COPY --from=builder /usr/src/multus-cni/bin/multus /usr/src/multus-cni/bin
-ADD ./images/entrypoint.sh /
-
-ENTRYPOINT ["/entrypoint.sh"]
-EOF
-    docker build -t ${MULTUS_IMAGE_TAGGED} .
-)
-
-if [ ! -z ${PUSH_IMAGES} ]; then
-    echo 'Push the image to KubeVirt repo'
-    docker push "${MULTUS_IMAGE_TAGGED}"
-fi
-
 if [[ -n "$(docker-utils::check_image_exists "${MULTUS_IMAGE}" "${MULTUS_TAG}")" ]]; then
     MULTUS_IMAGE_DIGEST="$(docker-utils::get_image_digest "${MULTUS_IMAGE_TAGGED}" "${MULTUS_IMAGE}")"
 else
     MULTUS_IMAGE_DIGEST=${MULTUS_IMAGE_TAGGED}
 fi
-
-
 
 echo 'Update multus references under CNAO'
 sed -i -r "s#\"${MULTUS_IMAGE}(@sha256)?:.*\"#\"${MULTUS_IMAGE_DIGEST}\"#" pkg/components/components.go

--- a/hack/components/bump-multus.sh
+++ b/hack/components/bump-multus.sh
@@ -34,6 +34,7 @@ function __parametize_by_object() {
 				yaml-utils::update_param ${f} spec.template.spec.containers[0].resources.requests.cpu '"10m"'
 				yaml-utils::update_param ${f} spec.template.spec.containers[0].resources.requests.memory '"15Mi"'
 				yaml-utils::set_param ${f} spec.template.spec.nodeSelector '{{ toYaml .Placement.NodeSelector | nindent 8 }}'
+				yaml-utils::set_param ${f} spec.template.spec.containers[0].lifecycle.preStop.exec.command '["/bin/sh", "-c", "rm -f /host/etc/cni/net.d/00-multus.conf"]'
 				yaml-utils::set_param ${f} spec.template.spec.affinity '{{ toYaml .Placement.Affinity | nindent 8 }}'
 				yaml-utils::update_param ${f} spec.template.spec.tolerations '{{ toYaml .Placement.Tolerations | nindent 8 }}'
 				yaml-utils::remove_single_quotes_from_yaml ${f}

--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -28,7 +28,7 @@ var (
 )
 
 const (
-	MultusImageDefault            = "quay.io/kubevirt/cluster-network-addon-multus@sha256:32867c73cda4d605651b898dc85fea67d93191c47f27e1ad9e9f2b9041c518de"
+	MultusImageDefault            = "ghcr.io/k8snetworkplumbingwg/multus-cni@sha256:9479537fe0827d23bc40056e98f8d1e75778ec294d89ae4d8a62f83dfc74a31d"
 	LinuxBridgeCniImageDefault    = "quay.io/kubevirt/cni-default-plugins@sha256:5d9442c26f8750d44f97175f36dbd74bef503f782b9adefcfd08215d065c437a"
 	LinuxBridgeMarkerImageDefault = "quay.io/kubevirt/bridge-marker@sha256:9d90a5bd051d71429b6d9fc34112081fe64c6d3fb02221e18ebe72d428d58092"
 	KubeMacPoolImageDefault       = "quay.io/kubevirt/kubemacpool@sha256:2d12855105b04d28e191dee3e36103fb3bb0d5c736fe2e2a7b3bca07b19f2bcd"

--- a/test/releases/99.0.0.go
+++ b/test/releases/99.0.0.go
@@ -12,7 +12,7 @@ func init() {
 				ParentName: "multus",
 				ParentKind: "DaemonSet",
 				Name:       "kube-multus",
-				Image:      "quay.io/kubevirt/cluster-network-addon-multus@sha256:32867c73cda4d605651b898dc85fea67d93191c47f27e1ad9e9f2b9041c518de",
+				Image:      "ghcr.io/k8snetworkplumbingwg/multus-cni@sha256:9479537fe0827d23bc40056e98f8d1e75778ec294d89ae4d8a62f83dfc74a31d",
 			},
 			{
 				ParentName: "bridge-marker",


### PR DESCRIPTION
**What this PR does / why we need it**:
Multus project has change a little:
- They don't have a manifests pert arch since they are using multiarch
  registry.
- They have bump golang to 1.17
- The CNI binary is not able to acess apiserver if daemonset is not there https://github.com/k8snetworkplumbingwg/multus-cni/issues/592.

**Special notes for your reviewer**:
This change moves away golang origin builder since there is non for
1.17

Closes #1230 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
Bump multus to v3.8
```
