### PR TITLE
Bump OVS CNI to 0.29.1 and adapt to OVS CNI based on a single image

### DIFF
--- a/components.yaml
+++ b/components.yaml
@@ -31,7 +31,7 @@ components:
     metadata: v3.9.1
   ovs-cni:
     url: https://github.com/k8snetworkplumbingwg/ovs-cni
-    commit: 2fa991b4d95bf0c3053361afbfdaf36fd1948fa2
+    commit: 05da205a682694307d1df78fdeccde1321f563f6
     branch: main
     update-policy: tagged
-    metadata: v0.28.0
+    metadata: v0.29.1

--- a/data/ovs/001-ovs-cni.yaml
+++ b/data/ovs/001-ovs-cni.yaml
@@ -30,7 +30,11 @@ spec:
       initContainers:
         - name: ovs-cni-plugin
           image: {{ .OvsCNIImage }}
-          command: ["cp", "/ovs", "/host{{ .CNIBinDir }}/ovs"]
+          command: ["/bin/sh", "-c"]
+          args:
+            - >
+              cp /ovs /host/opt/cni/bin/ovs && cp /ovs-mirror-producer /host/opt/cni/bin/ovs-mirror-producer && cp /ovs-mirror-consumer /host/opt/cni/bin/ovs-mirror-consumer
+
           imagePullPolicy: {{ .ImagePullPolicy }}
           securityContext:
             privileged: true
@@ -40,41 +44,20 @@ spec:
               memory: "15Mi"
           volumeMounts:
             - name: cnibin
-              mountPath: /host{{ .CNIBinDir }}
-        - name: ovs-mirror-producer
-          image: {{ .OvsCNIMirrorProducerImage }}
-          command: ["cp", "/ovs-mirror-producer", "/host{{ .CNIBinDir }}/ovs-mirror-producer"]
-          imagePullPolicy: {{ .ImagePullPolicy }}
-          securityContext:
-            privileged: true
-          resources:
-            requests:
-              cpu: "10m"
-              memory: "15Mi"
-          volumeMounts:
-            - name: cnibin
-              mountPath: /host{{ .CNIBinDir }}
-        - name: ovs-mirror-consumer
-          image: {{ .OvsCNIMirrorConsumerImage }}
-          command: ["cp", "/ovs-mirror-consumer", "/host{{ .CNIBinDir }}/ovs-mirror-consumer"]
-          imagePullPolicy: {{ .ImagePullPolicy }}
-          securityContext:
-            privileged: true
-          resources:
-            requests:
-              cpu: "10m"
-              memory: "15Mi"
-          volumeMounts:
-            - name: cnibin
-              mountPath: /host{{ .CNIBinDir }}
+              mountPath: /host/opt/cni/bin
       priorityClassName: system-node-critical
       containers:
         - name: ovs-cni-marker
-          image: {{ .OvsMarkerImage }}
+          image: {{ .OvsCNIImage }}
           imagePullPolicy: {{ .ImagePullPolicy }}
           securityContext:
             privileged: true
+          command:
+            - /marker
           args:
+            - -v
+            - "3"
+            - -logtostderr
             - -node-name
             - $(NODE_NAME)
             - -ovs-socket

--- a/hack/components/bump-ovs-cni.sh
+++ b/hack/components/bump-ovs-cni.sh
@@ -21,18 +21,9 @@ function __parametize_by_object() {
 			./DaemonSet_ovs-cni-amd64.yaml)
 				yaml-utils::update_param ${f} metadata.namespace  '{{ .Namespace }}'
 				yaml-utils::update_param ${f} spec.template.spec.initContainers[0].image  '{{ .OvsCNIImage }}'
-				yaml-utils::update_param ${f} spec.template.spec.initContainers[0].command  '["cp", "/ovs", "/host{{ .CNIBinDir }}/ovs"]'
 				yaml-utils::update_param ${f} spec.template.spec.initContainers[0].imagePullPolicy  '{{ .ImagePullPolicy }}'
