### PR TITLE
[release 0.53] bump kubevirtci and k8s 1.21

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,8 +319,8 @@ make docker-build-registry
 # bring up a local cluster with Kubernetes
 make cluster-up
 
-# bridge up a local cluster with kubernetes 1.19
-export KUBEVIRT_PROVIDER=k8s-1.19
+# bridge up a local cluster with kubernetes 1.21
+export KUBEVIRT_PROVIDER=k8s-1.21
 make cluster-up
 
 # build images and push them to the local cluster

--- a/automation/check-patch.e2e-lifecycle-k8s.sh
+++ b/automation/check-patch.e2e-lifecycle-k8s.sh
@@ -18,7 +18,7 @@ versionChanged() {
 }
 
 main() {
-    export KUBEVIRT_PROVIDER='k8s-1.19'
+    export KUBEVIRT_PROVIDER='k8s-1.21'
 
     source automation/check-patch.setup.sh
     cd ${TMP_PROJECT_PATH}

--- a/automation/check-patch.e2e-workflow-k8s.sh
+++ b/automation/check-patch.e2e-workflow-k8s.sh
@@ -14,7 +14,7 @@ teardown() {
 }
 
 main() {
-    export KUBEVIRT_PROVIDER='k8s-1.19'
+    export KUBEVIRT_PROVIDER='k8s-1.21'
 
     source automation/check-patch.setup.sh
     cd ${TMP_PROJECT_PATH}

--- a/automation/components-functests.setup.sh
+++ b/automation/components-functests.setup.sh
@@ -22,7 +22,7 @@ source hack/components/yaml-utils.sh
 source cluster/cluster.sh
 
 # Spin up Kubernetes cluster
-export KUBEVIRT_PROVIDER='k8s-1.19'
+export KUBEVIRT_PROVIDER='k8s-1.21'
 make cluster-down cluster-up
 
 # Export .kubeconfig full path, so it will be possible

--- a/cluster/cluster.sh
+++ b/cluster/cluster.sh
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 export KUBEVIRT_PROVIDER=${KUBEVIRT_PROVIDER:-'k8s-1.19'}
-export KUBEVIRTCI_TAG='2111221759-b05af17'
+export KUBEVIRTCI_TAG='2203222209-7c38b02'
 
 KUBEVIRTCI_REPO='https://github.com/kubevirt/kubevirtci.git'
 # The CLUSTER_PATH var is used in cluster folder and points to the _kubevirtci where the cluster is deployed from.

--- a/cluster/cluster.sh
+++ b/cluster/cluster.sh
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-export KUBEVIRT_PROVIDER=${KUBEVIRT_PROVIDER:-'k8s-1.19'}
+export KUBEVIRT_PROVIDER=${KUBEVIRT_PROVIDER:-'k8s-1.21'}
 export KUBEVIRTCI_TAG='2203222209-7c38b02'
 
 KUBEVIRTCI_REPO='https://github.com/kubevirt/kubevirtci.git'

--- a/cluster/up.sh
+++ b/cluster/up.sh
@@ -33,11 +33,7 @@ fi
 if [[ "$KUBEVIRT_PROVIDER" =~ k8s- ]]; then
     echo 'Installing Open vSwitch and NetworkManager 1.34 on nodes'
     for node in $(./cluster/kubectl.sh get nodes --no-headers | awk '{print $1}'); do
-        ./cluster/cli.sh ssh ${node} -- sudo dnf install -y centos-release-nfv-openvswitch
-        ./cluster/cli.sh ssh ${node} -- sudo dnf install -y openvswitch2.16 libibverbs NetworkManager-1.34.0 NetworkManager-ovs-1.34.0
-        ./cluster/cli.sh ssh ${node} -- sudo systemctl daemon-reload
         ./cluster/cli.sh ssh ${node} -- sudo systemctl enable --now openvswitch
         ./cluster/cli.sh ssh ${node} -- sudo systemctl restart openvswitch
-        ./cluster/cli.sh ssh ${node} -- sudo systemctl restart NetworkManager
     done
 fi

--- a/pkg/apis/networkaddonsoperator/shared/networkaddonsconfig_types.go
+++ b/pkg/apis/networkaddonsoperator/shared/networkaddonsconfig_types.go
@@ -37,7 +37,7 @@ type SelfSignConfiguration struct {
 // PlacementConfiguration defines node placement configuration
 type PlacementConfiguration struct {
 	// Infra defines placement configuration for master nodes
-	Infra     *Placement `json:"infra,omitempty"`
+	Infra *Placement `json:"infra,omitempty"`
 	// Workloads defines placement configuration for worker nodes
 	Workloads *Placement `json:"workloads,omitempty"`
 }
@@ -71,7 +71,7 @@ type KubeMacPool struct {
 	// RangeStart defines the first mac in range
 	RangeStart string `json:"rangeStart,omitempty"`
 	// RangeEnd defines the last mac in range
-	RangeEnd   string `json:"rangeEnd,omitempty"`
+	RangeEnd string `json:"rangeEnd,omitempty"`
 }
 
 // MacvtapCni plugin allows users to define Kubernetes networks on top of existing host interfaces

--- a/tools/bumper/bumper.go
+++ b/tools/bumper/bumper.go
@@ -4,9 +4,9 @@ import (
 	"bytes"
 	"flag"
 	"fmt"
-	"strings"
 	"log"
 	"os"
+	"strings"
 
 	"github.com/pkg/errors"
 )

--- a/tools/bumper/git_fakes.go
+++ b/tools/bumper/git_fakes.go
@@ -87,7 +87,7 @@ func (g *mockGithubApi) listPullRequests(owner string, repo string, branch strin
 
 func (g *mockGithubApi) createPullRequest(owner string, repo string, pull *github.NewPullRequest) (*github.PullRequest, *github.Response, error) {
 	base := &github.PullRequestBranch{
-		Ref:  pull.Base,
+		Ref: pull.Base,
 	}
 	pullRequest := &github.PullRequest{Title: pull.Title, Base: base}
 	g.fakePRList = append(g.fakePRList, pullRequest)


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR bumps KUBRVIRTCI_TAG and KUBEVIRT_PROVIDER to the correct k8s provider
Also, from this kubrvirtci bump there is no need to install a specific networkManager on cluster-up, as the version in kubevirtci is good enough.

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
