### PR TITLE
crds: sort tlsProfiles to generate deterministic crd

### DIFF
--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -588,8 +588,8 @@ func GetCrd() *extv1.CustomResourceDefinition {
 
 	cipherSuites := func() []extv1.JSON {
 		suites := []extv1.JSON{}
-		for _, p := range ocpv1.TLSProfiles {
-			for _, c := range p.Ciphers {
+		for _, p := range tlsProfiles(ocpv1.TLSProfiles).sortedKeys() {
+			for _, c := range ocpv1.TLSProfiles[p].Ciphers {
 				suites = append(suites, extv1.JSON{Raw: []byte(fmt.Sprintf("\"%s\"", c))})
 			}
 		}

--- a/pkg/components/tlsProfiles.go
+++ b/pkg/components/tlsProfiles.go
@@ -1,0 +1,24 @@
+package components
+
+import (
+	"sort"
+
+	ocpv1 "github.com/openshift/api/config/v1"
+)
+
+type byTLSProfileName []ocpv1.TLSProfileType
+
+func (a byTLSProfileName) Len() int           { return len(a) }
+func (a byTLSProfileName) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
+func (a byTLSProfileName) Less(i, j int) bool { return a[i] < a[j] }
+
+type tlsProfiles map[ocpv1.TLSProfileType]*ocpv1.TLSProfileSpec
+
+func (p tlsProfiles) sortedKeys() []ocpv1.TLSProfileType {
+	tlsProfiles := []ocpv1.TLSProfileType{}
+	for k, _ := range p {
+		tlsProfiles = append(tlsProfiles, k)
+	}
+	sort.Sort(byTLSProfileName(tlsProfiles))
+	return tlsProfiles
+}

--- a/pkg/components/tlsProfiles_test.go
+++ b/pkg/components/tlsProfiles_test.go
@@ -1,0 +1,33 @@
+package components
+
+import (
+	ocpv1 "github.com/openshift/api/config/v1"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Sorting TLSProfiles", func() {
+	type tlsProfilesSortCase struct {
+		tlsProfiles        map[ocpv1.TLSProfileType]*ocpv1.TLSProfileSpec
+		expectedSortedKeys []ocpv1.TLSProfileType
+	}
+	DescribeTable("When sortedKeys is called", func(c tlsProfilesSortCase) {
+		Expect(tlsProfiles(c.tlsProfiles).sortedKeys()).To(Equal(c.expectedSortedKeys))
+	},
+		Entry("with one profile", tlsProfilesSortCase{
+			tlsProfiles: map[ocpv1.TLSProfileType]*ocpv1.TLSProfileSpec{
+				ocpv1.TLSProfileIntermediateType: ocpv1.TLSProfiles[ocpv1.TLSProfileIntermediateType],
+			},
+			expectedSortedKeys: []ocpv1.TLSProfileType{ocpv1.TLSProfileIntermediateType},
+		}),
+		Entry("with all profiles", tlsProfilesSortCase{
+			tlsProfiles: map[ocpv1.TLSProfileType]*ocpv1.TLSProfileSpec{
+				ocpv1.TLSProfileIntermediateType: ocpv1.TLSProfiles[ocpv1.TLSProfileIntermediateType],
+				ocpv1.TLSProfileOldType:          ocpv1.TLSProfiles[ocpv1.TLSProfileOldType],
+				ocpv1.TLSProfileModernType:       ocpv1.TLSProfiles[ocpv1.TLSProfileModernType],
+			},
+			expectedSortedKeys: []ocpv1.TLSProfileType{ocpv1.TLSProfileIntermediateType, ocpv1.TLSProfileModernType, ocpv1.TLSProfileOldType},
+		}))
+})


### PR DESCRIPTION
Signed-off-by: Radim Hrazdil <rhrazdil@redhat.com>

**What this PR does / why we need it**:
Sort tlsProfiles alphabetically, so that generated CRD is always the same

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
