### PR TITLE
multus dynamic networks: validate configuration

### DIFF
--- a/pkg/network/multus_dynamic_networks_controller.go
+++ b/pkg/network/multus_dynamic_networks_controller.go
@@ -8,6 +8,8 @@ import (
 	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
+	openshiftoperatorv1 "github.com/openshift/api/operator/v1"
+
 	cnao "github.com/kubevirt/cluster-network-addons-operator/pkg/apis/networkaddonsoperator/shared"
 	"github.com/kubevirt/cluster-network-addons-operator/pkg/network/cni"
 	"github.com/kubevirt/cluster-network-addons-operator/pkg/render"
@@ -39,9 +41,13 @@ func renderMultusDynamicNetworks(conf *cnao.NetworkAddonsConfigSpec, manifestDir
 	return objs, nil
 }
 
-func validateMultusDynamicNetworks(conf *cnao.NetworkAddonsConfigSpec) []error {
+func validateMultusDynamicNetworks(conf *cnao.NetworkAddonsConfigSpec, openshiftNetworkConfig *openshiftoperatorv1.Network) []error {
 	if conf.MultusDynamicNetworks == nil {
 		return nil
+	}
+
+	if openshiftNetworkConfig != nil {
+		return []error{fmt.Errorf("`multusDynamicNetworks` configuration is not supported on Openshift yet")}
 	}
 
 	if conf.Multus == nil {

--- a/pkg/network/multus_dynamic_networks_controller.go
+++ b/pkg/network/multus_dynamic_networks_controller.go
@@ -1,6 +1,7 @@
 package network
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 
@@ -36,4 +37,15 @@ func renderMultusDynamicNetworks(conf *cnao.NetworkAddonsConfigSpec, manifestDir
 	}
 
 	return objs, nil
+}
+
+func validateMultusDynamicNetworks(conf *cnao.NetworkAddonsConfigSpec) []error {
+	if conf.MultusDynamicNetworks == nil {
+		return nil
+	}
+
+	if conf.Multus == nil {
+		return []error{fmt.Errorf("the `multus` configuration is required")}
+	}
+	return nil
 }

--- a/pkg/network/multus_dynamic_networks_controller_test.go
+++ b/pkg/network/multus_dynamic_networks_controller_test.go
@@ -1,0 +1,41 @@
+package network
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	cnao "github.com/kubevirt/cluster-network-addons-operator/pkg/apis/networkaddonsoperator/shared"
+)
+
+var _ = Describe("Testing multus-dynamic-networks", func() {
+	Context("the correct configuration is passed", func() {
+		var config cnao.NetworkAddonsConfigSpec
+
+		BeforeEach(func() {
+			config = cnao.NetworkAddonsConfigSpec{
+				Multus:                &cnao.Multus{},
+				MultusDynamicNetworks: &cnao.MultusDynamicNetworks{},
+			}
+		})
+
+		It("is successfully validated", func() {
+			Expect(validateMultusDynamicNetworks(&config)).To(BeEmpty())
+		})
+	})
+
+	Context("the configuration is missing the multus dependency", func() {
+		var config cnao.NetworkAddonsConfigSpec
+
+		BeforeEach(func() {
+			config = cnao.NetworkAddonsConfigSpec{
+				MultusDynamicNetworks: &cnao.MultusDynamicNetworks{},
+			}
+		})
+
+		It("fails to be validated", func() {
+			Expect(
+				validateMultusDynamicNetworks(&config),
+			).To(ConsistOf(MatchError("the `multus` configuration is required")))
+		})
+	})
+})

--- a/pkg/network/multus_dynamic_networks_controller_test.go
+++ b/pkg/network/multus_dynamic_networks_controller_test.go
@@ -4,11 +4,13 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	openshiftoperatorv1 "github.com/openshift/api/operator/v1"
+
 	cnao "github.com/kubevirt/cluster-network-addons-operator/pkg/apis/networkaddonsoperator/shared"
 )
 
 var _ = Describe("Testing multus-dynamic-networks", func() {
-	Context("the correct configuration is passed", func() {
+	Context("the correct CNAO configuration is passed", func() {
 		var config cnao.NetworkAddonsConfigSpec
 
 		BeforeEach(func() {
@@ -19,7 +21,7 @@ var _ = Describe("Testing multus-dynamic-networks", func() {
 		})
 
 		It("is successfully validated", func() {
-			Expect(validateMultusDynamicNetworks(&config)).To(BeEmpty())
+			Expect(validateMultusDynamicNetworks(&config, nil)).To(BeEmpty())
 		})
 	})
 
@@ -34,8 +36,30 @@ var _ = Describe("Testing multus-dynamic-networks", func() {
 
 		It("fails to be validated", func() {
 			Expect(
-				validateMultusDynamicNetworks(&config),
+				validateMultusDynamicNetworks(&config, nil),
 			).To(ConsistOf(MatchError("the `multus` configuration is required")))
+		})
+	})
+
+	When("`multusDynamicNetworks` is not configured", func() {
+		DescribeTable(
+			"the configuration is validated",
+			func(cnaoConfig *cnao.NetworkAddonsConfigSpec, openshiftNetworkConfig *openshiftoperatorv1.Network) {
+				Expect(validateMultusDynamicNetworks(cnaoConfig, openshiftNetworkConfig)).To(BeEmpty())
+			},
+			Entry("without an openshift network configuration", &cnao.NetworkAddonsConfigSpec{}, nil),
+			Entry("on an openshift cluster", &cnao.NetworkAddonsConfigSpec{}, &openshiftoperatorv1.Network{}),
+		)
+	})
+
+	When("an openshift network configuration in passed", func() {
+		It("a valid configuration fails", func() {
+			openshiftNetworkConfig := &openshiftoperatorv1.Network{}
+			cnaoConfig := &cnao.NetworkAddonsConfigSpec{
+				Multus:                &cnao.Multus{},
+				MultusDynamicNetworks: &cnao.MultusDynamicNetworks{},
+			}
+			Expect(validateMultusDynamicNetworks(cnaoConfig, openshiftNetworkConfig)).To(ConsistOf(MatchError("`multusDynamicNetworks` configuration is not supported on Openshift yet")))
 		})
 	})
 })

--- a/pkg/network/network.go
+++ b/pkg/network/network.go
@@ -41,6 +41,7 @@ func Validate(conf *cnao.NetworkAddonsConfigSpec, openshiftNetworkConfig *osv1.N
 	errs = append(errs, validateKubeMacPool(conf)...)
 	errs = append(errs, validateImagePullPolicy(conf)...)
 	errs = append(errs, validateSelfSignConfiguration(conf)...)
+	errs = append(errs, validateMultusDynamicNetworks(conf)...)
 
 	if len(errs) > 0 {
 		return errors.Errorf("invalid configuration:\n%s", errorListToMultiLineString(errs))

--- a/pkg/network/network.go
+++ b/pkg/network/network.go
@@ -41,7 +41,7 @@ func Validate(conf *cnao.NetworkAddonsConfigSpec, openshiftNetworkConfig *osv1.N
 	errs = append(errs, validateKubeMacPool(conf)...)
 	errs = append(errs, validateImagePullPolicy(conf)...)
 	errs = append(errs, validateSelfSignConfiguration(conf)...)
-	errs = append(errs, validateMultusDynamicNetworks(conf)...)
+	errs = append(errs, validateMultusDynamicNetworks(conf, openshiftNetworkConfig)...)
 
 	if len(errs) > 0 {
 		return errors.Errorf("invalid configuration:\n%s", errorListToMultiLineString(errs))


### PR DESCRIPTION
The `multusDynamicNetworks` feature **depends** on multus; as such, ensure the multus dependency is present whenever the `multusDynamicNetworks` is requested.

Signed-off-by: Miguel Duarte Barroso <mdbarroso@redhat.com>

<!-- Thanks for sending a pull request!

Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the main branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it

If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**What this PR does / why we need it**:
The `multusDynamicNetworks` feature **depends** on multus; as such,
ensure the multus dependency is present whenever the `multusDynamicNetworks`
is requested.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
Ensure the CNAO configuration also features `multus` whenever the `multusDynamicNetworks` feature is requested.
```
