### PR TITLE
workflows, Fix jobs in prepare-release-branch workflow

### DIFF
--- a/.github/workflows/prepare-release-branch.yaml
+++ b/.github/workflows/prepare-release-branch.yaml
@@ -11,11 +11,7 @@ on:
         description: 'The new CNAO release branch name'
         required: true
         type: string
-      pushBranch:
-        description: 'Push new branch to repository'
-        required: true
-        type: boolean
-        default: true
+
 jobs:
   create-release-branch:
     runs-on: ubuntu-latest
@@ -27,7 +23,6 @@ jobs:
           fetch-depth: 0
 
       - name: Push the branch to CNAO repo
-        if: ${{ github.event.inputs.pushBranch == 'true' }}
         run: |
           git push origin HEAD:refs/heads/${{ github.event.inputs.branchName }}
 
@@ -39,6 +34,12 @@ jobs:
         run: |
           git config --global user.email "noreplay@github.com"
           git config --global user.name "CNAO Version bot"
+
+      - name: Check out main branch code into the Go module directory
+        uses: actions/checkout@v2
+        with:
+          ref: main
+          fetch-depth: 0
 
       - name: Run make update-release-branch-workflows
         run: make update-workflows-branches git_base_tag=${{ github.event.inputs.baseTag }} branch_name=${{ github.event.inputs.branchName }}


### PR DESCRIPTION

**What this PR does / why we need it**:
Add checkout to main branch on 'Run make update-release-branch-workflows' job
Remove unneeded pushBranch input option.

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
