### PR TITLE
[release-0.44] components, fix linux bridge primary branch to main

### DIFF
--- a/components.yaml
+++ b/components.yaml
@@ -14,7 +14,7 @@ components:
   linux-bridge:
     url: https://github.com/containernetworking/plugins
     commit: 74a6b28a2c2796a2638ba61a85bb620640bfeb31
-    branch: master
+    branch: main
     update-policy: static
     metadata: ""
   macvtap-cni:


### PR DESCRIPTION
**What this PR does / why we need it**:
linux-bridge primary branch has changed to main.
Updating components.yaml accordingly

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
