### PR TITLE
Annotate NMState CR with rejectOwner annotation

### DIFF
--- a/data/nmstate/operator/nmstate.io_v1_nmstate_cr.yaml
+++ b/data/nmstate/operator/nmstate.io_v1_nmstate_cr.yaml
@@ -1,4 +1,6 @@
 apiVersion: nmstate.io/v1
 kind: NMState
 metadata:
+  annotations:
+    networkaddonsoperator.network.kubevirt.io/rejectOwner: ""
   name: nmstate

--- a/hack/components/bump-nmstate.sh
+++ b/hack/components/bump-nmstate.sh
@@ -57,3 +57,4 @@ cp $NMSTATE_PATH/deploy/examples/nmstate.io_*_nmstate_cr.yaml data/nmstate/opera
 
 echo 'Apply custom CNAO patches on kubernetes-nmstate manifests'
 sed -i -z 's#kind: Secret\nmetadata:#kind: Secret\nmetadata:\n  annotations:\n    networkaddonsoperator.network.kubevirt.io\/rejectOwner: ""#' data/nmstate/operand/operator.yaml
+sed -i -z 's#metadata:\n#metadata:\n  annotations:\n    networkaddonsoperator.network.kubevirt.io\/rejectOwner: ""\n#' data/nmstate/operator/nmstate.io_*_nmstate_cr.yaml


### PR DESCRIPTION
Signed-off-by: Radim Hrazdil <rhrazdil@redhat.com>

<!-- Thanks for sending a pull request!

Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the main branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it

If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->


```release-note
CNAO no longer owns NMState CR created when knmstate-operator is present
```
