### PR TITLE
 multus: bump imgs to v4.0.1

### DIFF
--- a/components.yaml
+++ b/components.yaml
@@ -31,10 +31,10 @@ components:
     metadata: v0.11.0
   multus:
     url: https://github.com/k8snetworkplumbingwg/multus-cni
-    commit: 77e0150afe0665438bc75e2bc6b2caa72aeb46c8
+    commit: 77aac95dfc67ae7662fdab8f406b15330c9b44a6
     branch: master
-    update-policy: static
-    metadata: ""
+    update-policy: tagged
+    metadata: "v4.0.1"
   multus-dynamic-networks:
     url: https://github.com/k8snetworkplumbingwg/multus-dynamic-networks-controller
     commit: 82597aa703a8b40d68c8c2feea94d509786d9d1a

--- a/data/multus/001-multus.yaml
+++ b/data/multus/001-multus.yaml
@@ -104,12 +104,12 @@ data:
     {
         "chrootDir": "/hostroot",
         "confDir": "/host/etc/cni/net.d",
-        "logToStderr": true,
-        "logLevel": "debug",
-        "logFile": "/tmp/multus.log",
-        "binDir": "/opt/cni/bin",
-        "cniDir": "/var/lib/cni/multus",
-        "socketDir": "/host/run/multus/"
+        "logLevel": "verbose",
+        "socketDir": "/host/run/multus/",
+        "cniVersion": "0.3.1",
+        "cniConfigDir": "/host/etc/cni/net.d",
+        "multusConfigFile": "auto",
+        "multusAutoconfigDir": "/host/etc/cni/net.d"
     }
 ---
 apiVersion: apps/v1
@@ -142,12 +142,6 @@ spec:
         - name: kube-multus
           image: {{ .MultusImage }}
           command: ["/usr/src/multus-cni/bin/multus-daemon"]
-          args:
-            - "-cni-version=0.3.1"
-            - "-cni-config-dir=/host/etc/cni/multus/net.d"
-            - "-multus-autoconfig-dir=/host/etc/cni/net.d"
-            - "-multus-log-to-stderr=true"
-            - "-multus-log-level=verbose"
           resources:
             requests:
               cpu: "10m"

--- a/hack/components/bump-multus.sh
+++ b/hack/components/bump-multus.sh
@@ -28,7 +28,6 @@ function __parametize_by_object() {
 				yaml-utils::update_param ${f} spec.template.metadata.labels.name 'kube-multus-ds-amd64'
 				yaml-utils::update_param ${f} spec.template.spec.containers[0].image '{{ .MultusImage }}'
 				yaml-utils::set_param ${f} spec.template.spec.containers[0].imagePullPolicy '{{ .ImagePullPolicy }}'
-				yaml-utils::set_param ${f} spec.template.spec.containers[0].args[1] '"-cni-config-dir=/host/etc/cni/multus/net.d"' # https://github.com/k8snetworkplumbingwg/multus-cni/issues/971
 				yaml-utils::update_param ${f} spec.template.spec.initContainers[0].image '{{ .MultusImage }}'
 				yaml-utils::set_param ${f} spec.template.spec.priorityClassName 'system-cluster-critical'
 				yaml-utils::update_param ${f} spec.template.spec.volumes[0].hostPath.path '{{ .CNIConfigDir }}'
@@ -126,9 +125,7 @@ cp ${MULTUS_PATH}/config/cnao/001-multus.yaml data/multus/
 echo 'Get multus image name'
 MULTUS_TAG=$(git-utils::get_component_tag ${MULTUS_PATH})
 MULTUS_IMAGE=ghcr.io/k8snetworkplumbingwg/multus-cni
-# TODO: do not use this hardcoded image, and rely on tagged versions instead.
-# had to resort to this shenanigan because of https://github.com/k8snetworkplumbingwg/multus-cni/issues/944
-MULTUS_IMAGE_TAGGED=${MULTUS_IMAGE}@sha256:4e336bd177b5c60e753be48484abb48edb002c7207de9f265fff2e00e8f5106e
+MULTUS_IMAGE_TAGGED="${MULTUS_IMAGE}:${MULTUS_TAG}-thick"
 if [[ -n "$(docker-utils::check_image_exists "${MULTUS_IMAGE}" "${MULTUS_TAG}")" ]]; then
     MULTUS_IMAGE_DIGEST="$(docker-utils::get_image_digest "${MULTUS_IMAGE_TAGGED}" "${MULTUS_IMAGE}")"
 else

--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -29,7 +29,7 @@ var (
 )
 
 const (
-	MultusImageDefault                = "ghcr.io/k8snetworkplumbingwg/multus-cni@sha256:4e336bd177b5c60e753be48484abb48edb002c7207de9f265fff2e00e8f5106e"
+	MultusImageDefault                = "ghcr.io/k8snetworkplumbingwg/multus-cni@sha256:42dc78591161880fadd741ccdbc1c6997d47122c4827dbc128ff591b0960b697"
 	MultusDynamicNetworksImageDefault = "ghcr.io/k8snetworkplumbingwg/multus-dynamic-networks-controller@sha256:dee1979d92f0a31598a6e3569ac7004be7d29e7ca9e31db23753ef263110dc04"
 	LinuxBridgeCniImageDefault        = "quay.io/kubevirt/cni-default-plugins@sha256:2871dd1b09cec8cb669a2008611cb81c6f9098eb674c757725154ae002ea7ab6"
 	LinuxBridgeMarkerImageDefault     = "quay.io/kubevirt/bridge-marker@sha256:5d24c6d1ecb0556896b7b81c7e5260b54173858425777b7a84df8a706c07e6d2"

--- a/test/releases/99.0.0.go
+++ b/test/releases/99.0.0.go
@@ -13,7 +13,7 @@ func init() {
 				ParentName: "multus",
 				ParentKind: "DaemonSet",
 				Name:       "kube-multus",
-				Image:      "ghcr.io/k8snetworkplumbingwg/multus-cni@sha256:4e336bd177b5c60e753be48484abb48edb002c7207de9f265fff2e00e8f5106e",
+				Image:      "ghcr.io/k8snetworkplumbingwg/multus-cni@sha256:42dc78591161880fadd741ccdbc1c6997d47122c4827dbc128ff591b0960b697",
 			},
 			{
 				ParentName: "dynamic-networks-controller-ds",
@@ -25,7 +25,7 @@ func init() {
 				ParentName: "multus",
 				ParentKind: "DaemonSet",
 				Name:       "install-multus-binary",
-				Image:      "ghcr.io/k8snetworkplumbingwg/multus-cni@sha256:4e336bd177b5c60e753be48484abb48edb002c7207de9f265fff2e00e8f5106e",
+				Image:      "ghcr.io/k8snetworkplumbingwg/multus-cni@sha256:42dc78591161880fadd741ccdbc1c6997d47122c4827dbc128ff591b0960b697",
 			},
 			{
 				ParentName: "bridge-marker",


### PR DESCRIPTION
Also, from now on, track the tagged multus releases, instead of using a pinned version.

<!-- Thanks for sending a pull request!

Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the main branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it

If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**What this PR does / why we need it**:
This PR consumes a tagged version of multus, instead of a pinned version.

It also updates the multus component update policy to track any multus releases.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
Consume multus-cni v4.0.1, thick plugin mode
```
