### PR TITLE
DeleteOwnedObject, Change Delete handling log location

### DIFF
--- a/pkg/apply/apply.go
+++ b/pkg/apply/apply.go
@@ -97,7 +97,6 @@ func DeleteOwnedObject(ctx context.Context, client k8sclient.Client, obj *uns.Un
 	gvk := obj.GroupVersionKind()
 	// used for logging and errors
 	objDesc := fmt.Sprintf("(%s) %s/%s", gvk.String(), namespace, name)
-	log.Printf("Handling deletion of %s", objDesc)
 
 	// Get existing
 	existing := &uns.Unstructured{}
@@ -113,7 +112,7 @@ func DeleteOwnedObject(ctx context.Context, client k8sclient.Client, obj *uns.Un
 	if !cnaoOwns(existing) {
 		return nil
 	}
-
+	log.Printf("Handling deletion of %s", objDesc)
 	if err := client.Delete(ctx, existing); err != nil {
 		return errors.Wrapf(err, "could not delete %s", objDesc)
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently the "Handling deletion of X" is printed even if the object is
not owned, This may lead to misleading log data when running on HCO.
Moving the log to after object is filtered for ownership

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
