### PR TITLE
release-notes: Ping the tool to v0.13.0

### DIFF
--- a/hack/render-release-notes.sh
+++ b/hack/render-release-notes.sh
@@ -11,7 +11,7 @@ end() {
 
 trap end EXIT SIGINT SIGTERM SIGSTOP
 
-GOFLAGS=-mod=readonly go install k8s.io/release/cmd/release-notes@latest
+GOFLAGS=-mod=readonly go install k8s.io/release/cmd/release-notes@v0.13.0
 release-notes \
     --list-v2 \
     --go-template go-template:$script_dir/release-notes.tmpl \


### PR DESCRIPTION
**What this PR does / why we need it**:
Latest releas-notes tool is using golang 1.19 and is using new golang features so the tool does not compile with go1.17 from CNAO project. This change pin it to latest go1.17 version v0.13.0.

```release-note
NONE
```
