### PR TITLE
kubevirtci: Fix bump script

### DIFF
--- a/hack/bump-kubevirtci.sh
+++ b/hack/bump-kubevirtci.sh
@@ -1,4 +1,8 @@
-#!/bin/bash
-val=$(git ls-remote https://github.com/kubevirt/kubevirtci | grep HEAD | awk '{print $1}')
-sed -i "/^[[:blank:]]*[KUBEVIRTCI_VERSION[:blank:]]*=/s/=.*/=\"${val}\"/" cluster/cluster.sh
-git --no-pager diff cluster/cluster.sh | grep KUBEVIRTCI_VERSION
+#!/bin/bash -e
+
+KUBEVIRTCI_TAG=$(curl -L -Ss https://storage.googleapis.com/kubevirt-prow/release/kubevirt/kubevirtci/latest)
+[[ ${#KUBEVIRTCI_TAG} != "18" ]] && echo "error getting KUBEVIRTCI_TAG" && exit 1
+
+sed -i "s/export KUBEVIRTCI_TAG=.*/export KUBEVIRTCI_TAG='${KUBEVIRTCI_TAG}'/g" cluster/cluster.sh
+
+git --no-pager diff cluster/cluster.sh | grep KUBEVIRTCI_TAG || true


### PR DESCRIPTION
**What this PR does / why we need it**:
It was outdated.

Fixed in a way that automation can use it:
In case fatal happens return error code.
In case all is good, determine if there was a change
according non empty stdout.

**Special notes for your reviewer**:

**Release note**:
```release-note
None
```
