### PR TITLE
e2e, workflow: get latest released tag for knmstate

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/kubevirt/cluster-network-addons-operator
 
 require (
-	github.com/Masterminds/semver v1.5.0 // indirect
+	github.com/Masterminds/semver v1.5.0
 	github.com/Masterminds/sprig v2.22.0+incompatible
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/coreos/go-semver v0.3.0

--- a/test/e2e/workflow/nmstate_test.go
+++ b/test/e2e/workflow/nmstate_test.go
@@ -22,10 +22,11 @@ import (
 	testenv "github.com/kubevirt/cluster-network-addons-operator/test/env"
 	"github.com/kubevirt/cluster-network-addons-operator/test/kubectl"
 	. "github.com/kubevirt/cluster-network-addons-operator/test/operations"
+	"github.com/kubevirt/cluster-network-addons-operator/test/release"
 )
 
 var _ = Describe("NMState", func() {
-	nmstateVersion := "v0.70.1"
+	nmstateVersion := latestNmstateTag()
 	gvk := GetCnaoV1GroupVersionKind()
 	Context("installed as standalone", func() {
 		BeforeEach(func() {
@@ -143,4 +144,15 @@ func checkStandaloneNMStateIsReady(timeout time.Duration) {
 	} else {
 		Expect(CheckForGenericDeployment("nmstate-webook", "nmstate", false, false)).ShouldNot(HaveOccurred(), "nmstate-webhook is not ready")
 	}
+}
+
+func latestNmstateTag() string {
+	data, err := release.GetUrlData(release.KnmstateReleasesUrl)
+	Expect(err).ShouldNot(HaveOccurred())
+
+	releases, err := release.ParseReleases(data)
+	Expect(err).ShouldNot(HaveOccurred())
+
+	semverTags := release.SortReleasesBySemver(releases)
+	return fmt.Sprintf("v%s", semverTags[len(semverTags)-1])
 }

--- a/test/release/release.go
+++ b/test/release/release.go
@@ -1,0 +1,77 @@
+package release
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"sort"
+	"time"
+
+	"github.com/Masterminds/semver"
+)
+
+const KnmstateReleasesUrl = "https://api.github.com/repos/nmstate/kubernetes-nmstate/releases"
+
+type Release struct {
+	TagName string `json:"tag_name"`
+}
+
+func newHttpClient() *http.Client {
+	return &http.Client{
+		Timeout: time.Second * 2,
+	}
+}
+
+func newGetRequest(url string) (*http.Request, error) {
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	return req, nil
+}
+
+func GetUrlData(url string) ([]byte, error) {
+	req, err := newGetRequest(url)
+	if err != nil {
+		return []byte{}, err
+	}
+
+	resp, err := newHttpClient().Do(req)
+	if err != nil {
+		return []byte{}, err
+	}
+	if resp.Body != nil {
+		defer resp.Body.Close()
+	}
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return []byte{}, err
+	}
+	return body, nil
+}
+
+func ParseReleases(data []byte) ([]Release, error) {
+	r := make([]Release, 0)
+	jsonErr := json.Unmarshal(data, &r)
+	if jsonErr != nil {
+		log.Fatal(jsonErr)
+	}
+	return r, nil
+}
+
+func SortReleasesBySemver(releases []Release) []*semver.Version {
+	sv := make([]*semver.Version, len(releases))
+	for i, r := range releases {
+		v, err := semver.NewVersion(r.TagName)
+		if err != nil {
+			fmt.Printf("Error parsing version: %s\n", err)
+		}
+		sv[i] = v
+	}
+
+	sort.Sort(semver.Collection(sv))
+	return sv
+}


### PR DESCRIPTION
Signed-off-by: Radim Hrazdil <rhrazdil@redhat.com>

<!-- Thanks for sending a pull request!

Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the main branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it

If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**What this PR does / why we need it**:
This commit installs latest released tag of NMstate when testing NetworkAddonsConfig
workflow.


**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
