### PR TITLE
bump kube-secondary-dns to v0.0.6

### DIFF
--- a/components.yaml
+++ b/components.yaml
@@ -5,6 +5,12 @@ components:
     branch: main
     update-policy: tagged
     metadata: 0.10.0
+  kube-secondary-dns:
+    url: https://github.com/kubevirt/kubesecondarydns
+    commit: 812cfcf78c2c6ef5e409454f6386c2fa336c8f62
+    branch: main
+    update-policy: tagged
+    metadata: v0.0.6
   kubemacpool:
     url: https://github.com/k8snetworkplumbingwg/kubemacpool
     commit: f559c0725c4d315d1bf48fbc380c25a19ddf9c10
@@ -41,9 +47,3 @@ components:
     branch: main
     update-policy: tagged
     metadata: v0.29.1
-  kube-secondary-dns:
-    url: https://github.com/kubevirt/kubesecondarydns
-    commit: a7779d99e0b196119f8bf9337186f091aea54df0
-    branch: main
-    update-policy: tagged
-    metadata: v0.0.5

--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -37,7 +37,7 @@ const (
 	OvsCniImageDefault                = "quay.io/kubevirt/ovs-cni-plugin@sha256:3654b80dd5e459c3e73dd027d732620ed8b488b8a15dfe7922457d16c7e834c3"
 	MacvtapCniImageDefault            = "quay.io/kubevirt/macvtap-cni@sha256:5a288f1f9956c2ea8127fa736b598326852d2aa58a8469fa663a1150c2313b02"
 	KubeRbacProxyImageDefault         = "quay.io/openshift/origin-kube-rbac-proxy@sha256:baedb268ac66456018fb30af395bb3d69af5fff3252ff5d549f0231b1ebb6901"
-	KubeSecondaryDNSImageDefault      = "ghcr.io/kubevirt/kubesecondarydns@sha256:b25074818c76d149cbf64bfb4b5559afcc1c3d4733b450ce70856903a80eb2c7"
+	KubeSecondaryDNSImageDefault      = "ghcr.io/kubevirt/kubesecondarydns@sha256:a338b9680a4c27a3066d640430cae43b512f98e5565c3554a2b42b7af3d0d539"
 	CoreDNSImageDefault               = "k8s.gcr.io/coredns/coredns@sha256:5b6ec0d6de9baaf3e92d0f66cd96a25b9edbce8716f5f15dcd1a616b3abd590e"
 )
 

--- a/test/releases/99.0.0.go
+++ b/test/releases/99.0.0.go
@@ -75,7 +75,7 @@ func init() {
 				ParentName: secondaryDNSDeployment,
 				ParentKind: "Deployment",
 				Name:       "status-monitor",
-				Image:      "ghcr.io/kubevirt/kubesecondarydns@sha256:b25074818c76d149cbf64bfb4b5559afcc1c3d4733b450ce70856903a80eb2c7",
+				Image:      "ghcr.io/kubevirt/kubesecondarydns@sha256:a338b9680a4c27a3066d640430cae43b512f98e5565c3554a2b42b7af3d0d539",
 			},
 			{
 				ParentName: secondaryDNSDeployment,


### PR DESCRIPTION
bump kube-secondary-dns to v0.0.6
Executed by Bumper script

```release-note
bump kube-secondary-dns to v0.0.6
```