### PR TITLE
kubevirtci: Bump and use k8s-1.25

### DIFF
--- a/cluster/cluster.sh
+++ b/cluster/cluster.sh
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-export KUBEVIRT_PROVIDER=${KUBEVIRT_PROVIDER:-'k8s-1.23'}
-export KUBEVIRTCI_TAG='2211212125-021efaa'
+export KUBEVIRT_PROVIDER=${KUBEVIRT_PROVIDER:-'k8s-1.25'}
+export KUBEVIRTCI_TAG='2212191323-5743c8c'
 
 KUBEVIRTCI_REPO='https://github.com/kubevirt/kubevirtci.git'
 # The CLUSTER_PATH var is used in cluster folder and points to the _kubevirtci where the cluster is deployed from.


### PR DESCRIPTION
**What this PR does / why we need it**:
Includes https://github.com/kubevirt/kubevirtci/pull/915
`KUBEVIRT_PSA` is false by default

**Special notes for your reviewer**:

**Release note**:
```release-note
None
```
