### PR TITLE
Add TLS Security Profile API to NAC

### DIFF
--- a/data/kubemacpool/kubemacpool.yaml
+++ b/data/kubemacpool/kubemacpool.yaml
@@ -300,6 +300,10 @@ spec:
           value: '{{ .CertRotateInterval | default "4380h0m0s" }}'
         - name: CERT_OVERLAP_INTERVAL
           value: '{{ .CertOverlapInterval | default "24h0m0s" }}'
+        - name: TLS_MIN_VERSION
+          value: '{{ .TLSMinVersion }}'
+        - name: TLS_CIPHERS
+          value: '{{ .TLSSecurityProfileCiphers }}'
         image: '{{ .KubeMacPoolImage }}'
         imagePullPolicy: '{{ .ImagePullPolicy }}'
         name: manager

--- a/hack/components/bump-kubemacpool.sh
+++ b/hack/components/bump-kubemacpool.sh
@@ -77,6 +77,10 @@ spec:
             value: "{{ .CertRotateInterval | default \"4380h0m0s\" }}"
           - name: CERT_OVERLAP_INTERVAL
             value: "{{ .CertOverlapInterval | default \"24h0m0s\" }}"
+          - name: TLS_MIN_VERSION
+            value: "{{ .TLSMinVersion }}"
+          - name: TLS_CIPHERS
+            value: "{{ .TLSSecurityProfileCiphers }}"
 EOF
 
     cat <<EOF > config/cnao/cnao_placement_patch.yaml

