### PR TITLE
WIP Bump kubevirtci

### DIFF
--- a/automation/check-patch.e2e-ovs-cni-functests.sh
+++ b/automation/check-patch.e2e-ovs-cni-functests.sh
@@ -28,7 +28,7 @@ main() {
 
     # Run ovs-cni functional tests
     cd ${TMP_COMPONENT_PATH}
-    KUBECONFIG=${KUBECONFIG} E2E_TEST_ARGS="-ginkgo.v -test.v -ginkgo.noColor --junit-output=$ARTIFACTS/junit.functest.xml" make functest
+    KUBECONFIG=${KUBECONFIG} E2E_TEST_ARGS="-ginkgo.v -test.v -ginkgo.noColor -test.timeout 20m --junit-output=$ARTIFACTS/junit.functest.xml" make functest
 }
 
 [[ "${BASH_SOURCE[0]}" == "$0" ]] && main "$@"

--- a/cluster/cluster.sh
+++ b/cluster/cluster.sh
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 export KUBEVIRT_PROVIDER=${KUBEVIRT_PROVIDER:-'k8s-1.23'}
-export KUBEVIRTCI_TAG='2205030954-99bd4d1'
+export KUBEVIRTCI_TAG='2207060141-111fd50'
 
 KUBEVIRTCI_REPO='https://github.com/kubevirt/kubevirtci.git'
 # The CLUSTER_PATH var is used in cluster folder and points to the _kubevirtci where the cluster is deployed from.

--- a/components.yaml
+++ b/components.yaml
@@ -31,7 +31,7 @@ components:
     metadata: v3.9
   ovs-cni:
     url: https://github.com/k8snetworkplumbingwg/ovs-cni
-    commit: 3106dd64de405e309f1bd532e40e65489bdfe86e
+    commit: 0cc86e5eb965b96d3fcbd86eca6ca5f759b8ffc9
     branch: main
     update-policy: tagged
-    metadata: v0.27.0
+    metadata: v0.27.1

--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -33,8 +33,8 @@ const (
 	LinuxBridgeCniImageDefault    = "quay.io/kubevirt/cni-default-plugins@sha256:5d9442c26f8750d44f97175f36dbd74bef503f782b9adefcfd08215d065c437a"
 	LinuxBridgeMarkerImageDefault = "quay.io/kubevirt/bridge-marker@sha256:6536d684834f1301941108fd4123a55df39c74234e442fad60a584b69cfe6069"
 	KubeMacPoolImageDefault       = "quay.io/kubevirt/kubemacpool@sha256:47c6de03c9527b760bb26bd2db77a6caa14fcb822553c030b6ee595a92395977"
-	OvsCniImageDefault            = "quay.io/kubevirt/ovs-cni-plugin@sha256:e20d6669a146c392b03ab9c1546fb7a618faf3a7b080cea200ae9f27ee978a43"
-	OvsMarkerImageDefault         = "quay.io/kubevirt/ovs-cni-marker@sha256:a9923b7eb8040876c0ec190b00c20807354d9c1374981ccc8be2ecc3fe87406f"
+	OvsCniImageDefault            = "quay.io/kubevirt/ovs-cni-plugin@sha256:84807ded277c92fac93ceea24212d2b94c90667ea524392b84efebc71f2fbbb1"
+	OvsMarkerImageDefault         = "quay.io/kubevirt/ovs-cni-marker@sha256:d054b80712467205c162e442d53789b1c9691997f0c00360e576b706700e8a9b"
 	MacvtapCniImageDefault        = "quay.io/kubevirt/macvtap-cni@sha256:48e79c33cea4820c483ec460e7dc29a9d402292c4b509c1f800a80c227c282ea"
 	KubeRbacProxyImageDefault     = "quay.io/openshift/origin-kube-rbac-proxy@sha256:baedb268ac66456018fb30af395bb3d69af5fff3252ff5d549f0231b1ebb6901"
 )

--- a/test/releases/99.0.0.go
+++ b/test/releases/99.0.0.go
@@ -55,13 +55,13 @@ func init() {
 				ParentName: "ovs-cni-amd64",
 				ParentKind: "DaemonSet",
 				Name:       "ovs-cni-plugin",
-				Image:      "quay.io/kubevirt/ovs-cni-plugin@sha256:e20d6669a146c392b03ab9c1546fb7a618faf3a7b080cea200ae9f27ee978a43",
+				Image:      "quay.io/kubevirt/ovs-cni-plugin@sha256:84807ded277c92fac93ceea24212d2b94c90667ea524392b84efebc71f2fbbb1",
 			},
 			{
 				ParentName: "ovs-cni-amd64",
 				ParentKind: "DaemonSet",
 				Name:       "ovs-cni-marker",
-				Image:      "quay.io/kubevirt/ovs-cni-marker@sha256:a9923b7eb8040876c0ec190b00c20807354d9c1374981ccc8be2ecc3fe87406f",
+				Image:      "quay.io/kubevirt/ovs-cni-marker@sha256:d054b80712467205c162e442d53789b1c9691997f0c00360e576b706700e8a9b",
 			},
 		},
 		SupportedSpec: cnao.NetworkAddonsConfigSpec{


### PR DESCRIPTION
**What this PR does / why we need it**:
Bump kubevirtci in order to take latest podman changes
(support default root socket)

**Special notes for your reviewer**:

**Release note**:
```release-note
None
```
