### PR TITLE
Fix a typo in KubemacpoolDown runboook url

### DIFF
--- a/data/monitoring/prom-rule.yaml
+++ b/data/monitoring/prom-rule.yaml
@@ -50,7 +50,7 @@ spec:
         - alert: KubemacpoolDown
           annotations:
             summary: KubeMacpool is deployed by CNAO CR but KubeMacpool pod is down.
-            runbook_url: http://kubevirt.io/monitoring/runbooks/KubemacpoolDown
+            runbook_url: http://kubevirt.io/monitoring/runbooks/KubeMacPoolDown
           expr: kubevirt_cnao_cr_kubemacpool_deployed_total == 1 and kubevirt_cnao_kubemacpool_manager_num_up_pods_total == 0
           for: 5m
           labels:

--- a/hack/prom-rule-ci/prom-rules-tests.yaml
+++ b/hack/prom-rule-ci/prom-rules-tests.yaml
@@ -118,7 +118,7 @@ tests:
         exp_alerts:
           - exp_annotations:
               summary: "KubeMacpool is deployed by CNAO CR but KubeMacpool pod is down."
-              runbook_url: "http://kubevirt.io/monitoring/runbooks/KubemacpoolDown"
+              runbook_url: "http://kubevirt.io/monitoring/runbooks/KubeMacPoolDown"
             exp_labels:
               severity: "critical"
               kubernetes_operator_part_of: "kubevirt"


### PR DESCRIPTION
This PR fixes a typo in `KubemacpoolDown` alert runbook url.

Signed-off-by: assafad <aadmi@redhat.com>

```release-note
None
```
