### PR TITLE
placement-configuration: Add infra tolerations

### DIFF
--- a/pkg/network/placement_configuration.go
+++ b/pkg/network/placement_configuration.go
@@ -7,6 +7,7 @@ import (
 )
 
 func GetDefaultPlacementConfiguration() cnao.PlacementConfiguration {
+	var nodeNotNReadyTolerationInSeconds int64 = 60
 	return cnao.PlacementConfiguration{
 		Infra: &cnao.Placement{
 			Tolerations: []corev1.Toleration{
@@ -19,6 +20,18 @@ func GetDefaultPlacementConfiguration() cnao.PlacementConfiguration {
 					Key:      "node-role.kubernetes.io/master",
 					Operator: corev1.TolerationOpExists,
 					Effect:   corev1.TaintEffectNoSchedule,
+				},
+				corev1.Toleration{
+					Key:               "node.kubernetes.io/unreachable",
+					Operator:          corev1.TolerationOpExists,
+					Effect:            corev1.TaintEffectNoExecute,
+					TolerationSeconds: &nodeNotNReadyTolerationInSeconds,
+				},
+				corev1.Toleration{
+					Key:               "node.kubernetes.io/not-ready",
+					Operator:          corev1.TolerationOpExists,
+					Effect:            corev1.TaintEffectNoExecute,
+					TolerationSeconds: &nodeNotNReadyTolerationInSeconds,
 				},
 			},
 			Affinity: corev1.Affinity{


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently the default toleration for pods is to evict a node after 5 minutes that the node is not-ready/unschedulable.
In pods running on master nodes, this eviction needs to be faster in order to not delay a node's reboot.

This PR is adding infra tolerations that allows a pod to evict after 1 minute in case the node it is scheduled on is not-ready/unschedulable. 
As currently the only component using infra placement is Kubemacpool, this is the only component that will be affected.

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
