### PR TITLE
kubemacpool: Bump to v0.41.0

### DIFF
--- a/automation/check-patch.e2e-kubemacpool-functests.sh
+++ b/automation/check-patch.e2e-kubemacpool-functests.sh
@@ -54,7 +54,7 @@ main() {
     cd ${TMP_COMPONENT_PATH}
 
     export CLUSTER_ROOT_DIRECTORY=${TMP_PROJECT_PATH}
-    KUBECONFIG=${KUBECONFIG} E2E_TEST_ARGS="--junit-output=$ARTIFACTS/junit.functest.xml --ginkgo.skip $SKIPPED_TESTS" make functest
+    KUBECONFIG=${KUBECONFIG} make E2E_TEST_EXTRA_ARGS="-ginkgo.noColor -test.outputdir=$ARTIFACTS --ginkgo.junit-report=$ARTIFACTS/junit.functest.xml --ginkgo.skip $SKIPPED_TESTS" functest
 }
 
 [[ "${BASH_SOURCE[0]}" == "$0" ]] && main "$@"

--- a/components.yaml
+++ b/components.yaml
@@ -13,10 +13,10 @@ components:
     metadata: v0.0.10
   kubemacpool:
     url: https://github.com/k8snetworkplumbingwg/kubemacpool
-    commit: f559c0725c4d315d1bf48fbc380c25a19ddf9c10
+    commit: 09d6598c46192921fb35099223070f05ca80b237
     branch: main
     update-policy: tagged
-    metadata: v0.40.0
+    metadata: v0.41.0
   linux-bridge:
     url: https://github.com/containernetworking/plugins
     commit: c10af01dfb619b37ad631a84b823f99510151ee3

--- a/data/kubemacpool/kubemacpool.yaml
+++ b/data/kubemacpool/kubemacpool.yaml
@@ -3,86 +3,8 @@ kind: Namespace
 metadata:
   labels:
     control-plane: mac-controller-manager
-  name: {{ .Namespace }}
----
-apiVersion: admissionregistration.k8s.io/v1
-kind: MutatingWebhookConfiguration
-metadata:
-  name: kubemacpool-mutator
-webhooks:
-- admissionReviewVersions:
-  - v1
-  - v1beta1
-  clientConfig:
-    service:
-      name: kubemacpool-service
-      namespace: {{ .Namespace }}
-      path: /mutate-pods
-  failurePolicy: Fail
-  name: mutatepods.kubemacpool.io
-  namespaceSelector:
-    matchExpressions:
-    - key: runlevel
-      operator: NotIn
-      values:
-      - "0"
-      - "1"
-    - key: openshift.io/run-level
-      operator: NotIn
-      values:
-      - "0"
-      - "1"
-    - key: mutatepods.kubemacpool.io
-      operator: In
-      values:
-      - allocate
-  rules:
-  - apiGroups:
-    - ""
-    apiVersions:
-    - v1
-    operations:
-    - CREATE
-    resources:
-    - pods
-  sideEffects: NoneOnDryRun
-- admissionReviewVersions:
-  - v1
-  - v1beta1
-  clientConfig:
-    service:
-      name: kubemacpool-service
-      namespace: {{ .Namespace }}
-      path: /mutate-virtualmachines
-  failurePolicy: Fail
-  name: mutatevirtualmachines.kubemacpool.io
-  namespaceSelector:
-    matchExpressions:
-    - key: runlevel
-      operator: NotIn
-      values:
-      - "0"
-      - "1"
-    - key: openshift.io/run-level
-      operator: NotIn
-      values:
-      - "0"
-      - "1"
-    - key: mutatevirtualmachines.kubemacpool.io
-      operator: NotIn
-      values:
-      - ignore
-  rules:
-  - apiGroups:
-    - kubevirt.io
-    apiVersions:
-    - v1
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - virtualmachines
-  sideEffects: NoneOnDryRun
+    pod-security.kubernetes.io/enforce: restricted
+  name: '{{ .Namespace }}'
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -93,77 +15,45 @@ rules:
 - apiGroups:
   - admissionregistration.k8s.io
   resources:
-  - mutatingwebhookconfigurations
   - validatingwebhookconfigurations
   verbs:
-  - '*'
+  - list
+  - watch
+- apiGroups:
+  - admissionregistration.k8s.io
+  resources:
+  - mutatingwebhookconfigurations
+  verbs:
+  - list
+  - update
+  - watch
 - apiGroups:
   - ""
   resources:
   - secrets
   verbs:
