### PR TITLE
knmstate: Remove automation and cleanup cluster/up

### DIFF
--- a/automation/check-patch.e2e-nmstate-functests.sh
+++ b/automation/check-patch.e2e-nmstate-functests.sh
@@ -1,1 +1,0 @@
-#!/usr/bin/env bash

--- a/cluster/up.sh
+++ b/cluster/up.sh
@@ -33,13 +33,12 @@ if [[ "$KUBEVIRT_PROVIDER" =~ (ocp|okd)- ]]; then
 fi
 
 if [[ "$KUBEVIRT_PROVIDER" =~ k8s- ]]; then
-    echo 'Installing Open vSwitch and NetworkManager 1.34 on nodes'
+    echo 'Installing Open vSwitch'
     for node in $(./cluster/kubectl.sh get nodes --no-headers | awk '{print $1}'); do
         ./cluster/cli.sh ssh ${node} -- sudo dnf install -y centos-release-nfv-openvswitch
-        ./cluster/cli.sh ssh ${node} -- sudo dnf install -y openvswitch2.16 libibverbs NetworkManager-1.34.0 NetworkManager-ovs-1.34.0
+        ./cluster/cli.sh ssh ${node} -- sudo dnf install -y openvswitch2.16 libibverbs
         ./cluster/cli.sh ssh ${node} -- sudo systemctl daemon-reload
         ./cluster/cli.sh ssh ${node} -- sudo systemctl enable --now openvswitch
         ./cluster/cli.sh ssh ${node} -- sudo systemctl restart openvswitch
-        ./cluster/cli.sh ssh ${node} -- sudo systemctl restart NetworkManager
     done
 fi


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the main branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it

If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**What this PR does / why we need it**:
Now that kubernetes-nmstate is not handled by CNAO the automation to run
the prow job can be removed and the installation of NetworkManager can
be cleaned up from cluster/up.sh.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
