### PR TITLE
KSD: Bump to v0.0.11

### DIFF
--- a/components.yaml
+++ b/components.yaml
@@ -7,10 +7,10 @@ components:
     metadata: 0.10.0
   kube-secondary-dns:
     url: https://github.com/kubevirt/kubesecondarydns
-    commit: 08810acf5e9b5355d31e1c298e38ab6486f825b7
+    commit: 64799ca2414eb4042b794cc9e60a253bf9f348f5
     branch: main
     update-policy: tagged
-    metadata: v0.0.10
+    metadata: v0.0.11
   kubemacpool:
     url: https://github.com/k8snetworkplumbingwg/kubemacpool
     commit: 09d6598c46192921fb35099223070f05ca80b237

--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -38,8 +38,8 @@ const (
 	OvsCniImageDefault                = "quay.io/kubevirt/ovs-cni-plugin@sha256:5f7290e2294255ab2547c3b4bf48cc2d75531ec5a43e600366e9b2719bef983f"
 	MacvtapCniImageDefault            = "quay.io/kubevirt/macvtap-cni@sha256:434420511e09b2b5ede785a2c9062b6658ffbc26fbdd4629ce06110f9039c600"
 	KubeRbacProxyImageDefault         = "quay.io/openshift/origin-kube-rbac-proxy@sha256:baedb268ac66456018fb30af395bb3d69af5fff3252ff5d549f0231b1ebb6901"
-	KubeSecondaryDNSImageDefault      = "ghcr.io/kubevirt/kubesecondarydns@sha256:e0170ec6234f51f485944ee5ddcbc3c0545ad1922aa7d61536ca590047ef7a54"
-	CoreDNSImageDefault               = "registry.k8s.io/coredns/coredns@sha256:5b6ec0d6de9baaf3e92d0f66cd96a25b9edbce8716f5f15dcd1a616b3abd590e"
+	KubeSecondaryDNSImageDefault      = "ghcr.io/kubevirt/kubesecondarydns@sha256:77132adb5f840ceb0aadd408731a5c8b01a4b427a78084ab5e4e9b961195cb02"
+	CoreDNSImageDefault               = "registry.k8s.io/coredns/coredns@sha256:a0ead06651cf580044aeb0a0feba63591858fb2e43ade8c9dea45a6a89ae7e5e"
 )
 
 type AddonsImages struct {

--- a/test/releases/99.0.0.go
+++ b/test/releases/99.0.0.go
@@ -73,7 +73,7 @@ func init() {
 				ParentName: "secondary-dns",
 				ParentKind: "Deployment",
 				Name:       "status-monitor",
-				Image:      "ghcr.io/kubevirt/kubesecondarydns@sha256:e0170ec6234f51f485944ee5ddcbc3c0545ad1922aa7d61536ca590047ef7a54",
+				Image:      "ghcr.io/kubevirt/kubesecondarydns@sha256:77132adb5f840ceb0aadd408731a5c8b01a4b427a78084ab5e4e9b961195cb02",
 			},
 			{
 				ParentName: "secondary-dns",


### PR DESCRIPTION
**What this PR does / why we need it**:
See https://github.com/kubevirt/kubesecondarydns/pull/59

**Special notes for your reviewer**:

**Release note**:
```release-note
None
```
