### PR TITLE
[release-0.76] components.yaml, statify components on release-0.76

### DIFF
--- a/components.yaml
+++ b/components.yaml
@@ -3,12 +3,12 @@ components:
     url: https://github.com/kubevirt/bridge-marker
     commit: 128c5ae6ad196e67d432d6afdfc73afa01c64b85
     branch: main
-    update-policy: tagged
+    update-policy: static
     metadata: 0.9.2
   kubemacpool:
     url: https://github.com/k8snetworkplumbingwg/kubemacpool
     commit: 25f92cd76db3b7bed51fe54779ec63353ff7c24d
-    branch: main
+    branch: release-v0.38
     update-policy: tagged
     metadata: v0.38.0
   linux-bridge:
@@ -21,17 +21,17 @@ components:
     url: https://github.com/kubevirt/macvtap-cni
     commit: 50c4042a422aee6df0f54af43ba4cd63e518e044
     branch: main
-    update-policy: tagged
+    update-policy: static
     metadata: v0.7.0
   multus:
     url: https://github.com/k8snetworkplumbingwg/multus-cni
     commit: efdc0a5c7d1ea4bb236d638403420448b48782b3
     branch: master
-    update-policy: tagged
+    update-policy: static
     metadata: v3.8
   ovs-cni:
     url: https://github.com/k8snetworkplumbingwg/ovs-cni
     commit: 67388f0fb1b7324a7c9480030a74ad265c19ccf3
     branch: main
-    update-policy: tagged
+    update-policy: static
     metadata: v0.26.1


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR changes components to not follow relevant stable branches, and where there
is no stable branch, set to static.

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
