### PR TITLE
cluster deploy: Fix installing openvswitch

### DIFF
--- a/cluster/up.sh
+++ b/cluster/up.sh
@@ -30,6 +30,7 @@ $(cluster::path)/cluster-up/up.sh
 if [[ "$KUBEVIRT_PROVIDER" =~ k8s- ]]; then
     echo 'Installing Open vSwitch'
     for node in $(./cluster/kubectl.sh get nodes --no-headers | awk '{print $1}'); do
+        ./cluster/cli.sh ssh ${node} -- sudo dnf makecache --refresh
         ./cluster/cli.sh ssh ${node} -- sudo dnf install -y centos-release-nfv-openvswitch
         ./cluster/cli.sh ssh ${node} -- sudo dnf install -y openvswitch2.16 libibverbs
         ./cluster/cli.sh ssh ${node} -- sudo systemctl daemon-reload


### PR DESCRIPTION
**What this PR does / why we need it**:
Installing openvswitch failed because it couldn't
find a working mirror for centos-release-nfv-openvswitch.
Refreshing the dnf cache fixes this problem.

Note that installing centos-release-nfv-openvswitch
can be removed actually because it is already part of
kubevirtci, but this can be done on a follow commit.

**Special notes for your reviewer**:

**Release note**:
```release-note
None
```
