### PR TITLE
workflows, Fix branch names on peter-evans/create-pull-request

### DIFF
--- a/.github/workflows/prepare-release-branch.yaml
+++ b/.github/workflows/prepare-release-branch.yaml
@@ -47,7 +47,7 @@ jobs:
       - name: Create new release branch PR
         uses: peter-evans/create-pull-request@v3
         with:
-          branch: main
+          branch: main-update-worflows-new-branch-${{ github.event.inputs.branchName }}
           token: ${{ secrets.KUBEVIRT_BOT_TOKEN }}
           committer: GitHub <noreply@github.com>
           signoff: true
@@ -87,7 +87,7 @@ jobs:
       - name: Create components update PR on release branch
         uses: peter-evans/create-pull-request@v3
         with:
-          branch: ${{ github.event.inputs.branchName }}
+          branch: ${{ github.event.inputs.branchName }}-statify-components
           token: ${{ secrets.KUBEVIRT_BOT_TOKEN }}
           committer: GitHub <noreply@github.com>
           signoff: true


### PR DESCRIPTION
**What this PR does / why we need it**:
peter-evans/create-pull-request build parameter needs to be different
from the existing branch.

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
