### PR TITLE
Add an infra label to each of CNAO alerts

### DIFF
--- a/data/monitoring/prom-rule.yaml
+++ b/data/monitoring/prom-rule.yaml
@@ -22,6 +22,7 @@ spec:
             severity: warning
             kubernetes_operator_part_of: kubevirt
             kubernetes_operator_component: cluster-network-addons-operator
+            infra_alert: true
         - alert: NetworkAddonsConfigNotReady
           annotations:
             summary: CNAO CR NetworkAddonsConfig is not ready.
@@ -32,6 +33,7 @@ spec:
             severity: warning
             kubernetes_operator_part_of: kubevirt
             kubernetes_operator_component: cluster-network-addons-operator
+            infra_alert: true
         # +help:summary="Total count of duplicate KubeMacPool MAC addresses",type=Gauge
         - expr: sum(kubevirt_kmp_duplicate_macs{namespace='{{ .Namespace }}'} or vector(0))
           record: kubevirt_kubemacpool_duplicate_macs_total
@@ -45,6 +47,7 @@ spec:
             severity: warning
             kubernetes_operator_part_of: kubevirt
             kubernetes_operator_component: cluster-network-addons-operator
+            infra_alert: true
         # +help:summary="Total count of running KubeMacPool manager pods",type=Gauge
         - expr: sum(up{namespace='{{ .Namespace }}', pod=~'kubemacpool-mac-controller-manager-.*'} or vector(0))
           record: kubevirt_cnao_kubemacpool_manager_num_up_pods_total
@@ -61,3 +64,4 @@ spec:
             severity: critical
             kubernetes_operator_part_of: kubevirt
             kubernetes_operator_component: cluster-network-addons-operator
+            infra_alert: true

--- a/hack/prom-rule-ci/prom-rules-tests.yaml
+++ b/hack/prom-rule-ci/prom-rules-tests.yaml
@@ -23,6 +23,7 @@ tests:
               severity: "warning"
               kubernetes_operator_part_of: "kubevirt"
               kubernetes_operator_component: "cluster-network-addons-operator"
+              infra_alert: "true"
 # CnaoDown negative tests
   - interval: 1m
     input_series:
@@ -55,6 +56,7 @@ tests:
               severity: "warning"
               kubernetes_operator_part_of: "kubevirt"
               kubernetes_operator_component: "cluster-network-addons-operator"
+              infra_alert: "true"
 
 # NetworkAddonsConfigNotReady negative tests
   - interval: 1m
@@ -90,6 +92,7 @@ tests:
               severity: "warning"
               kubernetes_operator_part_of: "kubevirt"
               kubernetes_operator_component: "cluster-network-addons-operator"
+              infra_alert: "true"
 
 # KubeMacPoolDuplicateMacsFound negative tests
   - interval: 1m
@@ -123,6 +126,7 @@ tests:
               severity: "critical"
               kubernetes_operator_part_of: "kubevirt"
               kubernetes_operator_component: "cluster-network-addons-operator"
+              infra_alert: "true"
 
   # KubemacpoolDown negative tests
   - interval: 1m


### PR DESCRIPTION
This PR adds a boolean label to each of CNAO alerts, so that we can differentiate between alerts that are related to infrastructure, and alerts that are related to vmi. 
For more info, please see [#7796](https://github.com/kubevirt/kubevirt/pull/7796).

Signed-off-by: assafad [aadmi@redhat.com](mailto:aadmi@redhat.com)

```release-note
None
```