-				yaml-utils::update_param ${f} spec.template.spec.initContainers[0].volumeMounts[0].mountPath  '/host{{ .CNIBinDir }}'
-				yaml-utils::update_param ${f} spec.template.spec.initContainers[1].image  '{{ .OvsCNIMirrorProducerImage }}'
-				yaml-utils::update_param ${f} spec.template.spec.initContainers[1].command  '["cp", "/ovs-mirror-producer", "/host{{ .CNIBinDir }}/ovs-mirror-producer"]'
-				yaml-utils::update_param ${f} spec.template.spec.initContainers[1].imagePullPolicy  '{{ .ImagePullPolicy }}'
-				yaml-utils::update_param ${f} spec.template.spec.initContainers[1].volumeMounts[0].mountPath  '/host{{ .CNIBinDir }}'
-				yaml-utils::update_param ${f} spec.template.spec.initContainers[2].image  '{{ .OvsCNIMirrorConsumerImage }}'
-				yaml-utils::update_param ${f} spec.template.spec.initContainers[2].command  '["cp", "/ovs-mirror-consumer", "/host{{ .CNIBinDir }}/ovs-mirror-consumer"]'
-				yaml-utils::update_param ${f} spec.template.spec.initContainers[2].imagePullPolicy  '{{ .ImagePullPolicy }}'
-				yaml-utils::update_param ${f} spec.template.spec.initContainers[2].volumeMounts[0].mountPath  '/host{{ .CNIBinDir }}'
-				yaml-utils::update_param ${f} spec.template.spec.containers[0].image  '{{ .OvsMarkerImage }}'
+				yaml-utils::update_param ${f} spec.template.spec.initContainers[0].volumeMounts[0].mountPath  '/host/opt/cni/bin'
+				yaml-utils::update_param ${f} spec.template.spec.containers[0].image  '{{ .OvsCNIImage }}'
 				yaml-utils::update_param ${f} spec.template.spec.containers[0].imagePullPolicy  '{{ .ImagePullPolicy }}'
 				yaml-utils::update_param ${f} spec.template.spec.volumes[0].hostPath.path  '{{ .CNIBinDir }}'
 				yaml-utils::update_param ${f} spec.template.spec.nodeSelector '{{ toYaml .Placement.NodeSelector | nindent 8 }}'
