### PR TITLE
operator: Adapt to k8s-1.25 security restrictions

### DIFF
--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -128,6 +128,7 @@ func NewRelatedImage(image string) RelatedImage {
 func GetDeployment(version string, operatorVersion string, namespace string, repository string, imageName string, tag string, imagePullPolicy string, addonsImages *AddonsImages) *appsv1.Deployment {
 	image := fmt.Sprintf("%s/%s:%s", repository, imageName, tag)
 	runAsNonRoot := true
+	allowPrivilegeEscalation := false
 
 	deployment := &appsv1.Deployment{
 		TypeMeta: metav1.TypeMeta{
@@ -168,6 +169,9 @@ func GetDeployment(version string, operatorVersion string, namespace string, rep
 					ServiceAccountName: Name,
 					SecurityContext: &corev1.PodSecurityContext{
 						RunAsNonRoot: &runAsNonRoot,
+						SeccompProfile: &corev1.SeccompProfile{
+							Type: corev1.SeccompProfileTypeRuntimeDefault,
+						},
 					},
 					PriorityClassName: "system-cluster-critical",
 					Containers: []corev1.Container{
@@ -263,6 +267,12 @@ func GetDeployment(version string, operatorVersion string, namespace string, rep
 									Value: "prometheus-k8s",
 								},
 							},
+							SecurityContext: &corev1.SecurityContext{
+								AllowPrivilegeEscalation: &allowPrivilegeEscalation,
+								Capabilities: &corev1.Capabilities{
+									Drop: []corev1.Capability{corev1.Capability("ALL")},
+								},
+							},
 						},
 						{
 							Name:            "kube-rbac-proxy",
@@ -287,6 +297,12 @@ func GetDeployment(version string, operatorVersion string, namespace string, rep
 								},
 							},
 							TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
+							SecurityContext: &corev1.SecurityContext{
+								AllowPrivilegeEscalation: &allowPrivilegeEscalation,
+								Capabilities: &corev1.Capabilities{
+									Drop: []corev1.Capability{corev1.Capability("ALL")},
+								},
+							},
 						},
 					},
 				},


### PR DESCRIPTION
**What this PR does / why we need it**:
When deployed at some clusters based on k8s 1.25 the operator get the following error 

```
Warning: would violate PodSecurity "restricted:latest": allowPrivilegeEscalation != false (containers "cluster-network-addons-operator", "kube-rbac-proxy" must set securityContext.allowPrivilegeEscalation=false), unrestricted capabilities (containers "cluster-network-addons-operator", "kube-rbac-proxy" must set securityContext.capabilities.drop=["ALL"]), seccompProfile (pod or containers "cluster-network-addons-operator", "kube-rbac-proxy" must set securityContext.seccompProfile.type to "RuntimeDefault" or "Localhost")
```

To fix that the pod and container security context for the operator is fixed following instructions at https://github.com/redhat-openshift-ecosystem/community-operators-prod/discussions/1417.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
Fix operator pod and container security context for k8s-1.25
```
