### PR TITLE
[release-0.58] Pin bridge-marker to stable branch of 0.9.1

### DIFF
--- a/components.yaml
+++ b/components.yaml
@@ -1,10 +1,10 @@
 components:
   bridge-marker:
     url: https://github.com/kubevirt/bridge-marker
-    commit: 128c5ae6ad196e67d432d6afdfc73afa01c64b85
-    branch: main
+    commit: 7b0da824b960b022e9af1188b2fe52a5c66af7a6
+    branch: release-0.9.1
     update-policy: tagged
-    metadata: 0.9.2
+    metadata: 0.9.101
   kubemacpool:
     url: https://github.com/k8snetworkplumbingwg/kubemacpool
     commit: 6c156d1a14b618b6e06b382d919c73489139bb4b

--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -30,7 +30,7 @@ var (
 const (
 	MultusImageDefault            = "quay.io/kubevirt/cluster-network-addon-multus@sha256:32867c73cda4d605651b898dc85fea67d93191c47f27e1ad9e9f2b9041c518de"
 	LinuxBridgeCniImageDefault    = "quay.io/kubevirt/cni-default-plugins@sha256:b6906c6b4d783d0418db5ad7dad601129b7d99917edc7533999c960e6df828ec"
-	LinuxBridgeMarkerImageDefault = "quay.io/kubevirt/bridge-marker@sha256:6536d684834f1301941108fd4123a55df39c74234e442fad60a584b69cfe6069"
+	LinuxBridgeMarkerImageDefault = "quay.io/kubevirt/bridge-marker@sha256:109ee06aecc7bd2faba7e34bdc85123e6e132b5bdb1c41bc062749cb2af05548"
 	KubeMacPoolImageDefault       = "quay.io/kubevirt/kubemacpool@sha256:c575932475301d330a50162ca61808b5b55649556a892719687404506e901f79"
 	NMStateHandlerImageDefault    = "quay.io/nmstate/kubernetes-nmstate-handler@sha256:84b3df8fd8fe849a62521af4a5c0dff9cfde22d24de6d73696e8f25f1707dfa2"
 	OvsCniImageDefault            = "quay.io/kubevirt/ovs-cni-plugin@sha256:4b6b34f6271c66278b9e32295f3b221effc26e4ca94b6f51e0be720bed4dbc8b"

--- a/test/releases/99.0.0.go
+++ b/test/releases/99.0.0.go
@@ -18,7 +18,7 @@ func init() {
 				ParentName: "bridge-marker",
 				ParentKind: "DaemonSet",
 				Name:       "bridge-marker",
-				Image:      "quay.io/kubevirt/bridge-marker@sha256:6536d684834f1301941108fd4123a55df39c74234e442fad60a584b69cfe6069",
+				Image:      "quay.io/kubevirt/bridge-marker@sha256:109ee06aecc7bd2faba7e34bdc85123e6e132b5bdb1c41bc062749cb2af05548",
 			},
 			{
 				ParentName: "kube-cni-linux-bridge-plugin",


### PR DESCRIPTION
Signed-off-by: Petr Horáček <phoracek@redhat.com>

<!-- Thanks for sending a pull request!

Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the main branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it

If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**What this PR does / why we need it**:

Tag 0.9.2 was spoiled due to change in Go version dependency. This patch
pins marker back to 0.9.1 and sets the source branch to be stable
release-0.9.1.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
