### PR TITLE
[release-0.65] Pin goutils to v1.1.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -54,7 +54,7 @@ require (
 	github.com/Azure/go-autorest/tracing v0.6.0 // indirect
 	github.com/BurntSushi/toml v0.3.1 // indirect
 	github.com/MakeNowJust/heredoc v0.0.0-20170808103936-bb23615498cd // indirect
-	github.com/Masterminds/goutils v1.1.0 // indirect
+	github.com/Masterminds/goutils v1.1.1 // indirect
 	github.com/Masterminds/semver/v3 v3.1.0 // indirect
 	github.com/Masterminds/sprig/v3 v3.1.0 // indirect
 	github.com/Masterminds/squirrel v1.2.0 // indirect
@@ -277,5 +277,7 @@ replace (
 	golang.org/x/text => golang.org/x/text v0.3.3
 	k8s.io/client-go => k8s.io/client-go v0.23.1
 )
+
+replace github.com/Masterminds/goutils => github.com/Masterminds/goutils v1.1.1
 
 go 1.17

--- a/go.sum
+++ b/go.sum
@@ -91,8 +91,8 @@ github.com/DATA-DOG/go-sqlmock v1.4.1/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q
 github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/MakeNowJust/heredoc v0.0.0-20170808103936-bb23615498cd h1:sjQovDkwrZp8u+gxLtPgKGjk5hCxuy2hrRejBTA9xFU=
 github.com/MakeNowJust/heredoc v0.0.0-20170808103936-bb23615498cd/go.mod h1:64YHyfSL2R96J44Nlwm39UHepQbyR5q10x7iYa1ks2E=
-github.com/Masterminds/goutils v1.1.0 h1:zukEsf/1JZwCMgHiK3GZftabmxiCw4apj3a28RPBiVg=
-github.com/Masterminds/goutils v1.1.0/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy863GQaJW2MFNU=
+github.com/Masterminds/goutils v1.1.1 h1:5nUrii3FMTL5diU80unEVvNevw1nH4+ZV4DSLVJLSYI=
+github.com/Masterminds/goutils v1.1.1/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy863GQaJW2MFNU=
 github.com/Masterminds/semver v1.5.0 h1:H65muMkzWKEuNDnfl9d70GUjFniHKHRbFPGBuZ3QEww=
 github.com/Masterminds/semver v1.5.0/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
 github.com/Masterminds/semver/v3 v3.1.0 h1:Y2lUDsFKVRSYGojLJ1yLxSXdMmMYTYls0rCvoqmMUQk=

--- a/vendor/github.com/Masterminds/goutils/cryptorandomstringutils.go
+++ b/vendor/github.com/Masterminds/goutils/cryptorandomstringutils.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"math"
 	"math/big"
-	"regexp"
 	"unicode"
 )
 
