### PR TITLE
multus-v4: set generated config to whatever istio expects

### DIFF
--- a/data/multus/001-multus.yaml
+++ b/data/multus/001-multus.yaml
@@ -144,7 +144,7 @@ spec:
           command: ["/usr/src/multus-cni/bin/multus-daemon"]
           args:
             - "-cni-version=0.3.1"
-            - "-cni-config-dir=/host/etc/cni/net.d"
+            - "-cni-config-dir=/host/etc/cni/multus/net.d"
             - "-multus-autoconfig-dir=/host/etc/cni/net.d"
             - "-multus-log-to-stderr=true"
             - "-multus-log-level=verbose"

--- a/hack/components/bump-multus.sh
+++ b/hack/components/bump-multus.sh
@@ -28,6 +28,7 @@ function __parametize_by_object() {
 				yaml-utils::update_param ${f} spec.template.metadata.labels.name 'kube-multus-ds-amd64'
 				yaml-utils::update_param ${f} spec.template.spec.containers[0].image '{{ .MultusImage }}'
 				yaml-utils::set_param ${f} spec.template.spec.containers[0].imagePullPolicy '{{ .ImagePullPolicy }}'
+				yaml-utils::set_param ${f} spec.template.spec.containers[0].args[1] '"-cni-config-dir=/host/etc/cni/multus/net.d"' # https://github.com/k8snetworkplumbingwg/multus-cni/issues/971
 				yaml-utils::update_param ${f} spec.template.spec.initContainers[0].image '{{ .MultusImage }}'
 				yaml-utils::set_param ${f} spec.template.spec.priorityClassName 'system-cluster-critical'
 				yaml-utils::update_param ${f} spec.template.spec.volumes[0].hostPath.path '{{ .CNIConfigDir }}'


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the main branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it

If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**What this PR does / why we need it**:
This provides a work-around for an [opened multus issue](https://github.com/k8snetworkplumbingwg/multus-cni/issues/971) reporting its integration w/ istio was broken on multus-v4.

By setting the multus CNI conf dir to whatever istio expects, the integration works.

Multus does not care about this parameter since we are using [automatically generated multus configurations](https://github.com/k8snetworkplumbingwg/multus-cni/blob/master/docs/how-to-use.md), which output this auto-generated configuration [elsewhere](https://github.com/kubevirt/cluster-network-addons-operator/blob/146462ca6ada7935aec4d4a318558567543969a8/data/multus/001-multus.yaml#L148).

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
Make multus comply w/ istio's expectations of where to find the CNI plugin configurations.
```
