### PR TITLE
Integrate dynamic networks controller deployment tests

### DIFF
--- a/test/check/components.go
+++ b/test/check/components.go
@@ -72,6 +72,14 @@ var (
 		ServiceMonitor: "service-monitor-cluster-network-addons-operator",
 		PrometheusRule: "prometheus-rules-cluster-network-addons-operator",
 	}
+	MultusDynamicNetworks = Component{
+		ClusterRole:        "dynamic-networks-controller",
+		ClusterRoleBinding: "dynamic-networks-controller",
+		ComponentName:      "Multus Dynamic Networks",
+		DaemonSets: []string{
+			"dynamic-networks-controller-ds",
+		},
+	}
 	AllComponents = []Component{
 		KubeMacPoolComponent,
 		LinuxBridgeComponent,
@@ -79,6 +87,7 @@ var (
 		OvsComponent,
 		MacvtapComponent,
 		MonitoringComponent,
+		MultusDynamicNetworks,
 	}
 )
 

--- a/test/e2e/workflow/deployment_test.go
+++ b/test/e2e/workflow/deployment_test.go
@@ -25,7 +25,7 @@ import (
 var _ = Describe("NetworkAddonsConfig", func() {
 	gvk := GetCnaoV1GroupVersionKind()
 	Context("when there is no pre-existing Config", func() {
-		DescribeTable("should succeed deploying single component",
+		DescribeTable("should succeed deploying selected components",
 			func(configSpec cnao.NetworkAddonsConfigSpec, components []Component) {
 				testConfigCreate(gvk, configSpec, components)
 
@@ -72,6 +72,14 @@ var _ = Describe("NetworkAddonsConfig", func() {
 				},
 				[]Component{MacvtapComponent},
 			),
+			Entry(
+				"Multus Dynamic Networks and dependencies",
+				cnao.NetworkAddonsConfigSpec{
+					Multus:                &cnao.Multus{},
+					MultusDynamicNetworks: &cnao.MultusDynamicNetworks{},
+				},
+				[]Component{MultusComponent, MultusDynamicNetworks},
+			),
 		)
 		It("should deploy prometheus if NetworkAddonsConfigSpec is not empty", func() {
 			testConfigCreate(gvk, cnao.NetworkAddonsConfigSpec{MacvtapCni: &cnao.MacvtapCni{}}, []Component{MacvtapComponent, MonitoringComponent})
@@ -84,13 +92,15 @@ var _ = Describe("NetworkAddonsConfig", func() {
 				KubeMacPoolComponent,
 				OvsComponent,
 				MacvtapComponent,
+				MultusDynamicNetworks,
 			}
 			configSpec := cnao.NetworkAddonsConfigSpec{
-				KubeMacPool: &cnao.KubeMacPool{},
-				LinuxBridge: &cnao.LinuxBridge{},
-				Multus:      &cnao.Multus{},
-				Ovs:         &cnao.Ovs{},
-				MacvtapCni:  &cnao.MacvtapCni{},
+				KubeMacPool:           &cnao.KubeMacPool{},
+				LinuxBridge:           &cnao.LinuxBridge{},
+				Multus:                &cnao.Multus{},
+				Ovs:                   &cnao.Ovs{},
+				MacvtapCni:            &cnao.MacvtapCni{},
+				MultusDynamicNetworks: &cnao.MultusDynamicNetworks{},
 			}
 			testConfigCreate(gvk, configSpec, components)
 		})
@@ -128,6 +138,12 @@ var _ = Describe("NetworkAddonsConfig", func() {
 			configSpec.MacvtapCni = &cnao.MacvtapCni{}
 			components = append(components, MacvtapComponent)
 			testConfigUpdate(gvk, configSpec, components)
+
+			// Add Multus Dynamic Networks component (requires multus ...)
+			configSpec.Multus = &cnao.Multus{}
+			configSpec.MultusDynamicNetworks = &cnao.MultusDynamicNetworks{}
+			components = append(components, MultusComponent, MultusDynamicNetworks)
+			testConfigUpdate(gvk, configSpec, components)
 		})
 		Context("and workload PlacementConfiguration is deployed on components", func() {
 			components := []Component{
@@ -141,6 +157,7 @@ var _ = Describe("NetworkAddonsConfig", func() {
 				Multus:                 &cnao.Multus{},
 				Ovs:                    &cnao.Ovs{},
 				MacvtapCni:             &cnao.MacvtapCni{},
+				MultusDynamicNetworks:  &cnao.MultusDynamicNetworks{},
 				PlacementConfiguration: &cnao.PlacementConfiguration{},
 			}
 			checkWorkloadPlacementOnComponents := func(expectedWorkLoadPlacement cnao.Placement) {
@@ -223,13 +240,15 @@ var _ = Describe("NetworkAddonsConfig", func() {
 			OvsComponent,
 			MacvtapComponent,
 			MonitoringComponent,
+			MultusDynamicNetworks,
 		}
 		configSpec := cnao.NetworkAddonsConfigSpec{
-			LinuxBridge: &cnao.LinuxBridge{},
-			Multus:      &cnao.Multus{},
-			KubeMacPool: &cnao.KubeMacPool{},
-			Ovs:         &cnao.Ovs{},
-			MacvtapCni:  &cnao.MacvtapCni{},
+			LinuxBridge:           &cnao.LinuxBridge{},
+			Multus:                &cnao.Multus{},
+			KubeMacPool:           &cnao.KubeMacPool{},
+			Ovs:                   &cnao.Ovs{},
+			MacvtapCni:            &cnao.MacvtapCni{},
+			MultusDynamicNetworks: &cnao.MultusDynamicNetworks{},
 		}
 		BeforeEach(func() {
 			CreateConfig(gvk, configSpec)


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the main branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it

If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**What this PR does / why we need it**:
This PR adds the multus dynamic networks controller to CNAO's workflow deployment e2e tests.

Fixes: #1463 

**Special notes for your reviewer**:
Depends-on: #1462 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
