### PR TITLE
Fix undeploy components

### DIFF
--- a/pkg/network/network.go
+++ b/pkg/network/network.go
@@ -222,7 +222,7 @@ func RenderObjsToRemove(prev, conf *cnao.NetworkAddonsConfigSpec, manifestDir st
 
 	// render MacvtapCni
 	if conf.MacvtapCni == nil {
-		o, err := renderMacvtapCni(conf, manifestDir, clusterInfo)
+		o, err := renderMacvtapCni(prev, manifestDir, clusterInfo)
 		if err != nil {
 			return nil, err
 		}
@@ -231,7 +231,7 @@ func RenderObjsToRemove(prev, conf *cnao.NetworkAddonsConfigSpec, manifestDir st
 
 	// render KubeSecondaryDNS
 	if conf.KubeSecondaryDNS == nil {
-		o, err := renderKubeSecondaryDNS(conf, manifestDir, clusterInfo)
+		o, err := renderKubeSecondaryDNS(prev, manifestDir, clusterInfo)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:
The current config was used instead of the previous.
In the current config it is empty, we need to pass the previous config, 
so in case the component was configured in the previous config it will render its 
object and add it to the delete list.

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
