### PR TITLE
[release-0.65] nmstate: propagate placementConfiguration to NMState CR

### DIFF
--- a/data/nmstate/operator/nmstate.io_v1_nmstate_cr.yaml
+++ b/data/nmstate/operator/nmstate.io_v1_nmstate_cr.yaml
@@ -4,3 +4,10 @@ metadata:
   annotations:
     networkaddonsoperator.network.kubevirt.io/rejectOwner: ""
   name: nmstate
+spec:
+  nodeSelector: {{ toYaml .HandlerNodeSelector | nindent 4 }}
+  handlerTolerations: {{ toYaml .HandlerTolerations | nindent 4 }}
+  affinity: {{ toYaml .HandlerAffinity | nindent 4 }}
+  infraNodeSelector: {{ toYaml .InfraNodeSelector | nindent 4 }}
+  infraTolerations: {{ toYaml .InfraTolerations | nindent 4 }}
+  infraAffinity: {{ toYaml .InfraAffinity | nindent 4 }}

--- a/hack/components/bump-nmstate.sh
+++ b/hack/components/bump-nmstate.sh
@@ -58,3 +58,12 @@ cp $NMSTATE_PATH/deploy/examples/nmstate.io_*_nmstate_cr.yaml data/nmstate/opera
 echo 'Apply custom CNAO patches on kubernetes-nmstate manifests'
 sed -i -z 's#kind: Secret\nmetadata:#kind: Secret\nmetadata:\n  annotations:\n    networkaddonsoperator.network.kubevirt.io\/rejectOwner: ""#' data/nmstate/operand/operator.yaml
 sed -i -z 's#metadata:\n#metadata:\n  annotations:\n    networkaddonsoperator.network.kubevirt.io\/rejectOwner: ""\n#' data/nmstate/operator/nmstate.io_*_nmstate_cr.yaml
+cat <<EOF >> data/nmstate/operator/nmstate.io_*_nmstate_cr.yaml
+spec:
+  nodeSelector: {{ toYaml .HandlerNodeSelector | nindent 4 }}
+  handlerTolerations: {{ toYaml .HandlerTolerations | nindent 4 }}
+  affinity: {{ toYaml .HandlerAffinity | nindent 4 }}
+  infraNodeSelector: {{ toYaml .InfraNodeSelector | nindent 4 }}
+  infraTolerations: {{ toYaml .InfraTolerations | nindent 4 }}
+  infraAffinity: {{ toYaml .InfraAffinity | nindent 4 }}
+EOF

--- a/pkg/network/nmstate.go
+++ b/pkg/network/nmstate.go
@@ -35,7 +35,6 @@ func renderNMState(conf *cnao.NetworkAddonsConfigSpec, manifestDir string, clust
 	data.Data["HandlerNamespace"] = os.Getenv("OPERAND_NAMESPACE")
 	data.Data["HandlerImage"] = os.Getenv("NMSTATE_HANDLER_IMAGE")
 	data.Data["HandlerPullPolicy"] = confWithDefaults.ImagePullPolicy
-	data.Data["HandlerNodeSelector"] = map[string]string{}
 	data.Data["EnableSCC"] = clusterInfo.SCCAvailable
 	data.Data["CARotateInterval"] = confWithDefaults.SelfSignConfiguration.CARotateInterval
 	data.Data["CAOverlapInterval"] = confWithDefaults.SelfSignConfiguration.CAOverlapInterval
@@ -44,6 +43,12 @@ func renderNMState(conf *cnao.NetworkAddonsConfigSpec, manifestDir string, clust
 	data.Data["PlacementConfiguration"] = confWithDefaults.PlacementConfiguration
 	data.Data["WebhookReplicas"] = getNumberOfWebhookReplicas(clusterInfo)
 	data.Data["WebhookMinReplicas"] = getMinNumberOfWebhookReplicas(clusterInfo)
+	data.Data["HandlerNodeSelector"] = confWithDefaults.PlacementConfiguration.Workloads.NodeSelector
+	data.Data["HandlerTolerations"] = confWithDefaults.PlacementConfiguration.Workloads.Tolerations
+	data.Data["HandlerAffinity"] = confWithDefaults.PlacementConfiguration.Workloads.Affinity
+	data.Data["InfraNodeSelector"] = confWithDefaults.PlacementConfiguration.Infra.NodeSelector
+	data.Data["InfraTolerations"] = confWithDefaults.PlacementConfiguration.Infra.Tolerations
+	data.Data["InfraAffinity"] = confWithDefaults.PlacementConfiguration.Infra.Affinity
 
 	_, enableOVS := os.LookupEnv("NMSTATE_ENABLE_OVS")
 	data.Data["EnableOVS"] = enableOVS


### PR DESCRIPTION
Signed-off-by: Radim Hrazdil <rhrazdil@redhat.com>

<!-- Thanks for sending a pull request!

Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the main branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it

If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**What this PR does / why we need it**:

When users migrate from CNAO to standalone kubernetes-nmstate operator,
their placementConfiguration specified in cluster network addons is lost.
This PR propagates this configuration to the NMState CR.


**Special notes for your reviewer**:
This depends on kubernetes-nmstate having affinity fields in NMState CRD
https://github.com/nmstate/kubernetes-nmstate/pull/1003

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
propagate placementConfiguration to nmstate CR
```
