### PR TITLE
Add cni plugins img maintainer info

### DIFF
--- a/hack/components/bump-linux-bridge.sh
+++ b/hack/components/bump-linux-bridge.sh
@@ -40,6 +40,7 @@ WORKDIR ${LINUX_BRIDGE_PATH}
 RUN GOFLAGS=-mod=vendor ./build_linux.sh
 
 FROM registry.access.redhat.com/ubi8/ubi-minimal
+LABEL org.opencontainers.image.authors="phoracek@redhat.com"
 ENV SOURCE_DIR=${REMOTE_SOURCE_DIR}/app
 RUN mkdir -p ${LINUX_BRIDGE_TAR_CONTAINER_DIR}
 RUN microdnf install -y findutils


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the main branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it

If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**What this PR does / why we need it**:
Whenever we bump the CNI source code, we need to build the
`cni-default-plugins` image locally and push it to the quay repo.

Not everyone has permissions to push to that repo; thus, we point the
user towards someone with enough permissions to push to it.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
Label a maintainer in the `cni-default-plugins` container image.
```
