### PR TITLE
deploy scripts: Use 127.0.0.1 instead localhost

### DIFF
--- a/automation/check-patch.e2e-ovs-cni-functests.sh
+++ b/automation/check-patch.e2e-ovs-cni-functests.sh
@@ -7,7 +7,7 @@
 # check-patch.packages installed and docker running.
 #
 # yum -y install automation/check-patch.packages
-# automation/check-patch.e2e-kubemacpool-functests.sh
+# automation/check-patch.e2e-ovs-cni-functests.sh
 
 teardown() {
     rm -rf "${TMP_COMPONENT_PATH}"

--- a/cluster/operator-push.sh
+++ b/cluster/operator-push.sh
@@ -25,7 +25,7 @@ if [[ "${KUBEVIRT_PROVIDER}" == external ]]; then
     push_registry=$manifest_registry
 else
     manifest_registry=registry:5000
-    push_registry=localhost:$(./cluster/cli.sh ports registry | tr -d '\r')
+    push_registry=127.0.0.1:$(./cluster/cli.sh ports registry | tr -d '\r')
 fi
 
 # Cleanup previously generated manifests

--- a/cluster/operator-push.sh
+++ b/cluster/operator-push.sh
@@ -25,11 +25,7 @@ if [[ "${KUBEVIRT_PROVIDER}" == external ]]; then
     push_registry=$manifest_registry
 else
     manifest_registry=registry:5000
-    if [[ "${KUBEVIRT_PROVIDER}" =~ ^(okd|ocp)-.*$ ]]; then \
-		push_registry=localhost:$(./cluster/cli.sh ports --container-name=cluster registry | tr -d '\r')
-    else
-        push_registry=localhost:$(./cluster/cli.sh ports registry | tr -d '\r')
-    fi
+    push_registry=localhost:$(./cluster/cli.sh ports registry | tr -d '\r')
 fi
 
 # Cleanup previously generated manifests

--- a/cluster/up.sh
+++ b/cluster/up.sh
@@ -27,13 +27,6 @@ cluster::install
 
 $(cluster::path)/cluster-up/up.sh
 
-if [[ "$KUBEVIRT_PROVIDER" =~ (ocp|okd)- ]]; then
-    echo 'Remove components we do not need to save some resources'
-    ./cluster/kubectl.sh delete ns openshift-monitoring --wait=false
-    ./cluster/kubectl.sh delete ns openshift-marketplace --wait=false
-    ./cluster/kubectl.sh delete ns openshift-cluster-samples-operator --wait=false
-fi
-
 if [[ "$KUBEVIRT_PROVIDER" =~ k8s- ]]; then
     echo 'Installing Open vSwitch'
     for node in $(./cluster/kubectl.sh get nodes --no-headers | awk '{print $1}'); do


### PR DESCRIPTION
**What this PR does / why we need it**:
For some reason pushing to localhost registry doesn't work.
It does work using 127.0.0.1
   
A possible reason is
https://bugzilla.redhat.com/show_bug.cgi?id=2038634
(investigated as part of https://github.com/kubevirt/kubevirt/pull/6958)

It started since https://github.com/kubevirt/project-infra/pull/1616
More details on
https://github.com/kubevirt/containerized-data-importer/pull/2113

Additional changes:
Remove deprecated kubevirtci providers support
Fix comment.

**Special notes for your reviewer**:

**Release note**:
```release-note
None
```