@@ -99,27 +98,7 @@ Returns:
 	error - an error stemming from an invalid parameter within underlying function, CryptoRandom(...)
 */
 func CryptoRandomAlphaNumeric(count int) (string, error) {
-	if count == 0 {
-		return "", nil
-	}
-	RandomString, err := CryptoRandom(count, 0, 0, true, true)
-	if err != nil {
-		return "", fmt.Errorf("Error: %s", err)
-	}
-	match, err := regexp.MatchString("([0-9]+)", RandomString)
-	if err != nil {
-		panic(err)
-	}
-
-	if !match {
-		//Get the position between 0 and the length of the string-1  to insert a random number
-		position := getCryptoRandomInt(count)
-		//Insert a random number between [0-9] in the position
-		RandomString = RandomString[:position] + string('0' + getCryptoRandomInt(10)) + RandomString[position + 1:]
-		return RandomString, err
-	}
-	return RandomString, err
-
+	return CryptoRandom(count, 0, 0, true, true)
 }
 
 /*
@@ -204,7 +183,7 @@ func CryptoRandom(count int, start int, end int, letters bool, numbers bool, cha
 		if chars == nil {
 			ch = rune(getCryptoRandomInt(gap) + int64(start))
 		} else {
-			ch = chars[getCryptoRandomInt(gap) + int64(start)]
+			ch = chars[getCryptoRandomInt(gap)+int64(start)]
 		}
 
 		if letters && unicode.IsLetter(ch) || numbers && unicode.IsDigit(ch) || !letters && !numbers {

--- a/vendor/github.com/Masterminds/goutils/randomstringutils.go
+++ b/vendor/github.com/Masterminds/goutils/randomstringutils.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"math"
 	"math/rand"
-	"regexp"
 	"time"
 	"unicode"
 )
@@ -75,12 +74,10 @@ func RandomNumeric(count int) (string, error) {
 
 /*
 RandomAlphabetic creates a random string whose length is the number of characters specified.
-Characters will be chosen from the set of alpha-numeric characters as indicated by the arguments.
+Characters will be chosen from the set of alphabetic characters.
 
 Parameters:
 	count - the length of random string to create
-	letters - if true, generated string may include alphabetic characters
-	numbers - if true, generated string may include numeric characters
 
 Returns:
 	string - the random string
@@ -102,24 +99,7 @@ Returns:
 	error - an error stemming from an invalid parameter within underlying function, RandomSeed(...)
 */
 func RandomAlphaNumeric(count int) (string, error) {
-	RandomString, err := Random(count, 0, 0, true, true)
-	if err != nil {
-		return "", fmt.Errorf("Error: %s", err)
-	}
-	match, err := regexp.MatchString("([0-9]+)", RandomString)
-	if err != nil {
-		panic(err)
-	}
-
-	if !match {
-		//Get the position between 0 and the length of the string-1  to insert a random number
-		position := rand.Intn(count)
-		//Insert a random number between [0-9] in the position
-		RandomString = RandomString[:position] + string('0'+rand.Intn(10)) + RandomString[position+1:]
-		return RandomString, err
-	}
-	return RandomString, err
-
+	return Random(count, 0, 0, true, true)
 }
 
 /*

--- a/vendor/github.com/Masterminds/goutils/stringutils.go
+++ b/vendor/github.com/Masterminds/goutils/stringutils.go
@@ -222,3 +222,19 @@ func IndexOf(str string, sub string, start int) int {
 func IsEmpty(str string) bool {
 	return len(str) == 0
 }
+
+// Returns either the passed in string, or if the string is empty, the value of defaultStr.
+func DefaultString(str string, defaultStr string) string {
+	if IsEmpty(str) {
+		return defaultStr
+	}
+	return str
+}
+
+// Returns either the passed in string, or if the string is whitespace, empty (""), the value of defaultStr.
+func DefaultIfBlank(str string, defaultStr string) string {
+	if IsBlank(str) {
+		return defaultStr
+	}
+	return str
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -30,7 +30,7 @@ github.com/BurntSushi/toml
 # github.com/MakeNowJust/heredoc v0.0.0-20170808103936-bb23615498cd
 ## explicit
 github.com/MakeNowJust/heredoc
-# github.com/Masterminds/goutils v1.1.0
+# github.com/Masterminds/goutils v1.1.1 => github.com/Masterminds/goutils v1.1.1
 ## explicit
 github.com/Masterminds/goutils
 # github.com/Masterminds/semver v1.5.0
@@ -1866,3 +1866,4 @@ sigs.k8s.io/yaml
 # github.com/openshift/custom-resource-status => github.com/openshift/custom-resource-status v1.1.2
 # golang.org/x/text => golang.org/x/text v0.3.3
 # k8s.io/client-go => k8s.io/client-go v0.23.1
+# github.com/Masterminds/goutils => github.com/Masterminds/goutils v1.1.1


### PR DESCRIPTION
**What this PR does / why we need it**:

Address https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-4238.

**Special notes for your reviewer**:

Manual backport of https://github.com/kubevirt/cluster-network-addons-operator/pull/1504.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
