### PR TITLE
[release-0.65] rbac: Add missing cluster-reader verbs

### DIFF
--- a/data/nmstate/operand/cluster_role.yaml
+++ b/data/nmstate/operand/cluster_role.yaml
@@ -1,0 +1,19 @@
+{{if .ClusterReaderExists}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: nmstate-cluster-reader
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-cluster-reader: "true"
+rules:
+- apiGroups:
+  - nmstate.io
+  resources:
+  - nodenetworkstates
+  - nodenetworkconfigurationpolicies
+  - nodenetworkconfigurationenactments
+  verbs:
+  - get
+  - list
+  - watch
+{{end}}

--- a/hack/components/bump-nmstate.sh
+++ b/hack/components/bump-nmstate.sh
@@ -68,3 +68,25 @@ spec:
   infraAffinity: {{ toYaml .InfraAffinity | nindent 4 }}
   selfSignConfiguration : {{ toYaml .SelfSignConfiguration | nindent 4 }}
 EOF
+
+cat <<EOF >> data/nmstate/operand/cluster_role.yaml
+{{if .ClusterReaderExists}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: nmstate-cluster-reader
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-cluster-reader: "true"
+rules:
+- apiGroups:
+  - nmstate.io
+  resources:
+  - nodenetworkstates
+  - nodenetworkconfigurationpolicies
+  - nodenetworkconfigurationenactments
+  verbs:
+  - get
+  - list
+  - watch
+{{end}}
+EOF

--- a/pkg/network/cluster-info.go
+++ b/pkg/network/cluster-info.go
@@ -1,9 +1,10 @@
 package network
 
 type ClusterInfo struct {
-	SCCAvailable        bool
-	OpenShift4          bool
-	NmstateOperator     bool
-	MonitoringAvailable bool
-	IsSingleReplica     bool
+	SCCAvailable           bool
+	OpenShift4             bool
+	NmstateOperator        bool
+	MonitoringAvailable    bool
+	IsSingleReplica        bool
+	ClusterReaderAvailable bool
 }

--- a/pkg/network/nmstate.go
+++ b/pkg/network/nmstate.go
@@ -58,6 +58,7 @@ func renderNMState(conf *cnao.NetworkAddonsConfigSpec, manifestDir string, clust
 	data.Data["InfraTolerations"] = confWithDefaults.PlacementConfiguration.Infra.Tolerations
 	data.Data["InfraAffinity"] = confWithDefaults.PlacementConfiguration.Infra.Affinity
 	data.Data["SelfSignConfiguration"] = selfSignConfiguration
+	data.Data["ClusterReaderExists"] = clusterInfo.ClusterReaderAvailable
 
 	_, enableOVS := os.LookupEnv("NMSTATE_ENABLE_OVS")
 	data.Data["EnableOVS"] = enableOVS

--- a/test/e2e/workflow/deployment_test.go
+++ b/test/e2e/workflow/deployment_test.go
@@ -13,7 +13,9 @@ import (
 	"github.com/pkg/errors"
 	v1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/retry"
@@ -514,6 +516,53 @@ var _ = Describe("NetworkAddonsConfig", func() {
 				})
 			})
 		})
+		Context("when cluser-reader exists", func() {
+			const (
+				clusterReaderRoleName = "cluster-reader"
+				testUserNamespace     = "default"
+				serviceAccountName    = "test-user"
+				testUserBindingName   = "test-user-binding"
+			)
+
+			var clusterReaderCreated bool
+
+			JustBeforeEach(func() {
+				CreateConfig(gvk, configSpec)
+				CheckConfigCondition(gvk, ConditionAvailable, ConditionTrue, 15*time.Minute, CheckDoNotRepeat)
+			})
+
+			BeforeEach(func() {
+				err := createClusterReaderCR(clusterReaderRoleName)
+				Expect(err).To(SatisfyAny(Succeed(), WithTransform(apierrors.IsAlreadyExists, BeTrue())))
+				if err == nil {
+					clusterReaderCreated = true
+				}
+
+				Expect(createTestUserSA(testUserNamespace, serviceAccountName)).To(Succeed(),
+					"should success creating a serviceaccount")
+				Expect(createTestUserCRB(testUserBindingName, testUserNamespace, serviceAccountName, clusterReaderRoleName)).To(Succeed(),
+					"should success creating a clusterrolebinding")
+			})
+
+			AfterEach(func() {
+				Expect(deleteTestUserCRB(testUserBindingName)).To(Succeed())
+			})
+			AfterEach(func() {
+				Expect(deleteTestUserSA(testUserNamespace, serviceAccountName)).To(Succeed())
+			})
+			AfterEach(func() {
+				if clusterReaderCreated {
+					Expect(deleteClusterReaderCR(clusterReaderRoleName)).To(Succeed())
+				}
+			})
+
+			It("should be able to read NMState resources with cluster-reader user", func() {
+				Eventually(func() error {
+					_, err := kubectl.Kubectl("get", "nns", fmt.Sprintf("--as=system:serviceaccount:%s:%s", testUserNamespace, serviceAccountName))
+					return err
+				}, 10*time.Second, time.Second).Should(Succeed())
+			})
+		})
 	})
 })
 
