### PR TITLE
kmp: Add placement to cert-manager

### DIFF
--- a/data/kubemacpool/kubemacpool.yaml
+++ b/data/kubemacpool/kubemacpool.yaml
@@ -260,6 +260,7 @@ spec:
         control-plane: cert-manager
         controller-tools.k8s.io: "1.0"
     spec:
+      affinity: {{ toYaml .Placement.Affinity | nindent 8 }}
       containers:
       - args:
         - --v=production
@@ -307,9 +308,11 @@ spec:
           requests:
             cpu: 30m
             memory: 30Mi
+      nodeSelector: {{ toYaml .Placement.NodeSelector | nindent 8 }}
       priorityClassName: system-cluster-critical
       restartPolicy: Always
       terminationGracePeriodSeconds: 5
+      tolerations: {{ toYaml .Placement.Tolerations | nindent 8 }}
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/hack/components/bump-kubemacpool.sh
+++ b/hack/components/bump-kubemacpool.sh
@@ -69,6 +69,9 @@ metadata:
 spec:
   template:
     spec:
+      affinity: AFFINITY
+      nodeSelector: NODE_SELECTOR
+      tolerations: TOLERATIONS
       containers:
       - image: "{{ .KubeMacPoolImage }}"
         imagePullPolicy: "{{ .ImagePullPolicy }}"

--- a/test/check/check.go
+++ b/test/check/check.go
@@ -112,6 +112,26 @@ func PlacementListFromComponentDaemonSets(component Component) ([]cnao.Placement
 	return placementList, nil
 }
 
+func PlacementListFromComponentDeployments(component Component) ([]cnao.Placement, error) {
+	placementList := []cnao.Placement{}
+	for _, deploymentName := range component.Deployments {
+		deployment := appsv1.Deployment{}
+		err := testenv.Client.Get(context.Background(), types.NamespacedName{Name: deploymentName, Namespace: components.Namespace}, &deployment)
+		if err != nil {
+			return placementList, err
+		}
+
+		deploymentPlacement := cnao.Placement{}
+		deploymentPlacement.NodeSelector = deployment.Spec.Template.Spec.NodeSelector
+		deploymentPlacement.Affinity = *deployment.Spec.Template.Spec.Affinity
+		deploymentPlacement.Tolerations = deployment.Spec.Template.Spec.Tolerations
+
+		placementList = append(placementList, deploymentPlacement)
+	}
+
+	return placementList, nil
+}
+
 func GetEnvVarsFromDeployment(deploymentName string) ([]corev1.EnvVar, error) {
 	deployment := appsv1.Deployment{}
 	err := testenv.Client.Get(context.Background(), types.NamespacedName{Name: deploymentName, Namespace: components.Namespace}, &deployment)

--- a/test/e2e/workflow/deployment_test.go
+++ b/test/e2e/workflow/deployment_test.go
@@ -209,6 +209,46 @@ var _ = Describe("NetworkAddonsConfig", func() {
 				checkWorkloadPlacementOnComponents(*configSpec.PlacementConfiguration.Workloads)
 			})
 		})
+		Context("and infra PlacementConfiguration is deployed on components", func() {
+			components := []Component{
+				KubeMacPoolComponent,
+			}
+			configSpec := cnao.NetworkAddonsConfigSpec{
+				KubeMacPool:            &cnao.KubeMacPool{},
+				PlacementConfiguration: &cnao.PlacementConfiguration{},
+			}
+			checkInfraPlacementOnComponents := func(expectedInfraPlacement cnao.Placement) {
+				for _, component := range components {
+					componentPlacementList, err := PlacementListFromComponentDeployments(component)
+					Expect(err).ToNot(HaveOccurred(), "Should succeed getting the component Placement config")
+					for _, placement := range componentPlacementList {
+						Expect(placement).To(Equal(expectedInfraPlacement), fmt.Sprintf("PlacementConfiguration of %s component should equal the default infra PlacementConfiguration", component.ComponentName))
+					}
+				}
+			}
+
+			BeforeEach(func() {
+				By("Deploying components with default PlacementConfiguration")
+				testConfigCreate(gvk, configSpec, components)
+
+				By("Checking PlacementConfiguration was set on components to default infra PlacementConfiguration")
+				checkInfraPlacementOnComponents(*network.GetDefaultPlacementConfiguration().Infra)
+			})
+
+			It("should be able to update infra PlacementConfigurations on components specs", func() {
+				configSpec.PlacementConfiguration = &cnao.PlacementConfiguration{
+					Infra: &cnao.Placement{NodeSelector: map[string]string{
+						"kubernetes.io/hostname": "node01"},
+					},
+				}
+
+				By("Re-deploying PlacementConfiguration with different infra values")
+				testConfigUpdate(gvk, configSpec, components)
+
+				By("Checking PlacementConfiguration was set on components to updated infra PlacementConfiguration")
+				checkInfraPlacementOnComponents(*configSpec.PlacementConfiguration.Infra)
+			})
+		})
 		Context("and SelfSignConfiguration is deployed on components", func() {
 			components := []Component{
 				KubeMacPoolComponent,


### PR DESCRIPTION
**What this PR does / why we need it**:
The cert-manager deployment from kubemacpool was missing the placement ocnfiguration. This change add that to the manifets.

/kind bug

/closes https://bugzilla.redhat.com/show_bug.cgi?id=2181997

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
Add placement configuration to kubemacpool cert-manager
```
