### PR TITLE
Macvtap parametrize configmap

### DIFF
--- a/pkg/apis/networkaddonsoperator/shared/networkaddonsconfig_types.go
+++ b/pkg/apis/networkaddonsoperator/shared/networkaddonsconfig_types.go
@@ -81,7 +81,11 @@ type KubeMacPool struct {
 }
 
 // MacvtapCni plugin allows users to define Kubernetes networks on top of existing host interfaces
-type MacvtapCni struct{}
+type MacvtapCni struct {
+	// DevicePluginConfig allows the user to override the name of the
+	// `ConfigMap` where the device plugin configuration is held.
+	DevicePluginConfig string `json:"devicePluginConfig,omitempty"`
+}
 
 // NetworkAddonsConfigStatus defines the observed state of NetworkAddonsConfig
 type NetworkAddonsConfigStatus struct {

--- a/pkg/network/macvtap.go
+++ b/pkg/network/macvtap.go
@@ -24,6 +24,7 @@ func renderMacvtapCni(conf *cnao.NetworkAddonsConfigSpec, manifestDir string, cl
 	data.Data["ImagePullPolicy"] = conf.ImagePullPolicy
 	data.Data["EnableSCC"] = clusterInfo.SCCAvailable
 	data.Data["MacvtapImage"] = os.Getenv("MACVTAP_CNI_IMAGE")
+	data.Data["DevicePluginConfigName"] = conf.MacvtapCni.DevicePluginConfig
 	if clusterInfo.OpenShift4 {
 		data.Data["CniMountPath"] = cni.BinDirOpenShift4
 	} else {

--- a/pkg/network/macvtap.go
+++ b/pkg/network/macvtap.go
@@ -37,3 +37,11 @@ func renderMacvtapCni(conf *cnao.NetworkAddonsConfigSpec, manifestDir string, cl
 
 	return objs, nil
 }
+
+func fillMacvtapDefaults(conf *cnao.NetworkAddonsConfigSpec) {
+	// https://github.com/kubevirt/macvtap-cni/blob/be1528fb09e9ac3c490a5df31330851d7e1f8b0a/manifests/macvtap.yaml#L23
+	const defaultMacvtapDevicePluginConfigMapName = "macvtap-deviceplugin-config"
+	if conf.MacvtapCni != nil && conf.MacvtapCni.DevicePluginConfig == "" {
+		conf.MacvtapCni.DevicePluginConfig = defaultMacvtapDevicePluginConfigMapName
+	}
+}

--- a/pkg/network/macvtap_test.go
+++ b/pkg/network/macvtap_test.go
@@ -1,0 +1,29 @@
+package network
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	cnao "github.com/kubevirt/cluster-network-addons-operator/pkg/apis/networkaddonsoperator/shared"
+)
+
+var _ = Describe("Testing macvtap", func() {
+	var config cnao.NetworkAddonsConfigSpec
+
+	Context("the device plugin configuration is not provided", func() {
+		BeforeEach(func() {
+			config = cnao.NetworkAddonsConfigSpec{
+				MacvtapCni: &cnao.MacvtapCni{},
+			}
+		})
+
+		It("defaults to the configuration", func() {
+			fillMacvtapDefaults(&config)
+			Expect(config).To(Equal(
+				cnao.NetworkAddonsConfigSpec{
+					MacvtapCni: &cnao.MacvtapCni{
+						DevicePluginConfig: "macvtap-deviceplugin-config"},
+				}))
+		})
+	})
+})

--- a/pkg/network/network.go
+++ b/pkg/network/network.go
@@ -61,6 +61,7 @@ func FillDefaults(conf, previous *cnao.NetworkAddonsConfigSpec) error {
 	errs = append(errs, fillDefaultsSelfSignConfiguration(conf, previous)...)
 	errs = append(errs, fillDefaultsImagePullPolicy(conf, previous)...)
 	errs = append(errs, fillDefaultsKubeMacPool(conf, previous)...)
+	fillMacvtapDefaults(conf)
 
 	if len(errs) > 0 {
 		return errors.Errorf("invalid configuration:\n%s", errorListToMultiLineString(errs))


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the main branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it

If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**What this PR does / why we need it**:
This PR adds a knob allowing users to override the name of the config map holding the macvtap device plugin `ConfigMap` name.

**Special notes for your reviewer**:
Fixes: #1512 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
Allow users to override the ConfigMap holding the macvtap device plugin configuration.
```
