### PR TITLE
tls: Use intermediate TLS profile by default

### DIFF
--- a/pkg/network/tlsSecurityProfile.go
+++ b/pkg/network/tlsSecurityProfile.go
@@ -6,7 +6,10 @@ import (
 
 func SelectCipherSuitesAndMinTLSVersion(profile *ocpv1.TLSSecurityProfile) ([]string, ocpv1.TLSProtocolVersion) {
 	if profile == nil {
-		return []string{}, ""
+		profile = &ocpv1.TLSSecurityProfile{
+			Type:         ocpv1.TLSProfileIntermediateType,
+			Intermediate: &ocpv1.IntermediateTLSProfile{},
+		}
 	}
 	if profile.Custom != nil {
 		return profile.Custom.TLSProfileSpec.Ciphers, profile.Custom.TLSProfileSpec.MinTLSVersion

--- a/pkg/network/tlsSecurityProfile_test.go
+++ b/pkg/network/tlsSecurityProfile_test.go
@@ -28,8 +28,8 @@ var _ = Describe("Testing TLS Security Profile", func() {
 		},
 		Entry("when TLSSecurityProfile is nil", loadSecurityProfileCase{
 			config:                &cnao.NetworkAddonsConfigSpec{},
-			expectedCiphers:       []string{},
-			expectedMinTLSVersion: "",
+			expectedCiphers:       ocpv1.TLSProfiles[ocpv1.TLSProfileIntermediateType].Ciphers,
+			expectedMinTLSVersion: ocpv1.TLSProfiles[ocpv1.TLSProfileIntermediateType].MinTLSVersion,
 		}),
 		Entry("when Old Security Profile is selected", loadSecurityProfileCase{
 			config: &cnao.NetworkAddonsConfigSpec{


### PR DESCRIPTION
/kind bug

**What this PR does / why we need it**:
When no TLS is specified at openshift the Intermediate profile is
selected [1]. This changes copy that behaviour at CNAO.

[1] https://github.com/openshift/library-go/blob/master/pkg/operator/configobserver/apiserver/observe_tlssecurityprofile.go#L81-L84

**Special notes for your reviewer**:
Closes https://bugzilla.redhat.com/show_bug.cgi?id=2069388

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
Use intermediate TLS profile by default
```