-  - get
   - list
   - watch
   - create
   - update
-  - patch
-  - delete
-- apiGroups:
-  - ""
-  resources:
-  - configmaps
-  verbs:
-  - '*'
-- apiGroups:
-  - ""
-  resources:
-  - events
-  verbs:
-  - get
-  - list
-  - create
-  - update
-- apiGroups:
-  - ""
-  resources:
-  - services
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - update
-  - patch
-  - delete
-- apiGroups:
-  - ""
-  resources:
-  - pods
-  - pods/status
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - update
-  - patch
 - apiGroups:
   - apiextensions.k8s.io
   resources:
   - customresourcedefinitions
   verbs:
   - get
-  - list
 - apiGroups:
-  - apps
+  - ""
   resources:
-  - deployments
+  - pods
   verbs:
-  - get
-  - create
-  - update
-  - patch
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
   - list
   - watch
 - apiGroups:
@@ -174,17 +64,14 @@ rules:
   - get
   - list
   - watch
-  - create
   - update
-  - patch
 - apiGroups:
   - ""
   resources:
-  - namespaces
+  - configmaps
   verbs:
   - get
-  - list
-  - watch
+  - delete
 - apiGroups:
   - authentication.k8s.io
   resources:
@@ -214,8 +101,8 @@ subjects:
 ---
 apiVersion: v1
 data:
-  RANGE_END: {{ .RangeEnd }}
-  RANGE_START: {{ .RangeStart }}
+  RANGE_END: '{{ .RangeEnd }}'
+  RANGE_START: '{{ .RangeStart }}'
 kind: ConfigMap
 metadata:
   labels:
@@ -267,6 +154,14 @@ spec:
         command:
         - /manager
         env:
+        - name: CA_ROTATE_INTERVAL
+          value: '{{ .CARotateInterval | default "8760h0m0s" }}'
+        - name: CA_OVERLAP_INTERVAL
+          value: '{{ .CAOverlapInterval | default "24h0m0s" }}'
+        - name: CERT_ROTATE_INTERVAL
+          value: '{{ .CertRotateInterval | default "4380h0m0s" }}'
+        - name: CERT_OVERLAP_INTERVAL
+          value: '{{ .CertOverlapInterval | default "24h0m0s" }}'
         - name: RUN_CERT_MANAGER
           value: ""
         - name: POD_NAMESPACE
@@ -293,14 +188,6 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.labels['app.kubernetes.io/managed-by']
-        - name: CA_ROTATE_INTERVAL
-          value: '{{ .CARotateInterval | default "8760h0m0s" }}'
-        - name: CA_OVERLAP_INTERVAL
-          value: '{{ .CAOverlapInterval | default "24h0m0s" }}'
-        - name: CERT_ROTATE_INTERVAL
-          value: '{{ .CertRotateInterval | default "4380h0m0s" }}'
-        - name: CERT_OVERLAP_INTERVAL
-          value: '{{ .CertOverlapInterval | default "24h0m0s" }}'
         image: '{{ .KubeMacPoolImage }}'
         imagePullPolicy: '{{ .ImagePullPolicy }}'
         name: manager
@@ -308,9 +195,19 @@ spec:
           requests:
             cpu: 30m
             memory: 30Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
       nodeSelector: {{ toYaml .Placement.NodeSelector | nindent 8 }}
       priorityClassName: system-cluster-critical
       restartPolicy: Always
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 107
+        seccompProfile:
+          type: RuntimeDefault
       terminationGracePeriodSeconds: 5
       tolerations: {{ toYaml .Placement.Tolerations | nindent 8 }}
 ---
@@ -392,6 +289,11 @@ spec:
           requests:
             cpu: 100m
             memory: 100Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
         volumeMounts:
         - mountPath: /tmp/k8s-webhook-server/serving-certs/
           name: tls-key-pair
