### PR TITLE
components: Remove double export

### DIFF
--- a/automation/components-functests.setup.sh
+++ b/automation/components-functests.setup.sh
@@ -22,7 +22,6 @@ source hack/components/yaml-utils.sh
 source cluster/cluster.sh
 
 # Spin up Kubernetes cluster
-export KUBEVIRT_PROVIDER='k8s-1.23'
 make cluster-down cluster-up
 
 # Export .kubeconfig full path, so it will be possible


### PR DESCRIPTION
**What this PR does / why we need it**:
`KUBEVIRT_PROVIDER` is already exported at the sourced `cluster.sh`, 
no need to override it.
It just confuse and harder to maintain because it will ignore the `cluster.sh` value
which is the main one we use.

**Special notes for your reviewer**:

**Release note**:
```release-note
None
```