@@ -123,27 +114,3 @@ OVS_PLUGIN_IMAGE_DIGEST="$(docker-utils::get_image_digest "${OVS_PLUGIN_IMAGE_TA
 
 sed -i -r "s#\"${OVS_PLUGIN_IMAGE}(@sha256)?:.*\"#\"${OVS_PLUGIN_IMAGE_DIGEST}\"#" pkg/components/components.go
 sed -i -r "s#\"${OVS_PLUGIN_IMAGE}(@sha256)?:.*\"#\"${OVS_PLUGIN_IMAGE_DIGEST}\"#" test/releases/${CNAO_VERSION}.go
-
-echo 'Get ovs-cni-mirror-producer image name and update it under CNAO'
-OVS_CNI_MIRROR_PRODUCER_IMAGE=quay.io/kubevirt/ovs-cni-mirror-producer
-OVS_CNI_MIRROR_PRODUCER_IMAGE_TAGGED=${OVS_CNI_MIRROR_PRODUCER_IMAGE}:${OVS_TAG}
-OVS_CNI_MIRROR_PRODUCER_IMAGE_DIGEST="$(docker-utils::get_image_digest "${OVS_CNI_MIRROR_PRODUCER_IMAGE_TAGGED}" "${OVS_CNI_MIRROR_PRODUCER_IMAGE}")"
-
-sed -i -r "s#\"${OVS_CNI_MIRROR_PRODUCER_IMAGE}(@sha256)?:.*\"#\"${OVS_CNI_MIRROR_PRODUCER_IMAGE_DIGEST}\"#" pkg/components/components.go
-sed -i -r "s#\"${OVS_CNI_MIRROR_PRODUCER_IMAGE}(@sha256)?:.*\"#\"${OVS_CNI_MIRROR_PRODUCER_IMAGE_DIGEST}\"#" test/releases/${CNAO_VERSION}.go
-
-echo 'Get ovs-cni-mirror-consumer image name and update it under CNAO'
-OVS_CNI_MIRROR_CONSUMER_IMAGE=quay.io/kubevirt/ovs-cni-mirror-consumer
-OVS_CNI_MIRROR_CONSUMER_IMAGE_TAGGED=${OVS_CNI_MIRROR_CONSUMER_IMAGE}:${OVS_TAG}
-OVS_CNI_MIRROR_CONSUMER_IMAGE_DIGEST="$(docker-utils::get_image_digest "${OVS_CNI_MIRROR_CONSUMER_IMAGE_TAGGED}" "${OVS_CNI_MIRROR_CONSUMER_IMAGE}")"
-
-sed -i -r "s#\"${OVS_CNI_MIRROR_CONSUMER_IMAGE}(@sha256)?:.*\"#\"${OVS_CNI_MIRROR_CONSUMER_IMAGE_DIGEST}\"#" pkg/components/components.go
-sed -i -r "s#\"${OVS_CNI_MIRROR_CONSUMER_IMAGE}(@sha256)?:.*\"#\"${OVS_CNI_MIRROR_CONSUMER_IMAGE_DIGEST}\"#" test/releases/${CNAO_VERSION}.go
-
-echo 'Get ovs-cni-marker image name and update it under CNAO'
-OVS_MARKER_IMAGE=quay.io/kubevirt/ovs-cni-marker
-OVS_MARKER_IMAGE_TAGGED=${OVS_MARKER_IMAGE}:${OVS_TAG}
-OVS_MARKER_IMAGE_DIGEST="$(docker-utils::get_image_digest "${OVS_MARKER_IMAGE_TAGGED}" "${OVS_MARKER_IMAGE}")"
-
-sed -i -r "s#\"${OVS_MARKER_IMAGE}(@sha256)?:.*\"#\"${OVS_MARKER_IMAGE_DIGEST}\"#" pkg/components/components.go
-sed -i -r "s#\"${OVS_MARKER_IMAGE}(@sha256)?:.*\"#\"${OVS_MARKER_IMAGE_DIGEST}\"#" test/releases/${CNAO_VERSION}.go

--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -29,29 +29,23 @@ var (
 )
 
 const (
-	MultusImageDefault               = "ghcr.io/k8snetworkplumbingwg/multus-cni@sha256:829c27e9392d013eee5086ca7670d7326d723ebaec526237215e86086b5a3234"
-	LinuxBridgeCniImageDefault       = "quay.io/kubevirt/cni-default-plugins@sha256:5d9442c26f8750d44f97175f36dbd74bef503f782b9adefcfd08215d065c437a"
-	LinuxBridgeMarkerImageDefault    = "quay.io/kubevirt/bridge-marker@sha256:5d24c6d1ecb0556896b7b81c7e5260b54173858425777b7a84df8a706c07e6d2"
-	KubeMacPoolImageDefault          = "quay.io/kubevirt/kubemacpool@sha256:fb07b1be9e0990e3846ef628e993694bf0765602af5907abf98f7e218db0cb4a"
-	OvsCniImageDefault               = "quay.io/kubevirt/ovs-cni-plugin@sha256:4a914963def39ce39fbdad3701e55e6e5ca602305ddf39f7eae4a4b3d215044d"
-	OvsCniMirrorProducerImageDefault = "quay.io/kubevirt/ovs-cni-mirror-producer@sha256:9b1e368adc2c55485d25debfdf69794da81b9d718d5ded560fcc2d5a4c602c6b"
-	OvsCniMirrorConsumerImageDefault = "quay.io/kubevirt/ovs-cni-mirror-consumer@sha256:350b2a4bb48c4d77a611246b017afa135134e9ca7ea45db06ae943526a6b03df"
-	OvsMarkerImageDefault            = "quay.io/kubevirt/ovs-cni-marker@sha256:e94ef06ec14c0e8fb47f216e8f2f606bad5d7388295f1ecdf333efd56be3825f"
-	MacvtapCniImageDefault           = "quay.io/kubevirt/macvtap-cni@sha256:48e79c33cea4820c483ec460e7dc29a9d402292c4b509c1f800a80c227c282ea"
-	KubeRbacProxyImageDefault        = "quay.io/openshift/origin-kube-rbac-proxy@sha256:baedb268ac66456018fb30af395bb3d69af5fff3252ff5d549f0231b1ebb6901"
+	MultusImageDefault            = "ghcr.io/k8snetworkplumbingwg/multus-cni@sha256:829c27e9392d013eee5086ca7670d7326d723ebaec526237215e86086b5a3234"
+	LinuxBridgeCniImageDefault    = "quay.io/kubevirt/cni-default-plugins@sha256:5d9442c26f8750d44f97175f36dbd74bef503f782b9adefcfd08215d065c437a"
+	LinuxBridgeMarkerImageDefault = "quay.io/kubevirt/bridge-marker@sha256:5d24c6d1ecb0556896b7b81c7e5260b54173858425777b7a84df8a706c07e6d2"
+	KubeMacPoolImageDefault       = "quay.io/kubevirt/kubemacpool@sha256:fb07b1be9e0990e3846ef628e993694bf0765602af5907abf98f7e218db0cb4a"
+	OvsCniImageDefault            = "quay.io/kubevirt/ovs-cni-plugin@sha256:3654b80dd5e459c3e73dd027d732620ed8b488b8a15dfe7922457d16c7e834c3"
+	MacvtapCniImageDefault        = "quay.io/kubevirt/macvtap-cni@sha256:48e79c33cea4820c483ec460e7dc29a9d402292c4b509c1f800a80c227c282ea"
+	KubeRbacProxyImageDefault     = "quay.io/openshift/origin-kube-rbac-proxy@sha256:baedb268ac66456018fb30af395bb3d69af5fff3252ff5d549f0231b1ebb6901"
 )
 
 type AddonsImages struct {
-	Multus               string
-	LinuxBridgeCni       string
-	LinuxBridgeMarker    string
-	KubeMacPool          string
-	OvsCni               string
-	OvsCniMirrorProducer string
-	OvsCniMirrorConsumer string
-	OvsMarker            string
-	MacvtapCni           string
-	KubeRbacProxy        string
+	Multus            string
+	LinuxBridgeCni    string
+	LinuxBridgeMarker string
+	KubeMacPool       string
+	OvsCni            string
+	MacvtapCni        string
+	KubeRbacProxy     string
 }
 
 type RelatedImage struct {
@@ -91,15 +85,6 @@ func (ai *AddonsImages) FillDefaults() *AddonsImages {
 	if ai.OvsCni == "" {
 		ai.OvsCni = OvsCniImageDefault
 	}
-	if ai.OvsCniMirrorProducer == "" {
-		ai.OvsCniMirrorProducer = OvsCniMirrorProducerImageDefault
-	}
-	if ai.OvsCniMirrorConsumer == "" {
-		ai.OvsCniMirrorConsumer = OvsCniMirrorConsumerImageDefault
-	}
-	if ai.OvsMarker == "" {
-		ai.OvsMarker = OvsMarkerImageDefault
-	}
 	if ai.MacvtapCni == "" {
 		ai.MacvtapCni = MacvtapCniImageDefault
 	}
@@ -116,9 +101,6 @@ func (ai AddonsImages) ToRelatedImages() RelatedImages {
 		ai.LinuxBridgeMarker,
 		ai.KubeMacPool,
 		ai.OvsCni,
-		ai.OvsCniMirrorProducer,
-		ai.OvsCniMirrorConsumer,
-		ai.OvsMarker,
 		ai.MacvtapCni,
 		ai.KubeRbacProxy,
 	)
@@ -213,18 +195,6 @@ func GetDeployment(version string, operatorVersion string, namespace string, rep
 								{
 									Name:  "OVS_CNI_IMAGE",
 									Value: addonsImages.OvsCni,
-								},
-								{
-									Name:  "OVS_CNI_MIRROR_PRODUCER_IMAGE",
-									Value: addonsImages.OvsCniMirrorProducer,
-								},
-								{
-									Name:  "OVS_CNI_MIRROR_CONSUMER_IMAGE",
-									Value: addonsImages.OvsCniMirrorConsumer,
-								},
-								{
-									Name:  "OVS_MARKER_IMAGE",
-									Value: addonsImages.OvsMarker,
 								},
 								{
 									Name:  "KUBEMACPOOL_IMAGE",

--- a/pkg/network/ovs.go
+++ b/pkg/network/ovs.go
@@ -22,10 +22,6 @@ func renderOvs(conf *cnao.NetworkAddonsConfigSpec, manifestDir string, clusterIn
 	data := render.MakeRenderData()
 	data.Data["Namespace"] = os.Getenv("OPERAND_NAMESPACE")
 	data.Data["OvsCNIImage"] = os.Getenv("OVS_CNI_IMAGE")
-	data.Data["OvsMarkerImage"] = os.Getenv("OVS_MARKER_IMAGE")
-	data.Data["OvsImage"] = os.Getenv("OVS_IMAGE")
-	data.Data["OvsCNIMirrorProducerImage"] = os.Getenv("OVS_CNI_MIRROR_PRODUCER_IMAGE")
-	data.Data["OvsCNIMirrorConsumerImage"] = os.Getenv("OVS_CNI_MIRROR_CONSUMER_IMAGE")
 	data.Data["ImagePullPolicy"] = conf.ImagePullPolicy
 	data.Data["Placement"] = conf.PlacementConfiguration.Workloads
 	if clusterInfo.OpenShift4 {

--- a/test/releases/99.0.0.go
+++ b/test/releases/99.0.0.go
@@ -55,25 +55,13 @@ func init() {
 				ParentName: "ovs-cni-amd64",
 				ParentKind: "DaemonSet",
 				Name:       "ovs-cni-plugin",
-				Image:      "quay.io/kubevirt/ovs-cni-plugin@sha256:4a914963def39ce39fbdad3701e55e6e5ca602305ddf39f7eae4a4b3d215044d",
-			},
-			{
-				ParentName: "ovs-cni-amd64",
-				ParentKind: "DaemonSet",
-				Name:       "ovs-mirror-producer",
-				Image:      "quay.io/kubevirt/ovs-cni-mirror-producer@sha256:9b1e368adc2c55485d25debfdf69794da81b9d718d5ded560fcc2d5a4c602c6b",
-			},
-			{
-				ParentName: "ovs-cni-amd64",
-				ParentKind: "DaemonSet",
-				Name:       "ovs-mirror-consumer",
-				Image:      "quay.io/kubevirt/ovs-cni-mirror-consumer@sha256:350b2a4bb48c4d77a611246b017afa135134e9ca7ea45db06ae943526a6b03df",
+				Image:      "quay.io/kubevirt/ovs-cni-plugin@sha256:3654b80dd5e459c3e73dd027d732620ed8b488b8a15dfe7922457d16c7e834c3",
 			},
 			{
 				ParentName: "ovs-cni-amd64",
 				ParentKind: "DaemonSet",
 				Name:       "ovs-cni-marker",
-				Image:      "quay.io/kubevirt/ovs-cni-marker@sha256:e94ef06ec14c0e8fb47f216e8f2f606bad5d7388295f1ecdf333efd56be3825f",
+				Image:      "quay.io/kubevirt/ovs-cni-plugin@sha256:3654b80dd5e459c3e73dd027d732620ed8b488b8a15dfe7922457d16c7e834c3",
 			},
 		},
 		SupportedSpec: cnao.NetworkAddonsConfigSpec{

--- a/tools/manifest-templator/manifest-templator.go
+++ b/tools/manifest-templator/manifest-templator.go
@@ -245,7 +245,6 @@ func main() {
 	linuxBridgeMarkerImage := flag.String("linux-bridge-marker-image", components.LinuxBridgeMarkerImageDefault, "The linux bridge marker image managed by CNA")
 	kubeMacPoolImage := flag.String("kubemacpool-image", components.KubeMacPoolImageDefault, "The kubemacpool-image managed by CNA")
 	ovsCniImage := flag.String("ovs-cni-image", components.OvsCniImageDefault, "The ovs cni image managed by CNA")
-	ovsMarkerImage := flag.String("ovs-marker-image", components.OvsMarkerImageDefault, "The ovs marker image managed by CNA")
 	macvtapCniImage := flag.String("macvtap-cni-image", components.MacvtapCniImageDefault, "The macvtap cni image managed by CNA")
 	kubeRbacProxyImage := flag.String("kube-rbac-proxy-image", components.KubeRbacProxyImageDefault, "The kube rbac proxy used by CNA")
 	dumpOperatorCRD := flag.Bool("dump-crds", false, "Append operator CRD to bottom of template. Used for csv-generator")
@@ -269,7 +268,6 @@ func main() {
 			LinuxBridgeMarker: *linuxBridgeMarkerImage,
 			KubeMacPool:       *kubeMacPoolImage,
 			OvsCni:            *ovsCniImage,
-			OvsMarker:         *ovsMarkerImage,
 			MacvtapCni:        *macvtapCniImage,
 			KubeRbacProxy:     *kubeRbacProxyImage,
 		}).FillDefaults(),


### PR DESCRIPTION


<!-- Thanks for sending a pull request!

Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the main branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it

If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**What this PR does / why we need it**:

Since https://github.com/k8snetworkplumbingwg/ovs-cni/pull/244 OVS CNI is shipping all its binaries in a single container image and deploying all CNI plugins via a single init container.

This PR adapts to that change.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
