### PR TITLE
Stop automatic bumps of components

### DIFF
--- a/components.yaml
+++ b/components.yaml
@@ -3,13 +3,13 @@ components:
     url: https://github.com/kubevirt/bridge-marker
     commit: 965fe62eb9c1c3f076f04c0e9a694c49e2066925
     branch: main
-    update-policy: tagged
+    update-policy: static
     metadata: 0.10.0
   kubemacpool:
     url: https://github.com/k8snetworkplumbingwg/kubemacpool
     commit: 3bf23d1c50844d6e845f93529cd0fee3c82c869a
     branch: main
-    update-policy: tagged
+    update-policy: static
     metadata: v0.39.0
   linux-bridge:
     url: https://github.com/containernetworking/plugins
@@ -21,17 +21,17 @@ components:
     url: https://github.com/kubevirt/macvtap-cni
     commit: 7b0f08ba3b0b10ff45ab538a247afedf25d2eb14
     branch: main
-    update-policy: tagged
+    update-policy: static
     metadata: v0.9.0
   multus:
     url: https://github.com/k8snetworkplumbingwg/multus-cni
     commit: f4c0adf54c99d7395d30a050a8d29b674b99d700
     branch: master
-    update-policy: tagged
+    update-policy: static
     metadata: v3.9.1
   ovs-cni:
     url: https://github.com/k8snetworkplumbingwg/ovs-cni
     commit: 05da205a682694307d1df78fdeccde1321f563f6
     branch: main
-    update-policy: tagged
+    update-policy: static
     metadata: v0.29.1


### PR DESCRIPTION


Signed-off-by: Petr Horáček <phoracek@redhat.com>

<!-- Thanks for sending a pull request!

Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the main branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it

If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**What this PR does / why we need it**:

We don't want to merge a new major release of a component by mistake. The policy can be set back to tagged only once stable branches are created on these components.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
