### PR TITLE
gitActions, Remove unsupported workflows

### DIFF
--- a/.github/workflows/component-bumper.yaml
+++ b/.github/workflows/component-bumper.yaml
@@ -15,8 +15,6 @@ jobs:
       matrix:
         branch:
           - main
-          - release-0.42
-          - release-0.44
           - release-0.53
           - release-0.58
           - release-0.65


### PR DESCRIPTION
**What this PR does / why we need it**:
As we support only last 2 stable branches, this PR is removing old workflows

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
