### PR TITLE
ksd: Bump manually to v0.0.7

### DIFF
--- a/automation/check-patch.e2e-kube-secondary-dns-functests.sh
+++ b/automation/check-patch.e2e-kube-secondary-dns-functests.sh
@@ -29,6 +29,7 @@ main() {
 
     trap teardown EXIT
 
+    ./hack/deploy-kubevirt.sh
     cd ${TMP_COMPONENT_PATH}
     make create-nodeport
     echo "Run kube-secondary-dns functional tests"

--- a/components.yaml
+++ b/components.yaml
@@ -43,7 +43,7 @@ components:
     metadata: v0.29.1
   kube-secondary-dns:
     url: https://github.com/kubevirt/kubesecondarydns
-    commit: a7779d99e0b196119f8bf9337186f091aea54df0
+    commit: 98b0eda5c294091ed7b5132419009c0751357838
     branch: main
     update-policy: tagged
-    metadata: v0.0.5
+    metadata: v0.0.7

--- a/hack/components/bump-kube-secondary-dns.sh
+++ b/hack/components/bump-kube-secondary-dns.sh
@@ -15,8 +15,8 @@ function __parametize_by_object() {
         ;;
       ./ConfigMap_secondary-dns.yaml)
         yaml-utils::update_param ${f} metadata.namespace '{{ .Namespace }}'
-        yaml-utils::update_param ${f} data.DOMAIN '{{ .Domain }}'
-        yaml-utils::update_param ${f} data.NAME_SERVER_IP '{{ .NameServerIp }}'
+        yaml-utils::set_param ${f} data.DOMAIN '{{ .Domain }}'
+        yaml-utils::set_param ${f} data.NAME_SERVER_IP '{{ .NameServerIp }}'
         yaml-utils::remove_single_quotes_from_yaml ${f}
         ;;
       ./ClusterRoleBinding_secondary.yaml)

--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -37,7 +37,7 @@ const (
 	OvsCniImageDefault                = "quay.io/kubevirt/ovs-cni-plugin@sha256:3654b80dd5e459c3e73dd027d732620ed8b488b8a15dfe7922457d16c7e834c3"
 	MacvtapCniImageDefault            = "quay.io/kubevirt/macvtap-cni@sha256:5a288f1f9956c2ea8127fa736b598326852d2aa58a8469fa663a1150c2313b02"
 	KubeRbacProxyImageDefault         = "quay.io/openshift/origin-kube-rbac-proxy@sha256:baedb268ac66456018fb30af395bb3d69af5fff3252ff5d549f0231b1ebb6901"
-	KubeSecondaryDNSImageDefault      = "ghcr.io/kubevirt/kubesecondarydns@sha256:b25074818c76d149cbf64bfb4b5559afcc1c3d4733b450ce70856903a80eb2c7"
+	KubeSecondaryDNSImageDefault      = "ghcr.io/kubevirt/kubesecondarydns@sha256:9bb0e7784cab32a8683f56b3d370b4ab5efed339fa372a8f3ca2e0408e1f8f19"
 	CoreDNSImageDefault               = "k8s.gcr.io/coredns/coredns@sha256:5b6ec0d6de9baaf3e92d0f66cd96a25b9edbce8716f5f15dcd1a616b3abd590e"
 )
 

--- a/test/releases/99.0.0.go
+++ b/test/releases/99.0.0.go
@@ -75,7 +75,7 @@ func init() {
 				ParentName: secondaryDNSDeployment,
 				ParentKind: "Deployment",
 				Name:       "status-monitor",
-				Image:      "ghcr.io/kubevirt/kubesecondarydns@sha256:b25074818c76d149cbf64bfb4b5559afcc1c3d4733b450ce70856903a80eb2c7",
+				Image:      "ghcr.io/kubevirt/kubesecondarydns@sha256:9bb0e7784cab32a8683f56b3d370b4ab5efed339fa372a8f3ca2e0408e1f8f19",
 			},
 			{
 				ParentName: secondaryDNSDeployment,


### PR DESCRIPTION
**What this PR does / why we need it**:
Bump KubeSecondaryDNS manually (v0.0.7), since auto-bumper has problems.
See https://github.com/kubevirt/cluster-network-addons-operator/pull/1474

Beside that:
* Install kubevirt before running KSD e2e tests.
* Fix bump script (use set instead of update, because strings might be empty).

**Special notes for your reviewer**:

**Release note**:
```release-note
None
```