@@ -411,13 +313,102 @@ spec:
           requests:
             cpu: 10m
             memory: 20Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
         terminationMessagePolicy: FallbackToLogsOnError
       nodeSelector: {{ toYaml .Placement.NodeSelector | nindent 8 }}
       priorityClassName: system-cluster-critical
       restartPolicy: Always
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 107
+        seccompProfile:
+          type: RuntimeDefault
       terminationGracePeriodSeconds: 5
       tolerations: {{ toYaml .Placement.Tolerations | nindent 8 }}
       volumes:
       - name: tls-key-pair
         secret:
           secretName: kubemacpool-service
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: kubemacpool-mutator
+webhooks:
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: kubemacpool-service
+      namespace: '{{ .Namespace }}'
+      path: /mutate-pods
+  failurePolicy: Fail
+  name: mutatepods.kubemacpool.io
+  namespaceSelector:
+    matchExpressions:
+    - key: runlevel
+      operator: NotIn
+      values:
+      - "0"
+      - "1"
+    - key: openshift.io/run-level
+      operator: NotIn
+      values:
+      - "0"
+      - "1"
+    - key: mutatepods.kubemacpool.io
+      operator: In
+      values:
+      - allocate
+  rules:
+  - apiGroups:
+    - ""
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    resources:
+    - pods
+  sideEffects: NoneOnDryRun
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: kubemacpool-service
+      namespace: '{{ .Namespace }}'
+      path: /mutate-virtualmachines
+  failurePolicy: Fail
+  name: mutatevirtualmachines.kubemacpool.io
+  namespaceSelector:
+    matchExpressions:
+    - key: runlevel
+      operator: NotIn
+      values:
+      - "0"
+      - "1"
+    - key: openshift.io/run-level
+      operator: NotIn
+      values:
+      - "0"
+      - "1"
+    - key: mutatevirtualmachines.kubemacpool.io
+      operator: NotIn
+      values:
+      - ignore
+  rules:
+  - apiGroups:
+    - kubevirt.io
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - virtualmachines
+  sideEffects: NoneOnDryRun

--- a/hack/components/bump-kubemacpool.sh
+++ b/hack/components/bump-kubemacpool.sh
@@ -32,9 +32,29 @@ bases:
 patchesStrategicMerge:
 - cnao_kubemacpool_manager_patch.yaml
 - cnao_cert-manager_patch.yaml
-- cnao_placement_patch.yaml
 - mutatevirtualmachines_opt_mode_patch.yaml
 - mutatepods_opt_mode_patch.yaml
+patches:
+- path: cnao_placement_patch.yaml
+  target:
+    group: apps
+    version: v1
+    kind: Deployment
+    name: cert-manager
+    namespace: system
+- path: cnao_placement_patch.yaml
+  target:
+    group: apps
+    version: v1
+    kind: Deployment
+    name: mac-controller-manager
+    namespace: system
+- path: cnao_mac-range_patch.json
+  target:
+    version: v1
+    kind: ConfigMap
+    name: mac-range-config
+    namespace: system
 EOF
 
     cat <<EOF > config/cnao/cnao_kubemacpool_manager_patch.yaml
@@ -69,9 +89,6 @@ metadata:
 spec:
   template:
     spec:
-      affinity: AFFINITY
-      nodeSelector: NODE_SELECTOR
-      tolerations: TOLERATIONS
       containers:
       - image: "{{ .KubeMacPoolImage }}"
         imagePullPolicy: "{{ .ImagePullPolicy }}"
@@ -88,18 +105,26 @@ spec:
 EOF
 
     cat <<EOF > config/cnao/cnao_placement_patch.yaml
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: mac-controller-manager
-  namespace: system
-spec:
-  template:
-    spec:
-      affinity: AFFINITY
-      nodeSelector: NODE_SELECTOR
-      tolerations: TOLERATIONS
+- op: replace
+  path: /spec/template/spec/affinity
+  value: "{{ toYaml .Placement.Affinity | nindent 8 }}"
+- op: replace
+  path: /spec/template/spec/nodeSelector
+  value: "{{ toYaml .Placement.NodeSelector | nindent 8 }}"
+- op: replace
+  path: /spec/template/spec/tolerations
+  value: "{{ toYaml .Placement.Tolerations | nindent 8 }}"
 EOF
