### PR TITLE
makefile: Add missing component to bump-all target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -205,7 +205,7 @@ auto-bumper: $(GO)
 
 bump-%:
 	CNAO_VERSION=${VERSION} ./hack/components/bump-$*.sh
-bump-all: bump-kubemacpool bump-macvtap-cni bump-linux-bridge bump-multus bump-ovs-cni bump-bridge-marker
+bump-all: bump-kubemacpool bump-macvtap-cni bump-linux-bridge bump-multus bump-ovs-cni bump-bridge-marker bump-multus-dynamic-networks
 
 generate-doc:
 	go run ./tools/metricsdocs > docs/metrics.md


### PR DESCRIPTION
**What this PR does / why we need it**:
This way it will be checked as part of the unit test lane that runs the bump-all target.

**Special notes for your reviewer**:
We need to support auto detection imo.

**Release note**:
```release-note
None
```
