### PR TITLE
[release-0.65] Propagate selfsign conf

### DIFF
--- a/data/nmstate/operator/nmstate.io_v1_nmstate_cr.yaml
+++ b/data/nmstate/operator/nmstate.io_v1_nmstate_cr.yaml
@@ -11,3 +11,4 @@ spec:
   infraNodeSelector: {{ toYaml .InfraNodeSelector | nindent 4 }}
   infraTolerations: {{ toYaml .InfraTolerations | nindent 4 }}
   infraAffinity: {{ toYaml .InfraAffinity | nindent 4 }}
+  selfSignConfiguration : {{ toYaml .SelfSignConfiguration | nindent 4 }}

--- a/hack/components/bump-nmstate.sh
+++ b/hack/components/bump-nmstate.sh
@@ -66,4 +66,5 @@ spec:
   infraNodeSelector: {{ toYaml .InfraNodeSelector | nindent 4 }}
   infraTolerations: {{ toYaml .InfraTolerations | nindent 4 }}
   infraAffinity: {{ toYaml .InfraAffinity | nindent 4 }}
+  selfSignConfiguration : {{ toYaml .SelfSignConfiguration | nindent 4 }}
 EOF


### PR DESCRIPTION
Signed-off-by: Radim Hrazdil <rhrazdil@redhat.com>

<!-- Thanks for sending a pull request!

Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the main branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it

If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**What this PR does / why we need it**:
When creating NMState CR for kubernetes-nmstate operator, propagate selfSignConfiguration.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
selfSignConfiguration is passed to NMState CR when deploying nmstate via standalone kubernetes-nmstate operator
```
