### PR TITLE
tests, metrics: Fix potential flakes on metrics scraping test

### DIFF
--- a/test/check/check.go
+++ b/test/check/check.go
@@ -707,7 +707,7 @@ func getMonitoringEndpoint() (*corev1.Endpoints, error) {
 	return endpoint, nil
 }
 
-func scrapeEndpointAddress(epAddress corev1.EndpointAddress, epPort int32) (string, error) {
+func ScrapeEndpointAddress(epAddress *corev1.EndpointAddress, epPort int32) (string, error) {
 	stdout, err := Kubectl("exec", "-n", epAddress.TargetRef.Namespace, epAddress.TargetRef.Name, "--", "curl", "-L", "-s", "-k", fmt.Sprintf("http://%s:%d/metrics", epAddress.IP, epPort))
 	if err != nil {
 		return "", err
@@ -715,21 +715,22 @@ func scrapeEndpointAddress(epAddress corev1.EndpointAddress, epPort int32) (stri
 	return stdout, nil
 }
 
-func GetScrapedDataFromMonitoringEndpoint() (string, error) {
+func GetMonitoringEndpoint() (*corev1.EndpointAddress, int32, error) {
 	endpoint, err := getMonitoringEndpoint()
 	if err != nil {
-		return "", err
+		return nil, 0, err
 	}
 
-	By("scraping the metrics endpoint on CNAO pod")
 	epPort := endpoint.Subsets[0].Ports[0].Port
-	for _, epAddress := range endpoint.Subsets[0].Addresses {
-		if !strings.HasPrefix(epAddress.TargetRef.Name, components.Name) {
+	for _, epAddr := range endpoint.Subsets[0].Addresses {
+		if !strings.HasPrefix(epAddr.TargetRef.Name, components.Name) {
 			continue
 		}
-		return scrapeEndpointAddress(epAddress, epPort)
+		epAddress := epAddr
+		return &epAddress, epPort, nil
 	}
-	return "", errors.New("no endpoint target ref name matches CNAO component")
+
+	return nil, 0, errors.New("no endpoint target ref name matches CNAO component")
 }
 
 func FindMetric(metrics string, expectedMetric string) string {

--- a/test/e2e/workflow/deployment_test.go
+++ b/test/e2e/workflow/deployment_test.go
@@ -295,7 +295,12 @@ var _ = Describe("NetworkAddonsConfig", func() {
 
 				Eventually(func() error {
 					By("scraping the monitoring endpoint")
-					scrapedData, err := GetScrapedDataFromMonitoringEndpoint()
+					epAddress, epPort, err := GetMonitoringEndpoint()
+					if err != nil {
+						return err
+					}
+
+					scrapedData, err := ScrapeEndpointAddress(epAddress, epPort)
 					Expect(err).ToNot(HaveOccurred())
 
 					By("comparing the scraped Data to the expected metrics' values")


### PR DESCRIPTION
Since it might take few seconds for the end point to be ready,
we should not assert in the Eventually loop but retry
in case the end point is not ready in the first try.

Mostly seen when the endpoint is behind additional container,
so it takes time until the image of it is pulled.
This change is good as is, because it splits the logic, and use
assert in the right place.

Signed-off-by: Or Shoval <oshoval@redhat.com>

```release-note
None
```
