### PR TITLE
[release-0.65] fix linux bridge main branch

### DIFF
--- a/components.yaml
+++ b/components.yaml
@@ -14,7 +14,7 @@ components:
   linux-bridge:
     url: https://github.com/containernetworking/plugins
     commit: f1f128e3c9220634d3f26b96950271f87c34e424
-    branch: master
+    branch: main
     update-policy: static
     metadata: ""
   macvtap-cni:


### PR DESCRIPTION
**What this PR does / why we need it**:
linux-bridge primary branch has changed to main.
Updating components.yaml accordingly

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
