### PR TITLE
[release-0.65] Set degraded if nmstate is requested in networkAddonsConfig on OCP 4.11 or later

### DIFF
--- a/test/e2e/workflow/recovery_test.go
+++ b/test/e2e/workflow/recovery_test.go
@@ -33,7 +33,7 @@ var _ = Describe("NetworkAddonsConfig", func() {
 
 			It("should turn from Failing to Available", func() {
 				CheckAvailableEvent(gvk)
-				CheckConfigCondition(gvk, ConditionAvailable, ConditionTrue, 5*time.Second, CheckDoNotRepeat)
+				CheckConfigCondition(gvk, ConditionAvailable, ConditionTrue, 10*time.Second, CheckDoNotRepeat)
 				CheckConfigCondition(gvk, ConditionDegraded, ConditionFalse, CheckImmediately, CheckDoNotRepeat)
 			})
 		})


### PR DESCRIPTION
HCO will reconcile and see that the NAC status is degraded
and in turn set it's status upgradeable to false.

That will block upgrade until user installs KNO

Signed-off-by: Radim Hrazdil <rhrazdil@redhat.com>

<!-- Thanks for sending a pull request!

Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the main branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it

If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
Block CNV upgrade if on OCP 4.11 and still using CNAO to deploy nmstate
```
