### PR TITLE
[ksd] Parameterize "runAsNonRoot" in the yaml

### DIFF
--- a/data/kube-secondary-dns/secondarydns.yaml
+++ b/data/kube-secondary-dns/secondarydns.yaml
@@ -76,8 +76,8 @@ spec:
     spec:
       serviceAccountName: secondary
       securityContext:
-        runAsUser: 1000
-        runAsNonRoot: true
+        runAsUser: {{ .RunAsUser }}
+        runAsNonRoot: {{ .RunAsNonRoot }}
         seccompProfile:
           type: "RuntimeDefault"
       containers:

--- a/hack/components/bump-kube-secondary-dns.sh
+++ b/hack/components/bump-kube-secondary-dns.sh
@@ -26,6 +26,8 @@ function __parametize_by_object() {
       ./Deployment_secondary-dns.yaml)
         yaml-utils::update_param ${f} metadata.namespace '{{ .Namespace }}'
         yaml-utils::update_param ${f} spec.template.spec.containers[0].image '{{ .CoreDNSImage }}'
+        yaml-utils::update_param ${f} spec.template.spec.securityContext.runAsNonRoot '{{ .RunAsNonRoot }}'
+        yaml-utils::update_param ${f} spec.template.spec.securityContext.runAsUser '{{ .RunAsUser }}'
         yaml-utils::update_param ${f} spec.template.spec.containers[1].image '{{ .KubeSecondaryDNSImage }}'
         yaml-utils::set_param ${f} spec.template.spec.containers[0].imagePullPolicy '{{ .ImagePullPolicy }}'
         yaml-utils::set_param ${f} spec.template.spec.containers[1].imagePullPolicy '{{ .ImagePullPolicy }}'

--- a/pkg/network/kube_secondary_dns_controller.go
+++ b/pkg/network/kube_secondary_dns_controller.go
@@ -26,6 +26,13 @@ func renderKubeSecondaryDNS(conf *cnao.NetworkAddonsConfigSpec, manifestDir stri
 	data.Data["NameServerIp"] = conf.KubeSecondaryDNS.NameServerIP
 	data.Data["KubeSecondaryDNSImage"] = os.Getenv("KUBE_SECONDARY_DNS_IMAGE")
 	data.Data["CoreDNSImage"] = os.Getenv("CORE_DNS_IMAGE")
+	if clusterInfo.SCCAvailable {
+		data.Data["RunAsNonRoot"] = "null"
+		data.Data["RunAsUser"] = "null"
+	} else {
+		data.Data["RunAsNonRoot"] = "true"
+		data.Data["RunAsUser"] = "1000"
+	}
 
 	objs, err := render.RenderDir(filepath.Join(manifestDir, "kube-secondary-dns"), &data)
 	if err != nil {


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the main branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it

If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**What this PR does / why we need it**:
In order to make ksd pod to work with restricted psa policy it should have `runAsNonRoot: true`.
However, once the pod's securityContext has `runAsNonRoot: true` it should also have a specific `rusAsUser`.
Having a specific user is problematic on Openshift since it may configure a range of valid ids (example of a possible error - `spec.containers[0].securityContext.runAsUser: Invalid value: 1000: must be in the ranges: [1000670000, 1000679999]`).

According to "What happens if I use runAsUser in my workloads?" section in https://github.com/redhat-openshift-ecosystem/community-operators-prod/discussions/1417 the suggested solution is - 
```
If you are unable to change the image, for Openshift distributions you MUST leave the RunAsUser and RunAsNonRoot fields empty and let the Openshift SCC inject the values when your workload is qualified to the SCC policy.
```

Since one of the kds pod containers is CoreDNS and not controlled by the ksd repository, this is the preferred solution in the described scenario.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
[KSD] set `runAsNonRoot: null` and `runAsUser:null` in case of Openshift environment.
```
