### PR TITLE
multus: bump to multus-v4 (thick plugin)

### DIFF
--- a/automation/check-patch.e2e-multus-functests.sh
+++ b/automation/check-patch.e2e-multus-functests.sh
@@ -37,13 +37,20 @@ function __prepare-test-environment() {
 
     echo "Deploy cni-plugins pod"
     CNI_PLUGIN_YAML="cni-install.yml"
+    cp "templates/${CNI_PLUGIN_YAML}.j2" ${CNI_PLUGIN_YAML}
     $KUBECTL create -f ${CNI_PLUGIN_YAML}
     $KUBECTL -n kube-system wait --for=condition=ready -l name=cni-plugins pod --timeout=300s
 
-    TEST_YAML="*macvlan1.yml"
+    mkdir -p yamls
+    TEST_YAML="simple-macvlan1.yml"
     # matching the test nodes to the CNAO cluster nodes
-    sed -i 's/kind-worker$/node01/g' ${TEST_YAML}
-    sed -i 's/kind-worker2$/node02/g' ${TEST_YAML}
+    sed 's/{{ CNI_VERSION }}/0.4.0/g' "templates/${TEST_YAML}.j2" > "yamls/${TEST_YAML}"
+    sed -i 's/kind-worker$/node01/g' "yamls/${TEST_YAML}"
+    sed -i 's/kind-worker2$/node02/g' "yamls/${TEST_YAML}"
+
+    TEST_YAML="default-route1.yml"
+    # matching the test nodes to the CNAO cluster nodes
+    sed 's/{{ CNI_VERSION }}/0.4.0/g' "templates/${TEST_YAML}.j2" > "yamls/${TEST_YAML}"
 
     echo "Deplopy kubernetes-nmstate"
     $KUBECTL apply -f https://github.com/nmstate/kubernetes-nmstate/releases/download/v0.64.7/nmstate.io_nmstates.yaml

--- a/components.yaml
+++ b/components.yaml
@@ -25,10 +25,10 @@ components:
     metadata: v0.10.1
   multus:
     url: https://github.com/k8snetworkplumbingwg/multus-cni
-    commit: f4c0adf54c99d7395d30a050a8d29b674b99d700
+    commit: f530d3eb84608fa25a59737bcf49991d4a037d82
     branch: master
     update-policy: tagged
-    metadata: v3.9.1
+    metadata: v4.0.0-alpha
   ovs-cni:
     url: https://github.com/k8snetworkplumbingwg/ovs-cni
     commit: 05da205a682694307d1df78fdeccde1321f563f6

--- a/components.yaml
+++ b/components.yaml
@@ -25,7 +25,7 @@ components:
     metadata: v0.10.1
   multus:
     url: https://github.com/k8snetworkplumbingwg/multus-cni
-    commit: f530d3eb84608fa25a59737bcf49991d4a037d82
+    commit: fa8a6e688081ba5a097998f42b3f7dddb94dbed4
     branch: master
     update-policy: tagged
     metadata: v4.0.0-alpha

--- a/data/multus/001-multus.yaml
+++ b/data/multus/001-multus.yaml
@@ -11,7 +11,7 @@ spec:
     singular: network-attachment-definition
     kind: NetworkAttachmentDefinition
     shortNames:
-    - net-attach-def
+      - net-attach-def
   versions:
     - name: v1
       served: true
@@ -91,6 +91,27 @@ metadata:
   name: multus
   namespace: {{ .Namespace }}
 ---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: multus-daemon-config
+  namespace: '{{ .Namespace }}'
+  labels:
+    tier: node
+    app: multus
+data:
+  daemon-config.json: |
+    {
+        "chrootDir": "/hostroot",
+        "confDir": "/host/etc/cni/net.d",
+        "logToStderr": true,
+        "logLevel": "debug",
+        "logFile": "/tmp/multus.log",
+        "binDir": "/opt/cni/bin",
+        "cniDir": "/var/lib/cni/multus",
+        "socketDir": "/host/run/multus/"
+    }
+---
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -114,15 +135,19 @@ spec:
         name: kube-multus-ds-amd64
     spec:
       hostNetwork: true
+      hostPID: true
       tolerations: {{ toYaml .Placement.Tolerations | nindent 8 }}
       serviceAccountName: multus
       containers:
         - name: kube-multus
           image: {{ .MultusImage }}
-          command: ["/entrypoint.sh"]
+          command: ["/usr/src/multus-cni/bin/multus-daemon"]
           args:
-            - "--multus-conf-file=auto"
-            - "--cni-version=0.3.1"
+            - "-cni-version=0.3.1"
+            - "-cni-config-dir=/host/etc/cni/net.d"
+            - "-multus-autoconfig-dir=/host/etc/cni/net.d"
+            - "-multus-log-to-stderr=true"
+            - "-multus-log-level=verbose"
           resources:
             requests:
               cpu: "10m"
@@ -132,10 +157,23 @@ spec:
           volumeMounts:
             - name: cni
               mountPath: /host/etc/cni/net.d
-            - name: cnibin
-              mountPath: /host/opt/cni/bin
-            - name: cnicache
-              mountPath: /host/var/lib/cni
+            - name: host-run
+              mountPath: /host/run
+            - name: host-var-lib-cni-multus
+              mountPath: /var/lib/cni/multus
+            - name: host-var-lib-kubelet
+              mountPath: /var/lib/kubelet
+            - name: host-run-k8s-cni-cncf-io
+              mountPath: /run/k8s.cni.cncf.io
+            - name: host-run-netns
+              mountPath: /run/netns
+              mountPropagation: HostToContainer
+            - name: multus-daemon-config
+              mountPath: /etc/cni/net.d/multus.d
+              readOnly: true
+            - name: hostroot
+              mountPath: /hostroot
+              mountPropagation: HostToContainer
           imagePullPolicy: {{ .ImagePullPolicy }}
           lifecycle:
             preStop:
@@ -146,8 +184,8 @@ spec:
           image: {{ .MultusImage }}
           command:
             - "cp"
-            - "/usr/src/multus-cni/bin/multus"
-            - "/host/opt/cni/bin/multus"
+            - "/usr/src/multus-cni/bin/multus-shim"
+            - "/host/opt/cni/bin/multus-shim"
           resources:
             requests:
               cpu: "10m"
@@ -166,9 +204,30 @@ spec:
         - name: cnibin
           hostPath:
             path: {{ .CNIBinDir }}
-        - name: cnicache
+        - name: hostroot
           hostPath:
-            path: /var/lib/cni
+            path: /
+        - name: multus-daemon-config
+          configMap:
+            name: multus-daemon-config
+            items:
+              - key: daemon-config.json
+                path: daemon-config.json
+        - name: host-run
+          hostPath:
+            path: /run
+        - name: host-var-lib-cni-multus
+          hostPath:
+            path: /var/lib/cni/multus
+        - name: host-var-lib-kubelet
+          hostPath:
+            path: /var/lib/kubelet
+        - name: host-run-k8s-cni-cncf-io
+          hostPath:
+            path: /run/k8s.cni.cncf.io
+        - name: host-run-netns
+          hostPath:
+            path: /run/netns/
       priorityClassName: system-cluster-critical
       nodeSelector: {{ toYaml .Placement.NodeSelector | nindent 8 }}
       affinity: {{ toYaml .Placement.Affinity | nindent 8 }}

--- a/hack/components/bump-multus.sh
+++ b/hack/components/bump-multus.sh
@@ -125,7 +125,9 @@ cp ${MULTUS_PATH}/config/cnao/001-multus.yaml data/multus/
 echo 'Get multus image name'
 MULTUS_TAG=$(git-utils::get_component_tag ${MULTUS_PATH})
 MULTUS_IMAGE=ghcr.io/k8snetworkplumbingwg/multus-cni
-MULTUS_IMAGE_TAGGED=${MULTUS_IMAGE}:${MULTUS_TAG}-thick
+# TODO: do not use this hardcoded image, and rely on tagged versions instead.
+# had to resort to this shenanigan because of https://github.com/k8snetworkplumbingwg/multus-cni/issues/944
+MULTUS_IMAGE_TAGGED=${MULTUS_IMAGE}@sha256:09a572e8bdf8a398db024ca252d06cf3ac0a03e07ae547d6a84221d4f6a9f96f
 if [[ -n "$(docker-utils::check_image_exists "${MULTUS_IMAGE}" "${MULTUS_TAG}")" ]]; then
     MULTUS_IMAGE_DIGEST="$(docker-utils::get_image_digest "${MULTUS_IMAGE_TAGGED}" "${MULTUS_IMAGE}")"
 else

--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -29,7 +29,7 @@ var (
 )
 
 const (
-	MultusImageDefault            = "ghcr.io/k8snetworkplumbingwg/multus-cni@sha256:1c909e4d03006a7c1acde5e0953cd607db0dd34fca680cab3dc9fcfc29ff9174"
+	MultusImageDefault            = "ghcr.io/k8snetworkplumbingwg/multus-cni@sha256:09a572e8bdf8a398db024ca252d06cf3ac0a03e07ae547d6a84221d4f6a9f96f"
 	LinuxBridgeCniImageDefault    = "quay.io/kubevirt/cni-default-plugins@sha256:5d9442c26f8750d44f97175f36dbd74bef503f782b9adefcfd08215d065c437a"
 	LinuxBridgeMarkerImageDefault = "quay.io/kubevirt/bridge-marker@sha256:5d24c6d1ecb0556896b7b81c7e5260b54173858425777b7a84df8a706c07e6d2"
 	KubeMacPoolImageDefault       = "quay.io/kubevirt/kubemacpool@sha256:fb07b1be9e0990e3846ef628e993694bf0765602af5907abf98f7e218db0cb4a"

--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -29,7 +29,7 @@ var (
 )
 
 const (
-	MultusImageDefault            = "ghcr.io/k8snetworkplumbingwg/multus-cni@sha256:829c27e9392d013eee5086ca7670d7326d723ebaec526237215e86086b5a3234"
+	MultusImageDefault            = "ghcr.io/k8snetworkplumbingwg/multus-cni@sha256:1c909e4d03006a7c1acde5e0953cd607db0dd34fca680cab3dc9fcfc29ff9174"
 	LinuxBridgeCniImageDefault    = "quay.io/kubevirt/cni-default-plugins@sha256:5d9442c26f8750d44f97175f36dbd74bef503f782b9adefcfd08215d065c437a"
 	LinuxBridgeMarkerImageDefault = "quay.io/kubevirt/bridge-marker@sha256:5d24c6d1ecb0556896b7b81c7e5260b54173858425777b7a84df8a706c07e6d2"
 	KubeMacPoolImageDefault       = "quay.io/kubevirt/kubemacpool@sha256:fb07b1be9e0990e3846ef628e993694bf0765602af5907abf98f7e218db0cb4a"

--- a/test/releases/99.0.0.go
+++ b/test/releases/99.0.0.go
@@ -13,13 +13,13 @@ func init() {
 				ParentName: "multus",
 				ParentKind: "DaemonSet",
 				Name:       "kube-multus",
-				Image:      "ghcr.io/k8snetworkplumbingwg/multus-cni@sha256:1c909e4d03006a7c1acde5e0953cd607db0dd34fca680cab3dc9fcfc29ff9174",
+				Image:      "ghcr.io/k8snetworkplumbingwg/multus-cni@sha256:09a572e8bdf8a398db024ca252d06cf3ac0a03e07ae547d6a84221d4f6a9f96f",
 			},
 			{
 				ParentName: "multus",
 				ParentKind: "DaemonSet",
 				Name:       "install-multus-binary",
-				Image:      "ghcr.io/k8snetworkplumbingwg/multus-cni@sha256:1c909e4d03006a7c1acde5e0953cd607db0dd34fca680cab3dc9fcfc29ff9174",
+				Image:      "ghcr.io/k8snetworkplumbingwg/multus-cni@sha256:09a572e8bdf8a398db024ca252d06cf3ac0a03e07ae547d6a84221d4f6a9f96f",
 			},
 			{
 				ParentName: "bridge-marker",

--- a/test/releases/99.0.0.go
+++ b/test/releases/99.0.0.go
@@ -13,13 +13,13 @@ func init() {
 				ParentName: "multus",
 				ParentKind: "DaemonSet",
 				Name:       "kube-multus",
-				Image:      "ghcr.io/k8snetworkplumbingwg/multus-cni@sha256:829c27e9392d013eee5086ca7670d7326d723ebaec526237215e86086b5a3234",
+				Image:      "ghcr.io/k8snetworkplumbingwg/multus-cni@sha256:1c909e4d03006a7c1acde5e0953cd607db0dd34fca680cab3dc9fcfc29ff9174",
 			},
 			{
 				ParentName: "multus",
 				ParentKind: "DaemonSet",
 				Name:       "install-multus-binary",
-				Image:      "ghcr.io/k8snetworkplumbingwg/multus-cni@sha256:829c27e9392d013eee5086ca7670d7326d723ebaec526237215e86086b5a3234",
+				Image:      "ghcr.io/k8snetworkplumbingwg/multus-cni@sha256:1c909e4d03006a7c1acde5e0953cd607db0dd34fca680cab3dc9fcfc29ff9174",
 			},
 			{
 				ParentName: "bridge-marker",


### PR DESCRIPTION

<!-- Thanks for sending a pull request!

Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the main branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it

If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**What this PR does / why we need it**:
The multus bump script was updated to:
- use a different multus manifest - `multus-daemonset-thick.yml`
- ignore comments in the manifest file. Comments in the manifests broke the `yaml-utils::split_yaml_by_seperator` function.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
Consume multus v4, which operates as a thick plugin.
```
