### PR TITLE
[release-0.58] Remove nmcli 1.34 from cluster-up

### DIFF
--- a/cluster/cluster.sh
+++ b/cluster/cluster.sh
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 export KUBEVIRT_PROVIDER=${KUBEVIRT_PROVIDER:-'k8s-1.21'}
-export KUBEVIRTCI_TAG='2106301530-8ce1562'
+export KUBEVIRTCI_TAG='2205030954-99bd4d1'
 
 KUBEVIRTCI_REPO='https://github.com/kubevirt/kubevirtci.git'
 # The CLUSTER_PATH var is used in cluster folder and points to the _kubevirtci where the cluster is deployed from.

--- a/cluster/up.sh
+++ b/cluster/up.sh
@@ -36,7 +36,7 @@ if [[ "$KUBEVIRT_PROVIDER" =~ k8s- ]]; then
     echo 'Installing Open vSwitch on nodes'
     for node in $(./cluster/kubectl.sh get nodes --no-headers | awk '{print $1}'); do
         ./cluster/cli.sh ssh ${node} -- sudo dnf install -y centos-release-nfv-openvswitch
-        ./cluster/cli.sh ssh ${node} -- sudo dnf install -y openvswitch2.16 libibverbs NetworkManager-1.34.0 NetworkManager-ovs-1.34.0
+        ./cluster/cli.sh ssh ${node} -- sudo dnf install -y openvswitch2.16 libibverbs
         ./cluster/cli.sh ssh ${node} -- sudo systemctl daemon-reload
         ./cluster/cli.sh ssh ${node} -- sudo systemctl enable --now openvswitch
         ./cluster/cli.sh ssh ${node} -- sudo systemctl restart openvswitch


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes the issue where cluster up is broken on this stable branch
We do this by bumping to a more up to date kubevirtci tag, one that does not need a separate networkmanager installation.

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
