### PR TITLE
Bump linux bridge CNI

### DIFF
--- a/components.yaml
+++ b/components.yaml
@@ -19,10 +19,10 @@ components:
     metadata: v0.40.0
   linux-bridge:
     url: https://github.com/containernetworking/plugins
-    commit: c4d24e80d64393d2c632a825a3486d1c2c0248ec
+    commit: 9f1f9a588b1cce419007830c6301a894ff09d535
     branch: main
-    update-policy: tagged
-    metadata: v1.2.0
+    update-policy: static
+    metadata: ""
   macvtap-cni:
     url: https://github.com/kubevirt/macvtap-cni
     commit: de5c9df7c0d58479a5f491821e981fa630292a55

--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -31,7 +31,7 @@ var (
 const (
 	MultusImageDefault                = "ghcr.io/k8snetworkplumbingwg/multus-cni@sha256:4e336bd177b5c60e753be48484abb48edb002c7207de9f265fff2e00e8f5106e"
 	MultusDynamicNetworksImageDefault = "ghcr.io/k8snetworkplumbingwg/multus-dynamic-networks-controller@sha256:ef8fe97a52eb9b3c03e99979a42cf2edaa7b3365cb3eb4dd1654b1bb9e73d7a3"
-	LinuxBridgeCniImageDefault        = "quay.io/kubevirt/cni-default-plugins@sha256:e75d67fb44f4b748137c85b1c06b500607410a3218cafbf8a4bb6359f2b90373"
+	LinuxBridgeCniImageDefault        = "quay.io/kubevirt/cni-default-plugins@sha256:2871dd1b09cec8cb669a2008611cb81c6f9098eb674c757725154ae002ea7ab6"
 	LinuxBridgeMarkerImageDefault     = "quay.io/kubevirt/bridge-marker@sha256:5d24c6d1ecb0556896b7b81c7e5260b54173858425777b7a84df8a706c07e6d2"
 	KubeMacPoolImageDefault           = "quay.io/kubevirt/kubemacpool@sha256:0cc5ad824fc163d6dea5e9bd872467c691eaa9a88944008b5d746495b2a72214"
 	OvsCniImageDefault                = "quay.io/kubevirt/ovs-cni-plugin@sha256:5f7290e2294255ab2547c3b4bf48cc2d75531ec5a43e600366e9b2719bef983f"

--- a/test/releases/99.0.0.go
+++ b/test/releases/99.0.0.go
@@ -37,7 +37,7 @@ func init() {
 				ParentName: "kube-cni-linux-bridge-plugin",
 				ParentKind: "DaemonSet",
 				Name:       "cni-plugins",
-				Image:      "quay.io/kubevirt/cni-default-plugins@sha256:e75d67fb44f4b748137c85b1c06b500607410a3218cafbf8a4bb6359f2b90373",
+				Image:      "quay.io/kubevirt/cni-default-plugins@sha256:2871dd1b09cec8cb669a2008611cb81c6f9098eb674c757725154ae002ea7ab6",
 			},
 			{
 				ParentName: "kubemacpool-mac-controller-manager",


### PR DESCRIPTION
**What this PR does / why we need it**:

This introduces bug fixes resolving issues with VLAN 1 leakage and performance issues of MAC spoof filtering [2].

[1] https://github.com/containernetworking/plugins/issues/667
[2] https://bugzilla.redhat.com/show_bug.cgi?id=2173485

**Special notes for your reviewer**:

Generated by referencing the latest plugins commit  from `components.yaml`, running `PUSH_IMAGES=yes make bump-linux-bridge` and replacing tags with digests.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
Fix PVID bug and performance issues of the bridge CNI 
```
