### PR TITLE
Set Upgradeable instead of Available condition when nmstate deployed

### DIFF
--- a/pkg/controller/statusmanager/status_manager.go
+++ b/pkg/controller/statusmanager/status_manager.go
@@ -166,23 +166,25 @@ func (status *StatusManager) set(reachedAvailableLevel bool, conditions ...condi
 			status.eventEmitter.EmitFailingForConfig(reason, message)
 			conditionsv1.SetStatusConditionNoHeartbeat(&config.Status.Conditions,
 				conditionsv1.Condition{
-					Type:    conditionsv1.ConditionDegraded,
-					Status:  corev1.ConditionTrue,
+					Type:    conditionsv1.ConditionUpgradeable,
+					Status:  corev1.ConditionFalse,
 					Reason:  reason,
 					Message: message,
 				},
 			)
 		} else {
-			// If successfully deployed all components and is not failing on anything, mark as Available
-			status.eventEmitter.EmitAvailableForConfig()
-			conditionsv1.SetStatusConditionNoHeartbeat(&config.Status.Conditions,
-				conditionsv1.Condition{
-					Type:   conditionsv1.ConditionAvailable,
-					Status: corev1.ConditionTrue,
-				},
-			)
-			config.Status.ObservedVersion = operatorVersion
+			conditionsv1.RemoveStatusCondition(&config.Status.Conditions, conditionsv1.ConditionUpgradeable)
 		}
+
+		// If successfully deployed all components and is not failing on anything, mark as Available
+		status.eventEmitter.EmitAvailableForConfig()
+		conditionsv1.SetStatusConditionNoHeartbeat(&config.Status.Conditions,
+			conditionsv1.Condition{
+				Type:   conditionsv1.ConditionAvailable,
+				Status: corev1.ConditionTrue,
+			},
+		)
+		config.Status.ObservedVersion = operatorVersion
 	}
 
 	// Make sure to expose deployed containers


### PR DESCRIPTION
Value of Upgradeable/Available condition propagates to HCO operator.
Since we want to only express we want to block an upgrade when nmstate
is enabled in CNAO, it's more accurate to only set Upgradeable condition
instead of setting Availabe condition to False.

With this change, HCO will set Upgradeable condition to False, but will
remain Available, which describes the situation better.

See the following snippets of networkaddonsconfig spec and status:

#### With nmstate

```yaml
  spec:
    imagePullPolicy: IfNotPresent
    kubeMacPool: {}
    linuxBridge: {}
    macvtap: {}
    multus: {}
    nmstate: {}
    ovs: {}
  status:
    conditions:
    - lastTransitionTime: "2022-04-20T07:01:30Z"
      status: "False"
      type: Degraded
    - lastTransitionTime: "2022-04-20T07:01:50Z"
      status: "False"
      type: Progressing
    - lastTransitionTime: "2022-04-20T07:01:50Z"
      status: "True"
      type: Available
    - lastTransitionTime: "2022-04-20T07:01:50Z"
      message: NMState deployment is not supported by CNAO anymore, please install
        Kubernetes NMState Operator
      reason: InvalidConfiguration
      status: "False"
      type: Upgradeable
```

#### Without nmstate
```yaml
  spec:
    imagePullPolicy: IfNotPresent
    kubeMacPool: {}
    linuxBridge: {}
    macvtap: {}
    multus: {}
    ovs: {}
  status:
    conditions:
    - lastTransitionTime: "2022-04-20T07:01:30Z"
      status: "False"
      type: Degraded
    - lastTransitionTime: "2022-04-20T07:01:50Z"
      status: "False"
      type: Progressing
    - lastTransitionTime: "2022-04-20T07:01:50Z"
      status: "True"
      type: Available
```

Signed-off-by: Radim Hrazdil <rhrazdil@redhat.com>

<!-- Thanks for sending a pull request!

Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the main branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it

If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**What this PR does / why we need it**:

**Special notes for your reviewer**:

See HCO staus logic diagram:
- https://github.com/kubevirt/hyperconverged-cluster-operator/blob/main/design/aggregateComponentConditions.svg

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
Set Upgradeable: False if nmstate enabled, instead of setting Available: False
```
