### PR TITLE
Revert "Set degraded if nmstate is deployed on OCP 4.11 or later

### DIFF
--- a/pkg/controller/statusmanager/status_manager.go
+++ b/pkg/controller/statusmanager/status_manager.go
@@ -158,30 +158,15 @@ func (status *StatusManager) set(reachedAvailableLevel bool, conditions ...condi
 			},
 		)
 	} else if reachedAvailableLevel {
-		if config.Spec.NMState != nil {
-			// CNAO doesn't support nmstate deployment anymore, set Degraded state is nmstate is requested in NetworkAddonsConfig
-			reason := "InvalidConfiguration"
-			message := "NMState deployment is not supported by CNAO anymore, please install Kubernetes NMState Operator"
-			status.eventEmitter.EmitFailingForConfig(reason, message)
-			conditionsv1.SetStatusConditionNoHeartbeat(&config.Status.Conditions,
-				conditionsv1.Condition{
-					Type:    conditionsv1.ConditionDegraded,
-					Status:  corev1.ConditionTrue,
-					Reason:  reason,
-					Message: message,
-				},
-			)
-		} else {
-			// If successfully deployed all components and is not failing on anything, mark as Available
-			status.eventEmitter.EmitAvailableForConfig()
-			conditionsv1.SetStatusConditionNoHeartbeat(&config.Status.Conditions,
-				conditionsv1.Condition{
-					Type:   conditionsv1.ConditionAvailable,
-					Status: corev1.ConditionTrue,
-				},
-			)
-			config.Status.ObservedVersion = operatorVersion
-		}
+		// If successfully deployed all components and is not failing on anything, mark as Available
+		status.eventEmitter.EmitAvailableForConfig()
+		conditionsv1.SetStatusConditionNoHeartbeat(&config.Status.Conditions,
+			conditionsv1.Condition{
+				Type:   conditionsv1.ConditionAvailable,
+				Status: corev1.ConditionTrue,
+			},
+		)
+		config.Status.ObservedVersion = operatorVersion
 	}
 
 	// Make sure to expose deployed containers

--- a/test/e2e/workflow/recovery_test.go
+++ b/test/e2e/workflow/recovery_test.go
@@ -33,7 +33,7 @@ var _ = Describe("NetworkAddonsConfig", func() {
 
 			It("should turn from Failing to Available", func() {
 				CheckAvailableEvent(gvk)
-				CheckConfigCondition(gvk, ConditionAvailable, ConditionTrue, 10*time.Second, CheckDoNotRepeat)
+				CheckConfigCondition(gvk, ConditionAvailable, ConditionTrue, 5*time.Second, CheckDoNotRepeat)
 				CheckConfigCondition(gvk, ConditionDegraded, ConditionFalse, CheckImmediately, CheckDoNotRepeat)
 			})
 		})


### PR DESCRIPTION
This check is not needed anymore, as nmstate is not valid field in
NetworkAddonsConfig spec.

This reverts commit 575bdd5ede5e79ac73fd4d43ed0aac015b80df66.

<!-- Thanks for sending a pull request!

Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the main branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it

If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
