### PR TITLE
rbac: Add missing verb

### DIFF
--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -399,6 +399,7 @@ func GetRole(namespace string) *rbacv1.Role {
 				Verbs: []string{
 					"update",
 					"get",
+					"patch",
 				},
 			},
 			{


### PR DESCRIPTION
**What this PR does / why we need it**:
Saw during running lifecycle tests on a release PR locally in the audit logs.
Addon to https://github.com/kubevirt/cluster-network-addons-operator/pull/1550

**Special notes for your reviewer**:

**Release note**:
```release-note
None
```
