### PR TITLE
config, sccs: add required parameters

### DIFF
--- a/data/linux-bridge/001-rbac.yaml
+++ b/data/linux-bridge/001-rbac.yaml
@@ -12,6 +12,11 @@ metadata:
   name: linux-bridge
 allowPrivilegedContainer: true
 allowHostDirVolumePlugin: true
+allowHostIPC: false
+allowHostNetwork: false
+allowHostPID: false
+allowHostPorts: false
+readOnlyRootFilesystem: false
 runAsUser:
   type: RunAsAny
 seLinuxContext:

--- a/data/linux-bridge/001-rbac.yaml
+++ b/data/linux-bridge/001-rbac.yaml
@@ -23,4 +23,6 @@ seLinuxContext:
   type: RunAsAny
 users:
 - system:serviceaccount:{{ .Namespace }}:linux-bridge
+volumes:
+- "*"
 {{ end }}

--- a/data/linux-bridge/003-bridge-marker.yaml
+++ b/data/linux-bridge/003-bridge-marker.yaml
@@ -99,5 +99,7 @@ seLinuxContext:
   type: RunAsAny
 users:
 - system:serviceaccount:{{ .Namespace }}:bridge-marker
+volumes:
+- "*"
 {{ end }}
 ---

--- a/data/linux-bridge/003-bridge-marker.yaml
+++ b/data/linux-bridge/003-bridge-marker.yaml
@@ -87,6 +87,12 @@ kind: SecurityContextConstraints
 metadata:
   name: bridge-marker
 allowHostNetwork: true
+allowHostDirVolumePlugin: true
+allowPrivilegedContainer: false
+readOnlyRootFilesystem: false
+allowHostIPC: false
+allowHostPID: false
+allowHostPorts: false
 runAsUser:
   type: RunAsAny
 seLinuxContext:

--- a/data/multus/001-multus.yaml
+++ b/data/multus/001-multus.yaml
@@ -163,6 +163,11 @@ metadata:
   name: multus
 allowPrivilegedContainer: true
 allowHostDirVolumePlugin: true
+readOnlyRootFilesystem: false
+allowHostIPC: false
+allowHostNetwork: true
+allowHostPID: false
+allowHostPorts: false
 runAsUser:
   type: RunAsAny
 seLinuxContext:

--- a/data/multus/001-multus.yaml
+++ b/data/multus/001-multus.yaml
@@ -174,5 +174,7 @@ seLinuxContext:
   type: RunAsAny
 users:
 - system:serviceaccount:{{ .Namespace }}:multus
+volumes:
+- "*"
 {{ end }}
 ---

--- a/hack/components/bump-bridge-marker.sh
+++ b/hack/components/bump-bridge-marker.sh
@@ -67,6 +67,12 @@ kind: SecurityContextConstraints
 metadata:
   name: bridge-marker
 allowHostNetwork: true
+allowHostDirVolumePlugin: true
+allowPrivilegedContainer: false
+readOnlyRootFilesystem: false
+allowHostIPC: false
+allowHostPID: false
+allowHostPorts: false
 runAsUser:
   type: RunAsAny
 seLinuxContext:

--- a/hack/components/bump-bridge-marker.sh
+++ b/hack/components/bump-bridge-marker.sh
@@ -79,6 +79,8 @@ seLinuxContext:
   type: RunAsAny
 users:
 - system:serviceaccount:{{ .Namespace }}:bridge-marker
+volumes:
+- "*"
 {{ end }}
 ---
 EOF

--- a/hack/components/bump-multus.sh
+++ b/hack/components/bump-multus.sh
@@ -100,6 +100,8 @@ seLinuxContext:
   type: RunAsAny
 users:
 - system:serviceaccount:{{ .Namespace }}:multus
+volumes:
+- "*"
 {{ end }}
 ---
 EOF

--- a/hack/components/bump-multus.sh
+++ b/hack/components/bump-multus.sh
@@ -89,6 +89,11 @@ metadata:
   name: multus
 allowPrivilegedContainer: true
 allowHostDirVolumePlugin: true
+readOnlyRootFilesystem: false
+allowHostIPC: false
+allowHostNetwork: true
+allowHostPID: false
+allowHostPorts: false
 runAsUser:
   type: RunAsAny
 seLinuxContext:


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the main branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it

If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**What this PR does / why we need it**:
According to [openshift's API specification](https://docs.openshift.com/container-platform/4.10/rest_api/security_apis/securitycontextconstraints-security-openshift-io-v1.html) the following
attributes are required:
- allowHostDirVolumePlugin
- allowHostIPC
- allowHostNetwork
- allowHostPID
- allowHostPorts
- allowPrivilegedContainer
- readOnlyRootFilesystem

This commits adds the required parameters to the SCCs that were missing
them.

Furthermore, there's this [openshift documentation bug](https://bugzilla.redhat.com/show_bug.cgi?id=2079224), in which the `volumes`
attribute is missing from the API.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
Add the required attributes to comply with the openshift SCC API.
```
