### PR TITLE
macvtap: allows overriding the macvtap device plugin configuration

### DIFF
--- a/components.yaml
+++ b/components.yaml
@@ -25,10 +25,10 @@ components:
     metadata: v1.2.0
   macvtap-cni:
     url: https://github.com/kubevirt/macvtap-cni
-    commit: e8e76c0fbf140d9f14a0b87775e363a43624f477
+    commit: de5c9df7c0d58479a5f491821e981fa630292a55
     branch: main
     update-policy: tagged
-    metadata: v0.10.1
+    metadata: v0.11.0
   multus:
     url: https://github.com/k8snetworkplumbingwg/multus-cni
     commit: 77e0150afe0665438bc75e2bc6b2caa72aeb46c8

--- a/data/macvtap/002-macvtap-daemonset.yaml
+++ b/data/macvtap/002-macvtap-daemonset.yaml
@@ -30,7 +30,7 @@ spec:
           command: ["/macvtap-deviceplugin", "-v", "3", "-logtostderr"]
           envFrom:
             - configMapRef:
-                name: macvtap-deviceplugin-config
+                name: {{ .DevicePluginConfigName }}
           image: {{ .MacvtapImage }}
           imagePullPolicy: {{ .ImagePullPolicy }}
           resources:

--- a/pkg/apis/networkaddonsoperator/shared/networkaddonsconfig_types.go
+++ b/pkg/apis/networkaddonsoperator/shared/networkaddonsconfig_types.go
@@ -81,7 +81,11 @@ type KubeMacPool struct {
 }
 
 // MacvtapCni plugin allows users to define Kubernetes networks on top of existing host interfaces