+
+    cat <<EOF > config/cnao/cnao_mac-range_patch.json
+- op: replace
+  path: /data/RANGE_START
+  value: "{{ .RangeStart }}"
+- op: replace
+  path: /data/RANGE_END
+  value: "{{ .RangeEnd }}"
+EOF
+
 
     (
         cd config/cnao
@@ -113,16 +138,14 @@ EOF
 )
 
 rm -rf data/kubemacpool/*
+kustomize_version=$(grep kustomize $KUBEMACPOOL_PATH/Makefile |sed "s/.*@v/v/g")
+curl -L "https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2F${kustomize_version}/kustomize_${kustomize_version}_linux_amd64.tar.gz" -o kustomize.tar.gz
+tar -xvzf kustomize.tar.gz
+mv kustomize $KUBEMACPOOL_PATH
+rm kustomize.tar.gz
 (
     cd $KUBEMACPOOL_PATH
-    make tools 1>/dev/null
-    ./build/_output/bin/go/bin/kustomize build config/cnao | \
-        sed 's/kubemacpool-system/{{ .Namespace }}/' | \
-        sed 's/RANGE_START: .*/RANGE_START: {{ .RangeStart }}/' | \
-        sed 's/RANGE_END: .*/RANGE_END: {{ .RangeEnd }}/' | \
-        sed 's/AFFINITY/{{ toYaml .Placement.Affinity | nindent 8 }}/' | \
-        sed 's/NODE_SELECTOR/{{ toYaml .Placement.NodeSelector | nindent 8 }}/' | \
-        sed 's/TOLERATIONS/{{ toYaml .Placement.Tolerations | nindent 8 }}/'
+    ./kustomize build config/cnao | sed "s/'{{ toYaml \(.*\)}}'/{{ toYaml \1}}/"
 ) > data/kubemacpool/kubemacpool.yaml
 
 echo 'Get kubemacpool image name and update it under CNAO'

--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -34,7 +34,7 @@ const (
 	MultusDynamicNetworksImageDefault = "ghcr.io/k8snetworkplumbingwg/multus-dynamic-networks-controller@sha256:dee1979d92f0a31598a6e3569ac7004be7d29e7ca9e31db23753ef263110dc04"
 	LinuxBridgeCniImageDefault        = "quay.io/kubevirt/cni-default-plugins@sha256:406b43253fb5d45f50d1543879353822e3f746e2794b65ab30754e800386b76d"
 	LinuxBridgeMarkerImageDefault     = "quay.io/kubevirt/bridge-marker@sha256:5d24c6d1ecb0556896b7b81c7e5260b54173858425777b7a84df8a706c07e6d2"
-	KubeMacPoolImageDefault           = "quay.io/kubevirt/kubemacpool@sha256:0cc5ad824fc163d6dea5e9bd872467c691eaa9a88944008b5d746495b2a72214"
+	KubeMacPoolImageDefault           = "quay.io/kubevirt/kubemacpool@sha256:afba7d0c4a95d2d4924f6ee6ef16bbe59117877383819057f01809150829cb0c"
 	OvsCniImageDefault                = "quay.io/kubevirt/ovs-cni-plugin@sha256:5f7290e2294255ab2547c3b4bf48cc2d75531ec5a43e600366e9b2719bef983f"
 	MacvtapCniImageDefault            = "quay.io/kubevirt/macvtap-cni@sha256:434420511e09b2b5ede785a2c9062b6658ffbc26fbdd4629ce06110f9039c600"
 	KubeRbacProxyImageDefault         = "quay.io/openshift/origin-kube-rbac-proxy@sha256:baedb268ac66456018fb30af395bb3d69af5fff3252ff5d549f0231b1ebb6901"

--- a/test/releases/99.0.0.go
+++ b/test/releases/99.0.0.go
@@ -43,7 +43,7 @@ func init() {
 				ParentName: "kubemacpool-mac-controller-manager",
 				ParentKind: "Deployment",
 				Name:       "manager",
-				Image:      "quay.io/kubevirt/kubemacpool@sha256:0cc5ad824fc163d6dea5e9bd872467c691eaa9a88944008b5d746495b2a72214",
+				Image:      "quay.io/kubevirt/kubemacpool@sha256:afba7d0c4a95d2d4924f6ee6ef16bbe59117877383819057f01809150829cb0c",
 			},
 			{
 				ParentName: "kubemacpool-mac-controller-manager",
@@ -55,7 +55,7 @@ func init() {
 				ParentName: "kubemacpool-cert-manager",
 				ParentKind: "Deployment",
 				Name:       "manager",
-				Image:      "quay.io/kubevirt/kubemacpool@sha256:0cc5ad824fc163d6dea5e9bd872467c691eaa9a88944008b5d746495b2a72214",
+				Image:      "quay.io/kubevirt/kubemacpool@sha256:afba7d0c4a95d2d4924f6ee6ef16bbe59117877383819057f01809150829cb0c",
 			},
 			{
 				ParentName: "ovs-cni-amd64",


### PR DESCRIPTION
**What this PR does / why we need it**:
Latest kubemacpool has some changes that breaks autobumper, this change adapt autobumper and do a manual bump.


```release-note
Bump kubemacpool to v0.41.0
```
