### PR TITLE
operator-push: Fix script in case of external provider

### DIFF
--- a/cluster/operator-push.sh
+++ b/cluster/operator-push.sh
@@ -19,7 +19,7 @@ set -ex
 if [[ "${KUBEVIRT_PROVIDER}" == external ]]; then
     if [[ ! -v DEV_IMAGE_REGISTRY ]]; then
         echo "Missing DEV_IMAGE_REGISTRY variable"
-        return 1
+        exit 1
     fi
     manifest_registry=$DEV_IMAGE_REGISTRY
     push_registry=$manifest_registry


### PR DESCRIPTION
**What this PR does / why we need it**:
Return can't be used unless in a function or sourced script. Use exit instead.

**Special notes for your reviewer**:

**Release note**:
```release-note
None
```
