### PR TITLE
DISCARDED [release-0.58] Pin CNAO to bridge-markers stable branch

### DIFF
--- a/components.yaml
+++ b/components.yaml
@@ -1,10 +1,10 @@
 components:
   bridge-marker:
     url: https://github.com/kubevirt/bridge-marker
-    commit: 128c5ae6ad196e67d432d6afdfc73afa01c64b85
-    branch: main
+    commit: 46b2b0f81a807bf140f0e90b377c6cea0ca7eb9b
+    branch: release-0.9.1
     update-policy: tagged
-    metadata: 0.9.2
+    metadata: 0.9.1
   kubemacpool:
     url: https://github.com/k8snetworkplumbingwg/kubemacpool
     commit: 6c156d1a14b618b6e06b382d919c73489139bb4b


### PR DESCRIPTION


Signed-off-by: Petr Horáček <phoracek@redhat.com>

<!-- Thanks for sending a pull request!

Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the main branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it

If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**What this PR does / why we need it**:

Tag 0.9.2 was spoiled due to change in Go version dependency. This patch
pins marker back to 0.9.1 and sets the source branch to be stable
release-0.9.1.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
