### PR TITLE
[release-0.65] Pin CNAO to bridge-markers stable branch

### DIFF
--- a/components.yaml
+++ b/components.yaml
@@ -2,8 +2,8 @@ components:
   bridge-marker:
     url: https://github.com/kubevirt/bridge-marker
     commit: 46b2b0f81a807bf140f0e90b377c6cea0ca7eb9b
-    branch: main
-    update-policy: static
+    branch: release-0.9.1
+    update-policy: tagged
     metadata: 0.9.1
   kubemacpool:
     url: https://github.com/k8snetworkplumbingwg/kubemacpool


### PR DESCRIPTION


**What this PR does / why we need it**:

A stable branch was created on bridge-marker. Let's use it to receive fixes.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