-type MacvtapCni struct{}
+type MacvtapCni struct {
+	// DevicePluginConfig allows the user to override the name of the
+	// `ConfigMap` where the device plugin configuration is held.
+	DevicePluginConfig string `json:"devicePluginConfig,omitempty"`
+}
 
 // NetworkAddonsConfigStatus defines the observed state of NetworkAddonsConfig
 type NetworkAddonsConfigStatus struct {

--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -35,7 +35,7 @@ const (
 	LinuxBridgeMarkerImageDefault     = "quay.io/kubevirt/bridge-marker@sha256:5d24c6d1ecb0556896b7b81c7e5260b54173858425777b7a84df8a706c07e6d2"
 	KubeMacPoolImageDefault           = "quay.io/kubevirt/kubemacpool@sha256:0cc5ad824fc163d6dea5e9bd872467c691eaa9a88944008b5d746495b2a72214"
 	OvsCniImageDefault                = "quay.io/kubevirt/ovs-cni-plugin@sha256:5f7290e2294255ab2547c3b4bf48cc2d75531ec5a43e600366e9b2719bef983f"
-	MacvtapCniImageDefault            = "quay.io/kubevirt/macvtap-cni@sha256:5a288f1f9956c2ea8127fa736b598326852d2aa58a8469fa663a1150c2313b02"
+	MacvtapCniImageDefault            = "quay.io/kubevirt/macvtap-cni@sha256:434420511e09b2b5ede785a2c9062b6658ffbc26fbdd4629ce06110f9039c600"
 	KubeRbacProxyImageDefault         = "quay.io/openshift/origin-kube-rbac-proxy@sha256:baedb268ac66456018fb30af395bb3d69af5fff3252ff5d549f0231b1ebb6901"
 	KubeSecondaryDNSImageDefault      = "ghcr.io/kubevirt/kubesecondarydns@sha256:b489a7c5d05b000f776c9c302985b8b7f29ff31f577a1480912ed625c8772d6b"
 	CoreDNSImageDefault               = "k8s.gcr.io/coredns/coredns@sha256:5b6ec0d6de9baaf3e92d0f66cd96a25b9edbce8716f5f15dcd1a616b3abd590e"

--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -824,6 +824,12 @@ func GetCrd() *extv1.CustomResourceDefinition {
 						"macvtap": extv1.JSONSchemaProps{
 							Description: "MacvtapCni plugin allows users to define Kubernetes networks on top of existing host interfaces",
 							Type:        "object",
+							Properties: map[string]extv1.JSONSchemaProps{
+								"devicePluginConfig": extv1.JSONSchemaProps{
+									Description: "DevicePluginConfig allows the user to override the name of the `ConfigMap` where the device plugin configuration is held",
+									Type:        "string",
+								},
+							},
 						},
 						"multus": extv1.JSONSchemaProps{
 							Description: "Multus plugin enables attaching multiple network interfaces to Pods in Kubernetes",

--- a/pkg/network/macvtap.go
+++ b/pkg/network/macvtap.go
@@ -24,6 +24,7 @@ func renderMacvtapCni(conf *cnao.NetworkAddonsConfigSpec, manifestDir string, cl
 	data.Data["ImagePullPolicy"] = conf.ImagePullPolicy
 	data.Data["EnableSCC"] = clusterInfo.SCCAvailable
 	data.Data["MacvtapImage"] = os.Getenv("MACVTAP_CNI_IMAGE")
+	data.Data["DevicePluginConfigName"] = conf.MacvtapCni.DevicePluginConfig
 	if clusterInfo.OpenShift4 {
 		data.Data["CniMountPath"] = cni.BinDirOpenShift4
 	} else {

--- a/pkg/network/macvtap.go
+++ b/pkg/network/macvtap.go
@@ -37,3 +37,23 @@ func renderMacvtapCni(conf *cnao.NetworkAddonsConfigSpec, manifestDir string, cl
 
 	return objs, nil
 }
+
+func fillMacvtapDefaults(conf *cnao.NetworkAddonsConfigSpec, previousConf *cnao.NetworkAddonsConfigSpec) {
+	if conf.MacvtapCni == nil {
+		return
+	}
+
+	// https://github.com/kubevirt/macvtap-cni/blob/be1528fb09e9ac3c490a5df31330851d7e1f8b0a/manifests/macvtap.yaml#L23
+	const defaultMacvtapDevicePluginConfigMapName = "macvtap-deviceplugin-config"
+	if conf.MacvtapCni.DevicePluginConfig == "" {
+		if hasDevicePluginConfigMapNameDefined(previousConf) {
+			conf.MacvtapCni.DevicePluginConfig = previousConf.MacvtapCni.DevicePluginConfig
+			return
+		}
+		conf.MacvtapCni.DevicePluginConfig = defaultMacvtapDevicePluginConfigMapName
+	}
+}
+
+func hasDevicePluginConfigMapNameDefined(conf *cnao.NetworkAddonsConfigSpec) bool {
+	return conf != nil && conf.MacvtapCni != nil && conf.MacvtapCni.DevicePluginConfig != ""
+}

--- a/pkg/network/macvtap_test.go
+++ b/pkg/network/macvtap_test.go
@@ -1,0 +1,61 @@
+package network
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	cnao "github.com/kubevirt/cluster-network-addons-operator/pkg/apis/networkaddonsoperator/shared"
+)
+
+var _ = Describe("Testing macvtap", func() {
+	var config cnao.NetworkAddonsConfigSpec
+
+	Context("the device plugin configuration is not provided", func() {
+		BeforeEach(func() {
+			config = cnao.NetworkAddonsConfigSpec{
+				MacvtapCni: &cnao.MacvtapCni{},
+			}
+		})
+
+		It("uses a default config map name", func() {
+			fillMacvtapDefaults(&config, nil)
+			Expect(config).To(Equal(
+				cnao.NetworkAddonsConfigSpec{
+					MacvtapCni: &cnao.MacvtapCni{
+						DevicePluginConfig: "macvtap-deviceplugin-config"},
+				}))
+		})
+
+		It("uses the previous configuration config map name when available", func() {
+			const configMapNameFromOldDays = "ldfj239"
+			oldConfig := cnao.NetworkAddonsConfigSpec{
+				MacvtapCni: &cnao.MacvtapCni{DevicePluginConfig: configMapNameFromOldDays},
+			}
+			fillMacvtapDefaults(&config, &oldConfig)
+			Expect(config).To(Equal(
+				cnao.NetworkAddonsConfigSpec{
+					MacvtapCni: &cnao.MacvtapCni{
+						DevicePluginConfig: configMapNameFromOldDays},
+				}))
+		})
+	})
+
+	It("uses the device plugin configuration defined in the macvtap config", func() {
+		const (
+			configMapNameFromOldDays = "ldfj239"
+			newConfigMapName         = "jasfjaofj"
+		)
+		oldConfig := cnao.NetworkAddonsConfigSpec{
+			MacvtapCni: &cnao.MacvtapCni{DevicePluginConfig: configMapNameFromOldDays},
+		}
+		newConfig := cnao.NetworkAddonsConfigSpec{
+			MacvtapCni: &cnao.MacvtapCni{DevicePluginConfig: newConfigMapName},
+		}
+		fillMacvtapDefaults(&newConfig, &oldConfig)
+		Expect(newConfig).To(Equal(
+			cnao.NetworkAddonsConfigSpec{
+				MacvtapCni: &cnao.MacvtapCni{
+					DevicePluginConfig: newConfigMapName},
+			}))
+	})
+})

--- a/pkg/network/network.go
+++ b/pkg/network/network.go
@@ -61,6 +61,7 @@ func FillDefaults(conf, previous *cnao.NetworkAddonsConfigSpec) error {
 	errs = append(errs, fillDefaultsSelfSignConfiguration(conf, previous)...)
 	errs = append(errs, fillDefaultsImagePullPolicy(conf, previous)...)
 	errs = append(errs, fillDefaultsKubeMacPool(conf, previous)...)
+	fillMacvtapDefaults(conf, previous)
 
 	if len(errs) > 0 {
 		return errors.Errorf("invalid configuration:\n%s", errorListToMultiLineString(errs))

--- a/test/e2e/workflow/deployment_test.go
+++ b/test/e2e/workflow/deployment_test.go
@@ -7,6 +7,7 @@ import (
 
 	v1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/retry"
@@ -319,42 +320,71 @@ var _ = Describe("NetworkAddonsConfig", func() {
 		})
 	})
 	Context("when Macvtap is deployed", func() {
-		BeforeEach(func() {
-			configSpec := cnao.NetworkAddonsConfigSpec{
-				MacvtapCni: &cnao.MacvtapCni{},
-			}
-			CreateConfig(gvk, configSpec)
-			CheckConfigCondition(gvk, ConditionAvailable, ConditionTrue, 15*time.Minute, CheckDoNotRepeat)
-		})
-		Context("and a forbidden day2 change is introduced to Macvtap daemonSet", func() {
-			annotationKey := "newDay2Changes"
+		Context("with the default device plugin configuration", func() {
 			BeforeEach(func() {
-				By("Setting a new Annotation to the macvtap daemonSet")
-				err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-					macvtapDaemonSet := &v1.DaemonSet{}
-					err := testenv.Client.Get(context.TODO(), types.NamespacedName{Name: MacvtapComponent.DaemonSets[0], Namespace: components.Namespace}, macvtapDaemonSet)
-					Expect(err).ToNot(HaveOccurred(), "should succeed getting the macvtap daemonSet")
+				configSpec := cnao.NetworkAddonsConfigSpec{
+					MacvtapCni: &cnao.MacvtapCni{},
+				}
+				CreateConfig(gvk, configSpec)
+				CheckConfigCondition(gvk, ConditionAvailable, ConditionTrue, 15*time.Minute, CheckDoNotRepeat)
+			})
+			Context("and a forbidden day2 change is introduced to Macvtap daemonSet", func() {
+				annotationKey := "newDay2Changes"
+				BeforeEach(func() {
+					By("Setting a new Annotation to the macvtap daemonSet")
+					err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+						macvtapDaemonSet := &v1.DaemonSet{}
+						err := testenv.Client.Get(context.TODO(), types.NamespacedName{Name: MacvtapComponent.DaemonSets[0], Namespace: components.Namespace}, macvtapDaemonSet)
+						Expect(err).ToNot(HaveOccurred(), "should succeed getting the macvtap daemonSet")
 
-					macvtapDaemonSet.Spec.Template.SetAnnotations(map[string]string{annotationKey: ""})
-					return testenv.Client.Update(context.TODO(), macvtapDaemonSet)
+						macvtapDaemonSet.Spec.Template.SetAnnotations(map[string]string{annotationKey: ""})
+						return testenv.Client.Update(context.TODO(), macvtapDaemonSet)
+					})
+					Expect(err).ToNot(HaveOccurred(), "should succeed setting a new Annotation to the macvtap daemonSet")
 				})
-				Expect(err).ToNot(HaveOccurred(), "should succeed setting a new Annotation to the macvtap daemonSet")
+
+				It("should reconcile the object and remove the new Annotation", func() {
+					By("checking that the Annotation eventually removed reconciled out by the CNAO operator")
+					Eventually(func() bool {
+						macvtapDaemonSet := &v1.DaemonSet{}
+						err := testenv.Client.Get(context.TODO(), types.NamespacedName{Name: MacvtapComponent.DaemonSets[0], Namespace: components.Namespace}, macvtapDaemonSet)
+						Expect(err).ToNot(HaveOccurred(), "should succeed getting the macvtap daemonSet")
+
+						deamonSetAnnotations := macvtapDaemonSet.Spec.Template.GetAnnotations()
+						if _, exist := deamonSetAnnotations[annotationKey]; exist {
+							return false
+						}
+						return true
+
+					}, 2*time.Minute, time.Second).Should(BeTrue(), fmt.Sprintf("Timed out waiting for macvtap daemonset added Annotation to be removed"))
+				})
+			})
+		})
+
+		Context("with a non-default configuration", func() {
+			const overriddenConfigMapName = "another-config"
+
+			BeforeEach(func() {
+				configSpec := cnao.NetworkAddonsConfigSpec{
+					MacvtapCni: &cnao.MacvtapCni{DevicePluginConfig: overriddenConfigMapName},
+				}
+				CreateConfig(gvk, configSpec)
+				CheckConfigCondition(gvk, ConditionAvailable, ConditionFalse, time.Minute, time.Minute)
+				CheckConfigCondition(gvk, ConditionProgressing, ConditionTrue, CheckDoNotRepeat, CheckDoNotRepeat)
 			})
 
-			It("should reconcile the object and remove the new Annotation", func() {
-				By("checking that the Annotation eventually removed reconciled out by the CNAO operator")
-				Eventually(func() bool {
-					macvtapDaemonSet := &v1.DaemonSet{}
-					err := testenv.Client.Get(context.TODO(), types.NamespacedName{Name: MacvtapComponent.DaemonSets[0], Namespace: components.Namespace}, macvtapDaemonSet)
-					Expect(err).ToNot(HaveOccurred(), "should succeed getting the macvtap daemonSet")
-
-					deamonSetAnnotations := macvtapDaemonSet.Spec.Template.GetAnnotations()
-					if _, exist := deamonSetAnnotations[annotationKey]; exist {
-						return false
-					}
-					return true
-
-				}, 2*time.Minute, time.Second).Should(BeTrue(), fmt.Sprintf("Timed out waiting for macvtap daemonset added Annotation to be removed"))
+			It("goes to available once the device plugin configuration is provisioned", func() {
+				configMap := &corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      overriddenConfigMapName,
+						Namespace: components.Namespace,
+					},
+					Data: map[string]string{
+						"DP_MACVTAP_CONF": "[]",
+					},
+				}
+				Expect(testenv.KubeClient.CoreV1().ConfigMaps(components.Namespace).Create(context.Background(), configMap, metav1.CreateOptions{}))
+				CheckConfigCondition(gvk, ConditionAvailable, ConditionTrue, 2*time.Minute, CheckDoNotRepeat)
 			})
 		})
 	})


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the main branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it

If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**What this PR does / why we need it**:
This PR allows users to define the macvtap-cni device-plugin configuration instead of using link auto-discovery (i.e. all links available in the host would be allowed as macvtap lower devices).

For that, we need macvtap-cni [v.0.11.0](https://github.com/kubevirt/macvtap-cni/releases/tag/v0.11.0), which templates the name of the config map holding the device plugin configuration.

**Special notes for your reviewer**:
Fixes: #1512 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
Allows overriding the macvtap-cni device plugin configuration.
```
