### PR TITLE
[release-0.65] nmstate: define Self Sign onfiguration defaults in operator code

### DIFF
--- a/pkg/network/nmstate.go
+++ b/pkg/network/nmstate.go
@@ -28,7 +28,15 @@ func renderNMState(conf *cnao.NetworkAddonsConfigSpec, manifestDir string, clust
 	}
 
 	confWithDefaults := pupulateNmstateDefaultConfiguration(conf)
-
+	selfSignConfiguration := conf.SelfSignConfiguration
+	if selfSignConfiguration == nil {
+		selfSignConfiguration = &cnao.SelfSignConfiguration{
+			CARotateInterval:    "8760h0m0s",
+			CAOverlapInterval:   "24h0m0s",
+			CertRotateInterval:  "4380h0m0s",
+			CertOverlapInterval: "24h0m0s",
+		}
+	}
 	// render the manifests on disk
 	data := render.MakeRenderData()
 	data.Data["HandlerPrefix"] = ""
@@ -49,6 +57,7 @@ func renderNMState(conf *cnao.NetworkAddonsConfigSpec, manifestDir string, clust
 	data.Data["InfraNodeSelector"] = confWithDefaults.PlacementConfiguration.Infra.NodeSelector
 	data.Data["InfraTolerations"] = confWithDefaults.PlacementConfiguration.Infra.Tolerations
 	data.Data["InfraAffinity"] = confWithDefaults.PlacementConfiguration.Infra.Affinity
+	data.Data["SelfSignConfiguration"] = selfSignConfiguration
 
 	_, enableOVS := os.LookupEnv("NMSTATE_ENABLE_OVS")
 	data.Data["EnableOVS"] = enableOVS


### PR DESCRIPTION
Signed-off-by: Radim Hrazdil <rhrazdil@redhat.com>


**What this PR does / why we need it**:
As part of adding Self Sign certificate configuration to NMState API, we've moved setting the defaults
to the operator code, instead of the yaml, since other default values are specified in the operator as well.
- https://github.com/nmstate/kubernetes-nmstate/pull/1029

This PR adds the change to CNAO.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
