### PR TITLE
Add `operator_health_impact` label to CNAO alerts

### DIFF
--- a/data/monitoring/prom-rule.yaml
+++ b/data/monitoring/prom-rule.yaml
@@ -20,6 +20,7 @@ spec:
           for: 5m
           labels:
             severity: warning
+            operator_health_impact: warning
             kubernetes_operator_part_of: kubevirt
             kubernetes_operator_component: cluster-network-addons-operator
         - alert: NetworkAddonsConfigNotReady
@@ -30,6 +31,7 @@ spec:
           for: 5m
           labels:
             severity: warning
+            operator_health_impact: warning
             kubernetes_operator_part_of: kubevirt
             kubernetes_operator_component: cluster-network-addons-operator
         # +help:summary="Total count of duplicate KubeMacPool MAC addresses",type=Gauge
@@ -43,6 +45,7 @@ spec:
           for: 5m
           labels:
             severity: warning
+            operator_health_impact: warning
             kubernetes_operator_part_of: kubevirt
             kubernetes_operator_component: cluster-network-addons-operator
         # +help:summary="Total count of running KubeMacPool manager pods",type=Gauge
@@ -59,5 +62,6 @@ spec:
           for: 5m
           labels:
             severity: critical
+            operator_health_impact: critical
             kubernetes_operator_part_of: kubevirt
             kubernetes_operator_component: cluster-network-addons-operator

--- a/hack/prom-rule-ci/prom-rules-tests.yaml
+++ b/hack/prom-rule-ci/prom-rules-tests.yaml
@@ -21,6 +21,7 @@ tests:
               runbook_url: "https://kubevirt.io/monitoring/runbooks/CnaoDown"
             exp_labels:
               severity: "warning"
+              operator_health_impact: "warning"
               kubernetes_operator_part_of: "kubevirt"
               kubernetes_operator_component: "cluster-network-addons-operator"
 # CnaoDown negative tests
@@ -53,6 +54,7 @@ tests:
               runbook_url: "https://kubevirt.io/monitoring/runbooks/NetworkAddonsConfigNotReady"
             exp_labels:
               severity: "warning"
+              operator_health_impact: "warning"
               kubernetes_operator_part_of: "kubevirt"
               kubernetes_operator_component: "cluster-network-addons-operator"
 
@@ -88,6 +90,7 @@ tests:
               runbook_url: "https://kubevirt.io/monitoring/runbooks/KubeMacPoolDuplicateMacsFound"
             exp_labels:
               severity: "warning"
+              operator_health_impact: "warning"
               kubernetes_operator_part_of: "kubevirt"
               kubernetes_operator_component: "cluster-network-addons-operator"
 
@@ -121,6 +124,7 @@ tests:
               runbook_url: "https://kubevirt.io/monitoring/runbooks/KubeMacPoolDown"
             exp_labels:
               severity: "critical"
+              operator_health_impact: "critical"
               kubernetes_operator_part_of: "kubevirt"
               kubernetes_operator_component: "cluster-network-addons-operator"
 

--- a/test/e2e/monitoring/rules_test.go
+++ b/test/e2e/monitoring/rules_test.go
@@ -59,6 +59,7 @@ var _ = Context("Prometheus Rules", func() {
 						if len(rule.Alert) > 0 {
 							Expect(rule.Labels).ToNot(BeNil())
 							checkForSeverityLabel(rule)
+							checkForHealthImpactLabel(rule)
 							checkForPartOfLabel(rule)
 							checkForComponentLabel(rule)
 						}
@@ -95,6 +96,12 @@ func checkForSeverityLabel(rule monitoringv1.Rule) {
 	severity, ok := rule.Labels["severity"]
 	ExpectWithOffset(1, ok).To(BeTrue(), fmt.Sprintf("%s does not have severity label", rule.Alert))
 	ExpectWithOffset(1, severity).To(BeElementOf("info", "warning", "critical"), fmt.Sprintf("%s severity label is not valid", rule.Alert))
+}
+
+func checkForHealthImpactLabel(rule monitoringv1.Rule) {
+	operatorHealthImpact, ok := rule.Labels["operator_health_impact"]
+	ExpectWithOffset(1, ok).To(BeTrue(), fmt.Sprintf("%s does not have operator_health_impact label", rule.Alert))
+	ExpectWithOffset(1, operatorHealthImpact).To(BeElementOf("none", "warning", "critical"), fmt.Sprintf("%s operator_health_impact label is not valid", rule.Alert))
 }
 
 func checkForPartOfLabel(rule monitoringv1.Rule) {


### PR DESCRIPTION
Signed-off-by: assafad <aadmi@redhat.com>

<!-- Thanks for sending a pull request!

Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the main branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it

If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**What this PR does / why we need it**:
This PR adds to each of CNAO alerts a label named `operator_health_impact`, which indicates how the alerts impact the operator health. This will enable us filtering alerts based on their impact on the operator health, and to later have an operator health metric, which will tell the user what is the aggregated operator health.

This label gets one of the following values:
- `critical` indicates that the alert fires due to an issue that impacts the operator's functionality badly, and an action must be taken immediately in order to solve it.
-  `warning` indicates that the alert fires due to an issue that soon might impact the operator's functionality badly, and the user should be warned in order to solve the issue.
- `none` indicates that the alert fires due to an issue that doesn't affect the operator health, and in most cases is related to the workload rather than the operator itself.

**Which issue(s) this PR fixes**:
https://issues.redhat.com/browse/CNV-18923

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
None
```
