### PR TITLE
[release-0.53] infra: bump kubevirtci to 1.21

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,8 +319,8 @@ make docker-build-registry
 # bring up a local cluster with Kubernetes
 make cluster-up
 
-# bridge up a local cluster with kubernetes 1.19
-export KUBEVIRT_PROVIDER=k8s-1.19
+# bridge up a local cluster with kubernetes 1.21
+export KUBEVIRT_PROVIDER=k8s-1.21
 make cluster-up
 
 # build images and push them to the local cluster

--- a/automation/check-patch.e2e-lifecycle-k8s.sh
+++ b/automation/check-patch.e2e-lifecycle-k8s.sh
@@ -18,7 +18,7 @@ versionChanged() {
 }
 
 main() {
-    export KUBEVIRT_PROVIDER='k8s-1.19'
+    export KUBEVIRT_PROVIDER='k8s-1.21'
 
     source automation/check-patch.setup.sh
     cd ${TMP_PROJECT_PATH}

--- a/automation/check-patch.e2e-workflow-k8s.sh
+++ b/automation/check-patch.e2e-workflow-k8s.sh
@@ -14,7 +14,7 @@ teardown() {
 }
 
 main() {
-    export KUBEVIRT_PROVIDER='k8s-1.19'
+    export KUBEVIRT_PROVIDER='k8s-1.21'
 
     source automation/check-patch.setup.sh
     cd ${TMP_PROJECT_PATH}

--- a/automation/components-functests.setup.sh
+++ b/automation/components-functests.setup.sh
@@ -22,7 +22,7 @@ source hack/components/yaml-utils.sh
 source cluster/cluster.sh
 
 # Spin up Kubernetes cluster
-export KUBEVIRT_PROVIDER='k8s-1.19'
+export KUBEVIRT_PROVIDER='k8s-1.21'
 make cluster-down cluster-up
 
 # Export .kubeconfig full path, so it will be possible

--- a/cluster/cluster.sh
+++ b/cluster/cluster.sh
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-export KUBEVIRT_PROVIDER=${KUBEVIRT_PROVIDER:-'k8s-1.19'}
-export KUBEVIRTCI_TAG='2111221759-b05af17'
+export KUBEVIRT_PROVIDER=${KUBEVIRT_PROVIDER:-'k8s-1.21'}
+export KUBEVIRTCI_TAG='2106301530-8ce1562'
 
 KUBEVIRTCI_REPO='https://github.com/kubevirt/kubevirtci.git'
 # The CLUSTER_PATH var is used in cluster folder and points to the _kubevirtci where the cluster is deployed from.

--- a/cluster/up.sh
+++ b/cluster/up.sh
@@ -31,7 +31,7 @@ if [[ "$KUBEVIRT_PROVIDER" =~ (ocp|okd)- ]]; then
 fi
 
 if [[ "$KUBEVIRT_PROVIDER" =~ k8s- ]]; then
-    echo 'Installing Open vSwitch and NetworkManager 1.34 on nodes'
+    echo 'Enabling and starting up openvswitch'
     for node in $(./cluster/kubectl.sh get nodes --no-headers | awk '{print $1}'); do
         ./cluster/cli.sh ssh ${node} -- sudo dnf install -y centos-release-nfv-openvswitch
         ./cluster/cli.sh ssh ${node} -- sudo dnf install -y openvswitch2.16 libibverbs NetworkManager-1.34.0 NetworkManager-ovs-1.34.0


### PR DESCRIPTION
Kubevirt v0.52.0 requires k8s cluster with PodDisruptionBudget,
which is not available on k8s-1.19.


**What this PR does / why we need it**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
