### PR TITLE
Bump kubevirtci

### DIFF
--- a/cluster/cluster.sh
+++ b/cluster/cluster.sh
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 export KUBEVIRT_PROVIDER=${KUBEVIRT_PROVIDER:-'k8s-1.23'}
-export KUBEVIRTCI_TAG='2211021552-8cca8c0'
+export KUBEVIRTCI_TAG='2211212125-021efaa'
 
 KUBEVIRTCI_REPO='https://github.com/kubevirt/kubevirtci.git'
 # The CLUSTER_PATH var is used in cluster folder and points to the _kubevirtci where the cluster is deployed from.


### PR DESCRIPTION
**What this PR does / why we need it**:
Bump kubevirtci in order to consume the latest changes of DNS
https://github.com/kubevirt/kubevirtci/pull/903

**Special notes for your reviewer**:

**Release note**:
```release-note
None
```
