### PR TITLE
kubevirtci_tag, Bump to 2203021427-243853c

### DIFF
--- a/cluster/cluster.sh
+++ b/cluster/cluster.sh
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 export KUBEVIRT_PROVIDER=${KUBEVIRT_PROVIDER:-'k8s-1.23'}
-export KUBEVIRTCI_TAG='2202081102-e8daf721'
+export KUBEVIRTCI_TAG='2203021427-243853c'
 
 KUBEVIRTCI_REPO='https://github.com/kubevirt/kubevirtci.git'
 # The CLUSTER_PATH var is used in cluster folder and points to the _kubevirtci where the cluster is deployed from.


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR bumps CNAO KUBEVIRTCI_TAG to [2203021427-243853c](https://github.com/kubevirt/kubevirtci/releases/tag/2203021427-243853c)

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