--- a/pkg/apis/networkaddonsoperator/shared/networkaddonsconfig_types.go
+++ b/pkg/apis/networkaddonsoperator/shared/networkaddonsconfig_types.go
@@ -1,6 +1,7 @@
 package shared
 
 import (
+	ocpv1 "github.com/openshift/api/config/v1"
 	conditionsv1 "github.com/openshift/custom-resource-status/conditions/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -8,15 +9,16 @@ import (
 
 // NetworkAddonsConfigSpec defines the desired state of NetworkAddonsConfig
 type NetworkAddonsConfigSpec struct {
-	Multus                 *Multus                 `json:"multus,omitempty"`
-	LinuxBridge            *LinuxBridge            `json:"linuxBridge,omitempty"`
-	Ovs                    *Ovs                    `json:"ovs,omitempty"`
-	KubeMacPool            *KubeMacPool            `json:"kubeMacPool,omitempty"`
-	ImagePullPolicy        corev1.PullPolicy       `json:"imagePullPolicy,omitempty"`
-	NMState                *NMState                `json:"nmstate,omitempty"`
-	MacvtapCni             *MacvtapCni             `json:"macvtap,omitempty"`
-	SelfSignConfiguration  *SelfSignConfiguration  `json:"selfSignConfiguration,omitempty"`
-	PlacementConfiguration *PlacementConfiguration `json:"placementConfiguration,omitempty"`
+	Multus                 *Multus                   `json:"multus,omitempty"`
+	LinuxBridge            *LinuxBridge              `json:"linuxBridge,omitempty"`
+	Ovs                    *Ovs                      `json:"ovs,omitempty"`
+	KubeMacPool            *KubeMacPool              `json:"kubeMacPool,omitempty"`
+	ImagePullPolicy        corev1.PullPolicy         `json:"imagePullPolicy,omitempty"`
+	NMState                *NMState                  `json:"nmstate,omitempty"`
+	MacvtapCni             *MacvtapCni               `json:"macvtap,omitempty"`
+	SelfSignConfiguration  *SelfSignConfiguration    `json:"selfSignConfiguration,omitempty"`
+	PlacementConfiguration *PlacementConfiguration   `json:"placementConfiguration,omitempty"`
+	TLSSecurityProfile     *ocpv1.TLSSecurityProfile `json:"tlsSecurityProfile,omitempty"`
 }
 
 // SelfSignConfiguration defines self sign configuration

--- a/pkg/apis/networkaddonsoperator/shared/zz_generated.deepcopy.go
+++ b/pkg/apis/networkaddonsoperator/shared/zz_generated.deepcopy.go
@@ -22,6 +22,7 @@ limitations under the License.
 package shared
 
 import (
+	configv1 "github.com/openshift/api/config/v1"
 	conditionsv1 "github.com/openshift/custom-resource-status/conditions/v1"
 	"k8s.io/api/core/v1"
 )
@@ -176,6 +177,11 @@ func (in *NetworkAddonsConfigSpec) DeepCopyInto(out *NetworkAddonsConfigSpec) {
 	if in.PlacementConfiguration != nil {
 		in, out := &in.PlacementConfiguration, &out.PlacementConfiguration
 		*out = new(PlacementConfiguration)
+		(*in).DeepCopyInto(*out)
+	}
+	if in.TLSSecurityProfile != nil {
+		in, out := &in.TLSSecurityProfile, &out.TLSSecurityProfile
+		*out = new(configv1.TLSSecurityProfile)
 		(*in).DeepCopyInto(*out)
 	}
 }

--- a/pkg/network/kubemacpool.go
+++ b/pkg/network/kubemacpool.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"strings"
 
 	"github.com/kubevirt/cluster-network-addons-operator/pkg/render"
 	"github.com/pkg/errors"
@@ -113,6 +114,10 @@ func renderKubeMacPool(conf *cnao.NetworkAddonsConfigSpec, manifestDir string) (
 	data.Data["CAOverlapInterval"] = conf.SelfSignConfiguration.CAOverlapInterval
 	data.Data["CertRotateInterval"] = conf.SelfSignConfiguration.CertRotateInterval
 	data.Data["CertOverlapInterval"] = conf.SelfSignConfiguration.CertOverlapInterval
+
+	ciphers, tlsMinVersion := SelectCipherSuitesAndMinTLSVersion(conf.TLSSecurityProfile)
+	data.Data["TLSSecurityProfileCiphers"] = strings.Join(ciphers, ",")
+	data.Data["TLSMinVersion"] = TLSVersionToHumanReadable(tlsMinVersion)
 
 	objs, err := render.RenderDir(filepath.Join(manifestDir, "kubemacpool"), &data)
 	if err != nil {

--- a/pkg/network/tlsSecurityProfile.go
+++ b/pkg/network/tlsSecurityProfile.go
@@ -1,0 +1,30 @@
+package network
+
+import (
+	ocpv1 "github.com/openshift/api/config/v1"
+)
+
+func SelectCipherSuitesAndMinTLSVersion(profile *ocpv1.TLSSecurityProfile) ([]string, ocpv1.TLSProtocolVersion) {
+	if profile == nil {
+		return []string{}, ""
+	}
+	if profile.Custom != nil {
+		return profile.Custom.TLSProfileSpec.Ciphers, profile.Custom.TLSProfileSpec.MinTLSVersion
+	}
+	return ocpv1.TLSProfiles[profile.Type].Ciphers, ocpv1.TLSProfiles[profile.Type].MinTLSVersion
+}
+
+func TLSVersionToHumanReadable(version ocpv1.TLSProtocolVersion) string {
+	switch version {
+	case ocpv1.VersionTLS10:
+		return "1.0"
+	case ocpv1.VersionTLS11:
+		return "1.1"
+	case ocpv1.VersionTLS12:
+		return "1.2"
+	case ocpv1.VersionTLS13:
+		return "1.3"
+	default:
+		return ""
+	}
+}

--- a/pkg/network/tlsSecurityProfile_test.go
+++ b/pkg/network/tlsSecurityProfile_test.go
@@ -1,0 +1,67 @@
+package network
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+
+	ocpv1 "github.com/openshift/api/config/v1"
+
+	cnao "github.com/kubevirt/cluster-network-addons-operator/pkg/apis/networkaddonsoperator/shared"
+)
+
+var _ = Describe("Testing TLS Security Profile", func() {
+	type loadSecurityProfileCase struct {
+		config                *cnao.NetworkAddonsConfigSpec
+		expectedCiphers       []string
+		expectedMinTLSVersion ocpv1.TLSProtocolVersion
+	}
+	testCustomTLSProfileSpec := ocpv1.TLSProfileSpec{
+		Ciphers:       []string{"foo,bar"},
+		MinTLSVersion: "foobar",
+	}
+	DescribeTable("SecurityProfileSpec function",
+		func(c loadSecurityProfileCase) {
+			ciphers, minTLSVersion := SelectCipherSuitesAndMinTLSVersion(c.config.TLSSecurityProfile)
+			Expect(ciphers).To(Equal(c.expectedCiphers))
+			Expect(minTLSVersion).To(Equal(c.expectedMinTLSVersion))
+		},
+		Entry("when TLSSecurityProfile is nil", loadSecurityProfileCase{
+			config:                &cnao.NetworkAddonsConfigSpec{},
+			expectedCiphers:       []string{},
+			expectedMinTLSVersion: "",
+		}),
+		Entry("when Old Security Profile is selected", loadSecurityProfileCase{
+			config: &cnao.NetworkAddonsConfigSpec{
+				TLSSecurityProfile: &ocpv1.TLSSecurityProfile{
+					Type: ocpv1.TLSProfileOldType,
+					Old:  &ocpv1.OldTLSProfile{},
+				},
+			},
+			expectedCiphers:       ocpv1.TLSProfiles[ocpv1.TLSProfileOldType].Ciphers,
+			expectedMinTLSVersion: ocpv1.TLSProfiles[ocpv1.TLSProfileOldType].MinTLSVersion,
+		}),
+		Entry("when Intermediate Security Profile is selected", loadSecurityProfileCase{
+			config: &cnao.NetworkAddonsConfigSpec{
+				TLSSecurityProfile: &ocpv1.TLSSecurityProfile{
+					Type:         ocpv1.TLSProfileIntermediateType,
+					Intermediate: &ocpv1.IntermediateTLSProfile{},
+				},
+			},
+			expectedCiphers:       ocpv1.TLSProfiles[ocpv1.TLSProfileIntermediateType].Ciphers,
+			expectedMinTLSVersion: ocpv1.TLSProfiles[ocpv1.TLSProfileIntermediateType].MinTLSVersion,
+		}),
+		Entry("when Custom Security Profile is selected", loadSecurityProfileCase{
+			config: &cnao.NetworkAddonsConfigSpec{
+				TLSSecurityProfile: &ocpv1.TLSSecurityProfile{
+					Type: ocpv1.TLSProfileCustomType,
+					Custom: &ocpv1.CustomTLSProfile{
+						TLSProfileSpec: testCustomTLSProfileSpec,
+					},
+				},
+			},
+			expectedCiphers:       testCustomTLSProfileSpec.Ciphers,
+			expectedMinTLSVersion: testCustomTLSProfileSpec.MinTLSVersion,
+		}),
+	)
+})


### PR DESCRIPTION


**What this PR does / why we need it**:
This PR adds API for configuration of TLSSecurityProfile to NAC custom resource.
TLS configuration is passed via ENV variables to kubemacpool certificate manager pods.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
Add API for TLSSecurityProfile
```
