### PR TITLE
Set degraded if nmstate is requested in networkAddonsConfig

### DIFF
--- a/pkg/controller/statusmanager/status_manager.go
+++ b/pkg/controller/statusmanager/status_manager.go
@@ -158,15 +158,30 @@ func (status *StatusManager) set(reachedAvailableLevel bool, conditions ...condi
 			},
 		)
 	} else if reachedAvailableLevel {
-		// If successfully deployed all components and is not failing on anything, mark as Available
-		status.eventEmitter.EmitAvailableForConfig()
-		conditionsv1.SetStatusConditionNoHeartbeat(&config.Status.Conditions,
-			conditionsv1.Condition{
-				Type:   conditionsv1.ConditionAvailable,
-				Status: corev1.ConditionTrue,
-			},
-		)
-		config.Status.ObservedVersion = operatorVersion
+		if config.Spec.NMState != nil {
+			// CNAO doesn't support nmstate deployment anymore, set Degraded state is nmstate is requested in NetworkAddonsConfig
+			reason := "InvalidConfiguration"
+			message := "NMState deployment is not supported by CNAO anymore, please install Kubernetes NMState Operator"
+			status.eventEmitter.EmitFailingForConfig(reason, message)
+			conditionsv1.SetStatusConditionNoHeartbeat(&config.Status.Conditions,
+				conditionsv1.Condition{
+					Type:    conditionsv1.ConditionDegraded,
+					Status:  corev1.ConditionTrue,
+					Reason:  reason,
+					Message: message,
+				},
+			)
+		} else {
+			// If successfully deployed all components and is not failing on anything, mark as Available
+			status.eventEmitter.EmitAvailableForConfig()
+			conditionsv1.SetStatusConditionNoHeartbeat(&config.Status.Conditions,
+				conditionsv1.Condition{
+					Type:   conditionsv1.ConditionAvailable,
+					Status: corev1.ConditionTrue,
+				},
+			)
+			config.Status.ObservedVersion = operatorVersion
+		}
 	}
 
 	// Make sure to expose deployed containers

--- a/test/e2e/workflow/recovery_test.go
+++ b/test/e2e/workflow/recovery_test.go
@@ -33,7 +33,7 @@ var _ = Describe("NetworkAddonsConfig", func() {
 
 			It("should turn from Failing to Available", func() {
 				CheckAvailableEvent(gvk)
-				CheckConfigCondition(gvk, ConditionAvailable, ConditionTrue, 5*time.Second, CheckDoNotRepeat)
+				CheckConfigCondition(gvk, ConditionAvailable, ConditionTrue, 10*time.Second, CheckDoNotRepeat)
 				CheckConfigCondition(gvk, ConditionDegraded, ConditionFalse, CheckImmediately, CheckDoNotRepeat)
 			})
 		})


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR aims to block upgrade if still using CNAO to deploy nmstate by Setting NetworkAddonsConfig Degraded Status to true.
HCO will reconcile it and see that the NAC status is degraded, consequently it will set it's status upgradeable to false.

See HCO: https://github.com/kubevirt/hyperconverged-cluster-operator/blob/main/controllers/hyperconverged/hyperconverged_controller.go#L740

That will block upgrade until user installs KNO (Kubernetes Nmstate Operator).

**Special notes for your reviewer**:

HCO change:
- https://github.com/kubevirt/hyperconverged-cluster-operator/pull/1847

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
Block CNV upgrade if still using CNAO to deploy nmstate
```
