### PR TITLE
release-0.65, operator: Adapt to k8s-1.25 security restrictions

### DIFF
--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -128,6 +128,7 @@ func NewRelatedImage(image string) RelatedImage {
 func GetDeployment(version string, operatorVersion string, namespace string, repository string, imageName string, tag string, imagePullPolicy string, addonsImages *AddonsImages) *appsv1.Deployment {
 	image := fmt.Sprintf("%s/%s:%s", repository, imageName, tag)
 	runAsNonRoot := true
+	allowPrivilegeEscalation := false
 
 	deployment := &appsv1.Deployment{
 		TypeMeta: metav1.TypeMeta{
@@ -268,6 +269,12 @@ func GetDeployment(version string, operatorVersion string, namespace string, rep
 								{
 									Name:  "MONITORING_SERVICE_ACCOUNT",
 									Value: "prometheus-k8s",
+								},
+							},
+							SecurityContext: &corev1.SecurityContext{
+								AllowPrivilegeEscalation: &allowPrivilegeEscalation,
+								Capabilities: &corev1.Capabilities{
+									Drop: []corev1.Capability{corev1.Capability("ALL")},
 								},
 							},
 						},


### PR DESCRIPTION
Signed-off-by: Enrique Llorente <ellorent@redhat.com>

<!-- Thanks for sending a pull request!

Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the main branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it

If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**What this PR does / why we need it**:
Cherry pick from https://github.com/kubevirt/cluster-network-addons-operator/pull/1401

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
Fix operator pod and container security context for k8s-1.25
```
