### PR TITLE
Set Not upgradeable only when KNO is not found

### DIFF
--- a/pkg/controller/networkaddonsconfig/networkaddonsconfig_controller.go
+++ b/pkg/controller/networkaddonsconfig/networkaddonsconfig_controller.go
@@ -211,6 +211,7 @@ func (r *ReconcileNetworkAddonsConfig) Reconcile(ctx context.Context, request re
 		log.Printf("Kubernetes NMState Operator is running")
 	}
 	r.clusterInfo.NmstateOperator = nmstateOperator
+	r.statusManager.NmstateOperator = nmstateOperator
 
 	if r.clusterInfo.OpenShift4 {
 		isSingleReplica, err := isOpenshiftSingleReplica(r.client)

--- a/pkg/controller/statusmanager/status_manager.go
+++ b/pkg/controller/statusmanager/status_manager.go
@@ -60,6 +60,8 @@ type StatusManager struct {
 	daemonSets  []types.NamespacedName
 	deployments []types.NamespacedName
 
+	NmstateOperator bool
+
 	containers   []cnao.Container
 	mux          sync.Mutex
 	eventEmitter eventemitter.EventEmitter
@@ -159,7 +161,7 @@ func (status *StatusManager) set(reachedAvailableLevel bool, conditions ...condi
 			},
 		)
 	} else if reachedAvailableLevel {
-		if status.isRunningOnOpenshift411OrLater() && config.Spec.NMState != nil {
+		if status.isRunningOnOpenshift411OrLater() && config.Spec.NMState != nil && !status.NmstateOperator {
 			// CNAO doesn't support nmstate deployment anymore, set Degraded state is nmstate is requested in NetworkAddonsConfig
 			reason := "InvalidConfiguration"
 			message := "NMState deployment is not supported by CNAO anymore, please install Kubernetes NMState Operator"


### PR DESCRIPTION
When CNAO hands over knmstate deployment to KNO,
NMstate remains in networkAddonsConfig spec.

For that, we need to check whether KNO is present
to make sure the Not Upgradeable condition is removed,
when KNO is installed.

Signed-off-by: Radim Hrazdil <rhrazdil@redhat.com>

<!-- Thanks for sending a pull request!

Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the main branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it

If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
