### PR TITLE
ksd: Update bump to include CoreDNS as well

### DIFF
--- a/hack/components/bump-kube-secondary-dns.sh
+++ b/hack/components/bump-kube-secondary-dns.sh
@@ -91,5 +91,11 @@ KUBE_SECONDARY_DNS_IMAGE=ghcr.io/kubevirt/kubesecondarydns
 KUBE_SECONDARY_DNS_IMAGE_TAGGED=${KUBE_SECONDARY_DNS_IMAGE}:${KUBE_SECONDARY_DNS_TAG}
 KUBE_SECONDARY_DNS_IMAGE_DIGEST="$(docker-utils::get_image_digest "${KUBE_SECONDARY_DNS_IMAGE_TAGGED}" "${KUBE_SECONDARY_DNS_IMAGE}")"
 
+CORE_DNS_IMAGE=registry.k8s.io/coredns/coredns
+CORE_DNS_IMAGE_TAGGED=$(grep $CORE_DNS_IMAGE ${KUBE_SECONDARY_DNS_PATH}/manifests/secondarydns.yaml | awk -F": " '{print $2}')
+CORE_DNS_IMAGE_DIGEST="$(docker-utils::get_image_digest "${CORE_DNS_IMAGE_TAGGED}" "${CORE_DNS_IMAGE}")"
+
 sed -i -r "s#\"${KUBE_SECONDARY_DNS_IMAGE}(@sha256)?:.*\"#\"${KUBE_SECONDARY_DNS_IMAGE_DIGEST}\"#" pkg/components/components.go
 sed -i -r "s#\"${KUBE_SECONDARY_DNS_IMAGE}(@sha256)?:.*\"#\"${KUBE_SECONDARY_DNS_IMAGE_DIGEST}\"#" test/releases/${CNAO_VERSION}.go
+
+sed -i -r "s#\"${CORE_DNS_IMAGE}(@sha256)?:.*\"#\"${CORE_DNS_IMAGE_DIGEST}\"#" pkg/components/components.go


### PR DESCRIPTION
**What this PR does / why we need it**:
Add the missing CoreDNS to KSD bump script.
In case we change the image on KSD, it will be reflected on CNAO as well.

Use the original manifest because the updated one is parameterized already,
and isn't split to yamls (so can't use yaml-utils).

**Special notes for your reviewer**:
Note that sed won't fail in case `CORE_DNS_IMAGE` isn't found,
we can improve it on the future, it isn't since it doesn't change a lot.
It is the same case for the rest of the images.
 
**Release note**:
```release-note
None
```
