### PR TITLE
KSD: Bump to v0.0.9

### DIFF
--- a/components.yaml
+++ b/components.yaml
@@ -7,10 +7,10 @@ components:
     metadata: 0.10.0
   kube-secondary-dns:
     url: https://github.com/kubevirt/kubesecondarydns
-    commit: 27f994c7ac66ef099af089d3e4640761b1d22561
+    commit: e22050c4fb1d93fefef9c282d982517a46abcc03
     branch: main
     update-policy: tagged
-    metadata: v0.0.8
+    metadata: v0.0.9
   kubemacpool:
     url: https://github.com/k8snetworkplumbingwg/kubemacpool
     commit: f559c0725c4d315d1bf48fbc380c25a19ddf9c10

--- a/data/kube-secondary-dns/secondarydns.yaml
+++ b/data/kube-secondary-dns/secondarydns.yaml
@@ -96,8 +96,6 @@ spec:
               name: dns
               protocol: UDP
           resources:
-            limits:
-              memory: 170Mi
             requests:
               cpu: 100m
               memory: 70Mi
@@ -114,6 +112,10 @@ spec:
             capabilities:
               drop: ["ALL"]
           image: {{ .KubeSecondaryDNSImage }}
+          resources:
+            requests:
+              cpu: 100m
+              memory: 70Mi
           volumeMounts:
             - name: secdns-zones
               mountPath: /zones

--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -37,7 +37,7 @@ const (
 	OvsCniImageDefault                = "quay.io/kubevirt/ovs-cni-plugin@sha256:5f7290e2294255ab2547c3b4bf48cc2d75531ec5a43e600366e9b2719bef983f"
 	MacvtapCniImageDefault            = "quay.io/kubevirt/macvtap-cni@sha256:5a288f1f9956c2ea8127fa736b598326852d2aa58a8469fa663a1150c2313b02"
 	KubeRbacProxyImageDefault         = "quay.io/openshift/origin-kube-rbac-proxy@sha256:baedb268ac66456018fb30af395bb3d69af5fff3252ff5d549f0231b1ebb6901"
-	KubeSecondaryDNSImageDefault      = "ghcr.io/kubevirt/kubesecondarydns@sha256:52baadf22ae10da4987b623b0c7a632429d09c5c080d96ded1086596a519d442"
+	KubeSecondaryDNSImageDefault      = "ghcr.io/kubevirt/kubesecondarydns@sha256:b489a7c5d05b000f776c9c302985b8b7f29ff31f577a1480912ed625c8772d6b"
 	CoreDNSImageDefault               = "k8s.gcr.io/coredns/coredns@sha256:5b6ec0d6de9baaf3e92d0f66cd96a25b9edbce8716f5f15dcd1a616b3abd590e"
 )
 

--- a/test/releases/99.0.0.go
+++ b/test/releases/99.0.0.go
@@ -73,7 +73,7 @@ func init() {
 				ParentName: "secondary-dns",
 				ParentKind: "Deployment",
 				Name:       "status-monitor",
-				Image:      "ghcr.io/kubevirt/kubesecondarydns@sha256:52baadf22ae10da4987b623b0c7a632429d09c5c080d96ded1086596a519d442",
+				Image:      "ghcr.io/kubevirt/kubesecondarydns@sha256:b489a7c5d05b000f776c9c302985b8b7f29ff31f577a1480912ed625c8772d6b",
 			},
 			{
 				ParentName: "secondary-dns",


### PR DESCRIPTION
**What this PR does / why we need it**:
See https://github.com/kubevirt/kubesecondarydns/releases/tag/v0.0.9

**Special notes for your reviewer**:

**Release note**:
```release-note
None
```
