### PR TITLE
multus: Delete cni cache at preStop

### DIFF
--- a/data/multus/001-multus.yaml
+++ b/data/multus/001-multus.yaml
@@ -134,11 +134,13 @@ spec:
               mountPath: /host/etc/cni/net.d
             - name: cnibin
               mountPath: /host/opt/cni/bin
+            - name: cnicache
+              mountPath: /host/var/lib/cni
           imagePullPolicy: {{ .ImagePullPolicy }}
           lifecycle:
             preStop:
               exec:
-                command: ["/bin/sh", "-c", "rm -f /host/etc/cni/net.d/00-multus.conf"]
+                command: ["/bin/sh", "-c", "rm -rf /host/etc/cni/net.d/00-multus.conf /host/var/lib/cni/*"]
       terminationGracePeriodSeconds: 10
       volumes:
         - name: cni
@@ -147,6 +149,9 @@ spec:
         - name: cnibin
           hostPath:
             path: {{ .CNIBinDir }}
+        - name: cnicache
+          hostPath:
+            path: /var/lib/cni
       priorityClassName: system-cluster-critical
       nodeSelector: {{ toYaml .Placement.NodeSelector | nindent 8 }}
       affinity: {{ toYaml .Placement.Affinity | nindent 8 }}

--- a/hack/components/bump-multus.sh
+++ b/hack/components/bump-multus.sh
@@ -27,14 +27,18 @@ function __parametize_by_object() {
 				yaml-utils::set_param ${f} spec.template.spec.containers[0].imagePullPolicy '{{ .ImagePullPolicy }}'
 				yaml-utils::set_param ${f} spec.template.spec.priorityClassName 'system-cluster-critical'
 				yaml-utils::delete_param ${f} spec.template.spec.containers[0].volumeMounts[2]
+				yaml-utils::set_param ${f} spec.template.spec.containers[0].volumeMounts[2].name 'cnicache'
+				yaml-utils::set_param ${f} spec.template.spec.containers[0].volumeMounts[2].mountPath '/host/var/lib/cni'
 				yaml-utils::update_param ${f} spec.template.spec.volumes[0].hostPath.path '{{ .CNIConfigDir }}'
 				yaml-utils::update_param ${f} spec.template.spec.volumes[1].hostPath.path '{{ .CNIBinDir }}'
 				yaml-utils::delete_param ${f} spec.template.spec.volumes[2]
+				yaml-utils::set_param ${f} spec.template.spec.volumes[2].name 'cnicache'
+				yaml-utils::set_param ${f} spec.template.spec.volumes[2].hostPath.path '/var/lib/cni'
 				yaml-utils::delete_param ${f} spec.template.spec.containers[0].resources.limits
 				yaml-utils::update_param ${f} spec.template.spec.containers[0].resources.requests.cpu '"10m"'
 				yaml-utils::update_param ${f} spec.template.spec.containers[0].resources.requests.memory '"15Mi"'
 				yaml-utils::set_param ${f} spec.template.spec.nodeSelector '{{ toYaml .Placement.NodeSelector | nindent 8 }}'
-				yaml-utils::set_param ${f} spec.template.spec.containers[0].lifecycle.preStop.exec.command '["/bin/sh", "-c", "rm -f /host/etc/cni/net.d/00-multus.conf"]'
+				yaml-utils::set_param ${f} spec.template.spec.containers[0].lifecycle.preStop.exec.command '["/bin/sh", "-c", "rm -rf /host/etc/cni/net.d/00-multus.conf /host/var/lib/cni/*"]'
 				yaml-utils::set_param ${f} spec.template.spec.affinity '{{ toYaml .Placement.Affinity | nindent 8 }}'
 				yaml-utils::update_param ${f} spec.template.spec.tolerations '{{ toYaml .Placement.Tolerations | nindent 8 }}'
 				yaml-utils::remove_single_quotes_from_yaml ${f}


### PR DESCRIPTION
/kind bug

**What this PR does / why we need it**:
When multus is deleted the CNI resolution has to be forced for already
present pods or they will not be able to be removed. This change remove
the CNI cache before deleting the multus daemonset. This is related to
[1]

[1] https://github.com/kubevirt/cluster-network-addons-operator/pull/1219/commits/07036046c82b1f902a60ae4c058be61612e51f0d

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
Delete CNI cache /var/lib/cni/* at multus delete, the cache should be reconstructed by the CRI if it's using libcni.
```
