### PR TITLE
WIP automation: Remove cluster-down as first operation

### DIFF
--- a/automation/check-patch.e2e-workflow-k8s.sh
+++ b/automation/check-patch.e2e-workflow-k8s.sh
@@ -19,7 +19,6 @@ main() {
     source automation/check-patch.setup.sh
     cd ${TMP_PROJECT_PATH}
 
-    make cluster-down
     make cluster-up
     trap teardown EXIT SIGINT SIGTERM SIGSTOP
     make cluster-operator-push


### PR DESCRIPTION
**What this PR does / why we need it**:

**Special notes for your reviewer**:

**Release note**:
```release-note
None
```
