### PR TITLE
e2e ovs: Increase timeout

### DIFF
--- a/automation/check-patch.e2e-ovs-cni-functests.sh
+++ b/automation/check-patch.e2e-ovs-cni-functests.sh
@@ -28,7 +28,7 @@ main() {
 
     # Run ovs-cni functional tests
     cd ${TMP_COMPONENT_PATH}
-    KUBECONFIG=${KUBECONFIG} E2E_TEST_ARGS="-ginkgo.v -test.v -ginkgo.noColor --junit-output=$ARTIFACTS/junit.functest.xml" make functest
+    KUBECONFIG=${KUBECONFIG} E2E_TEST_ARGS="-ginkgo.v -test.v -ginkgo.noColor -test.timeout 20m --junit-output=$ARTIFACTS/junit.functest.xml" make functest
 }
 
 [[ "${BASH_SOURCE[0]}" == "$0" ]] && main "$@"


### PR DESCRIPTION
**What this PR does / why we need it**:
Default is 10m which isn't enough.
Use 20m as OVS repo e2e tests are using.

**Special notes for your reviewer**:
This fixes the problem we saw after bumping ovs, but it isn't due to the bump
this problem exists even on clean main.

**Release note**:
```release-note
None
```