@@ -643,4 +692,91 @@ func checkConfigChange(gvk schema.GroupVersionKind, components []Component, whil
 		// Check that all requested components have been deployed
 		CheckComponentsDeployment(components)
 	}
+}
+
+func createClusterReaderCR(clusterReaderRoleName string) error {
+	clusterReader := rbacv1.ClusterRole{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "ClusterRole",
+			APIVersion: rbacv1.SchemeGroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: clusterReaderRoleName,
+		},
+		AggregationRule: &rbacv1.AggregationRule{
+			ClusterRoleSelectors: []metav1.LabelSelector{
+				{
+					MatchLabels: map[string]string{"rbac.authorization.k8s.io/aggregate-to-cluster-reader": "true"},
+				},
+			},
+		},
+	}
+	return testenv.Client.Create(context.TODO(), &clusterReader)
+}
+
+func createTestUserSA(testUserNamespace, serviceAccountName string) error {
+	testUserSA := corev1.ServiceAccount{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "ServiceAccount",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: testUserNamespace,
+			Name:      serviceAccountName,
+		},
+	}
+	return testenv.Client.Create(context.TODO(), &testUserSA)
+}
+
+func createTestUserCRB(testUserBindingName, testUserNamespace, serviceAccountName, clusterReaderRoleName string) error {
+	testUserBinding := rbacv1.ClusterRoleBinding{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "ClusterRoleBinding",
+			APIVersion: rbacv1.SchemeGroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: testUserBindingName,
+		},
+		Subjects: []rbacv1.Subject{
+			{
+				Kind:      "ServiceAccount",
+				Namespace: testUserNamespace,
+				Name:      serviceAccountName,
+			},
+		},
+		RoleRef: rbacv1.RoleRef{
+			Kind:     "ClusterRole",
+			Name:     clusterReaderRoleName,
+			APIGroup: rbacv1.GroupName,
+		},
+	}
+	return testenv.Client.Create(context.TODO(), &testUserBinding)
+}
+
+func deleteClusterReaderCR(clusterReaderRoleName string) error {
+	clusterReader := rbacv1.ClusterRole{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: clusterReaderRoleName,
+		},
+	}
+	return testenv.Client.Delete(context.TODO(), &clusterReader)
+}
+
+func deleteTestUserSA(testUserNamespace, serviceAccountName string) error {
+	testUserSA := corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: testUserNamespace,
+			Name:      serviceAccountName,
+		},
+	}
+	return testenv.Client.Delete(context.TODO(), &testUserSA)
+}
+
+func deleteTestUserCRB(testUserBindingName string) error {
+	testUserBinding := rbacv1.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: testUserBindingName,
+		},
+	}
+	return testenv.Client.Delete(context.TODO(), &testUserBinding)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
When using Openshift, in case cluster-reader
ClusterRole exists,
Users of cluster-readers group should be able to
access k8s nmstate crds, such as nns, nncp and nnce.

Add a ClusterRole that allows it in case
cluster-reader exists.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=2087091

**Special notes for your reviewer**:
Only if k8s-nmstate is deployed by CNAO, the logic is added.
For standalone operator the support of cluster-reader is
done at https://github.com/nmstate/kubernetes-nmstate/pull/1052 onwards.

**Release note**:
```release-note
None
```
