### PR TITLE
ksd: Bump to v0.0.8

### DIFF
--- a/components.yaml
+++ b/components.yaml
@@ -7,10 +7,10 @@ components:
     metadata: 0.10.0
   kube-secondary-dns:
     url: https://github.com/kubevirt/kubesecondarydns
-    commit: 98b0eda5c294091ed7b5132419009c0751357838
+    commit: 27f994c7ac66ef099af089d3e4640761b1d22561
     branch: main
     update-policy: tagged
-    metadata: v0.0.7
+    metadata: v0.0.8
   kubemacpool:
     url: https://github.com/k8snetworkplumbingwg/kubemacpool
     commit: f559c0725c4d315d1bf48fbc380c25a19ddf9c10

--- a/data/kube-secondary-dns/secondarydns.yaml
+++ b/data/kube-secondary-dns/secondarydns.yaml
@@ -9,7 +9,7 @@ data:
   DOMAIN: {{ .Domain }}
   NAME_SERVER_IP: {{ .NameServerIp }}
   Corefile: |
-    .:53 {
+    .:5353 {
         auto {
           directory /zones db\.(.*) {1}
           reload 45s
@@ -75,6 +75,11 @@ spec:
         kubectl.kubernetes.io/default-container: status-monitor
     spec:
       serviceAccountName: secondary
+      securityContext:
+        runAsUser: 1000
+        runAsNonRoot: true
+        seccompProfile:
+          type: "RuntimeDefault"
       containers:
         - args:
             - -conf
@@ -82,8 +87,12 @@ spec:
           image: {{ .CoreDNSImage }}
           imagePullPolicy: {{ .ImagePullPolicy }}
           name: secondary-dns
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
           ports:
-            - containerPort: 53
+            - containerPort: 5353
               name: dns
               protocol: UDP
           resources:
@@ -100,6 +109,10 @@ spec:
               mountPath: /zones
               readOnly: true
         - name: status-monitor
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
           image: {{ .KubeSecondaryDNSImage }}
           volumeMounts:
             - name: secdns-zones

--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -37,7 +37,7 @@ const (
 	OvsCniImageDefault                = "quay.io/kubevirt/ovs-cni-plugin@sha256:b9a56053b3469b02d96814cc2d67d35a81650db9dae9c2188011a986e3743aa4"
 	MacvtapCniImageDefault            = "quay.io/kubevirt/macvtap-cni@sha256:5a288f1f9956c2ea8127fa736b598326852d2aa58a8469fa663a1150c2313b02"
 	KubeRbacProxyImageDefault         = "quay.io/openshift/origin-kube-rbac-proxy@sha256:baedb268ac66456018fb30af395bb3d69af5fff3252ff5d549f0231b1ebb6901"
-	KubeSecondaryDNSImageDefault      = "ghcr.io/kubevirt/kubesecondarydns@sha256:9bb0e7784cab32a8683f56b3d370b4ab5efed339fa372a8f3ca2e0408e1f8f19"
+	KubeSecondaryDNSImageDefault      = "ghcr.io/kubevirt/kubesecondarydns@sha256:52baadf22ae10da4987b623b0c7a632429d09c5c080d96ded1086596a519d442"
 	CoreDNSImageDefault               = "k8s.gcr.io/coredns/coredns@sha256:5b6ec0d6de9baaf3e92d0f66cd96a25b9edbce8716f5f15dcd1a616b3abd590e"
 )
 

--- a/test/releases/99.0.0.go
+++ b/test/releases/99.0.0.go
@@ -73,7 +73,7 @@ func init() {
 				ParentName: "secondary-dns",
 				ParentKind: "Deployment",
 				Name:       "status-monitor",
-				Image:      "ghcr.io/kubevirt/kubesecondarydns@sha256:9bb0e7784cab32a8683f56b3d370b4ab5efed339fa372a8f3ca2e0408e1f8f19",
+				Image:      "ghcr.io/kubevirt/kubesecondarydns@sha256:52baadf22ae10da4987b623b0c7a632429d09c5c080d96ded1086596a519d442",
 			},
 			{
 				ParentName: "secondary-dns",


### PR DESCRIPTION
**What this PR does / why we need it**:
Bump KubeSecondaryDNS to [v0.0.8](https://github.com/kubevirt/kubesecondarydns/releases/tag/v0.0.8)

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
