### PR TITLE
e2e: nac upgradeable condition for nmstate deployment

### DIFF
--- a/test/check/conditions.go
+++ b/test/check/conditions.go
@@ -13,6 +13,7 @@ const (
 	ConditionAvailable   = ConditionType(conditionsv1.ConditionAvailable)
 	ConditionProgressing = ConditionType(conditionsv1.ConditionProgressing)
 	ConditionDegraded    = ConditionType(conditionsv1.ConditionDegraded)
+	ConditionUpgradeable = ConditionType(conditionsv1.ConditionUpgradeable)
 
 	ConditionTrue  = ConditionStatus(corev1.ConditionTrue)
 	ConditionFalse = ConditionStatus(corev1.ConditionFalse)


### PR DESCRIPTION
Signed-off-by: Radim Hrazdil <rhrazdil@redhat.com>

This PR adds E2E test for 
1) when nmstate is deployed with CNAO, Upgradeable condition is set to False
2) when nmstate is deployed with CNAO and then KNO is installed, Upgradeable condition is removed
    after nmstate is handed over from CNAO to KNO

<!-- Thanks for sending a pull request!

Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the main branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it

If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
