### PR TITLE
manifest: Restricted PSA on install

### DIFF
--- a/cluster/cluster.sh
+++ b/cluster/cluster.sh
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-export KUBEVIRT_PROVIDER=${KUBEVIRT_PROVIDER:-'k8s-1.23'}
+export KUBEVIRT_PROVIDER=${KUBEVIRT_PROVIDER:-'k8s-1.25'}
 export KUBEVIRTCI_TAG='2211212125-021efaa'
 
 KUBEVIRTCI_REPO='https://github.com/kubevirt/kubevirtci.git'

--- a/cluster/operator-install.sh
+++ b/cluster/operator-install.sh
@@ -23,3 +23,4 @@ if [[ ! $(./cluster/kubectl.sh -n cluster-network-addons wait deployment cluster
 	./cluster/kubectl.sh describe deployment cluster-network-addons-operator -n cluster-network-addons
 	exit 1
 fi
+./cluster/kubectl.sh label --overwrite namespace cluster-network-addons pod-security.kubernetes.io/enforce=privileged

--- a/templates/cluster-network-addons/VERSION/namespace.yaml.in
+++ b/templates/cluster-network-addons/VERSION/namespace.yaml.in
@@ -6,3 +6,4 @@ metadata:
   labels:
     name: {{.Namespace}}
     openshift.io/cluster-monitoring: "true"
+    pod-security.kubernetes.io/enforce: "restricted"


### PR DESCRIPTION
**What this PR does / why we need it**:
The CNAO workload cannot run on restricted PSA but it can be set on operator install to check audit-logs and then change it to privileged.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
