### PR TITLE
Explicitly request "use" verb on SCC

### DIFF
--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -394,6 +394,7 @@ func GetClusterRole() *rbacv1.ClusterRole {
 					"get",
 					"list",
 					"watch",
+					"use",
 				},
 			},
 			{


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the main branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it

If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**What this PR does / why we need it**:

In order to notify pod-security.kubernetes.io that we intent to create (potentially privileged) SCCs, so it labels us as "privileged", we have to explicitly request "use" verb for scc.

With this change, CNAO's namespace is marked as `pod-security.kubernetes.io/enforce: priviledged` even before we deploy any of our privileged components. This assures that CNAO does not show up in audit logs.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
Resolve audit warnings.
```
