### PR TITLE
Fix nmstate service cleanup

### DIFF
--- a/pkg/network/nmstate.go
+++ b/pkg/network/nmstate.go
@@ -141,7 +141,7 @@ func removeNmstateWebhookService(ctx context.Context, client k8sclient.Client) [
 	name := "nmstate-webhook"
 	kind := "Service"
 
-	return removeAppsV1Resource(ctx, client, name, namespace, kind)
+	return removeCoreV1Resource(ctx, client, name, namespace, kind)
 }
 
 func removeNmstateCertManager(ctx context.Context, client k8sclient.Client) []error {

--- a/test/e2e/workflow/deployment_test.go
+++ b/test/e2e/workflow/deployment_test.go
@@ -537,7 +537,9 @@ var _ = Describe("NetworkAddonsConfig", func() {
 						errHandler := testenv.Client.Get(context.TODO(), types.NamespacedName{Name: NMStateComponent.DaemonSets[0], Namespace: "cluster-network-addons"}, nmstateHandlerDaemonSet)
 						nmstateWebhookPDB := &policyv1.PodDisruptionBudget{}
 						errWebhookPDB := testenv.Client.Get(context.TODO(), types.NamespacedName{Name: "nmstate-webhook", Namespace: "cluster-network-addons"}, nmstateWebhookPDB)
-						return apierrors.IsNotFound(errHandler) && apierrors.IsNotFound(errWebhookPDB)
+						nmstateWebhookService := &corev1.Service{}
+						errWebhookService := testenv.Client.Get(context.TODO(), types.NamespacedName{Name: "nmstate-webhook", Namespace: "cluster-network-addons"}, nmstateWebhookService)
+						return apierrors.IsNotFound(errHandler) && apierrors.IsNotFound(errWebhookPDB) && apierrors.IsNotFound(errWebhookService)
 					}
 					Eventually(func() bool {
 						return cnaoNmstateNotFound()


### PR DESCRIPTION


**What this PR does / why we need it**:

The original code was using a wrong API group. With this patch, the group is fixed and a test is added.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
