### PR TITLE
e2e, checks: Add missing pdb leftovers check

### DIFF
--- a/test/check/check.go
+++ b/test/check/check.go
@@ -20,6 +20,7 @@ import (
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	policyv1beta1 "k8s.io/api/policy/v1beta1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	k8slabels "k8s.io/apimachinery/pkg/labels"
@@ -251,6 +252,10 @@ func CheckForLeftoverObjects(currentVersion string) {
 		services := corev1.ServiceList{}
 		Expect(testenv.Client.List(context.Background(), &services, &listOptions)).To(Succeed())
 		Expect(services.Items).To(BeEmpty(), "Found leftover objects from the previous operator version")
+
+		pdbs := policyv1beta1.PodDisruptionBudgetList{}
+		Expect(testenv.Client.List(context.Background(), &pdbs, &listOptions)).To(Succeed())
+		Expect(pdbs.Items).To(BeEmpty(), "Found leftover objects from the previous operator version")
 
 		serviceMonitors := monitoringv1.ServiceMonitorList{}
 		Expect(testenv.Client.List(context.Background(), &serviceMonitors, &listOptions)).To(Succeed())

--- a/vendor/github.com/operator-framework/api/pkg/validation/internal/object.go
+++ b/vendor/github.com/operator-framework/api/pkg/validation/internal/object.go
@@ -5,7 +5,7 @@ import (
 	"github.com/operator-framework/api/pkg/validation/errors"
 	interfaces "github.com/operator-framework/api/pkg/validation/interfaces"
 
-	policyv1beta1 "k8s.io/api/policy/v1beta1"
+	policyv1 "k8s.io/api/policy/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	schedulingv1 "k8s.io/api/scheduling/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -57,7 +57,7 @@ func validateObjects(objs ...interface{}) (results []errors.ManifestResult) {
 // validatePDB checks the PDB to ensure the minimum and maximum budgets are set to reasonable levels.
 // See https://github.com/operator-framework/operator-lifecycle-manager/blob/master/doc/design/adding-pod-disruption-budgets.md#limitations-on-pod-disruption-budgets
 func validatePDB(u *unstructured.Unstructured) (result errors.ManifestResult) {
-	pdb := policyv1beta1.PodDisruptionBudget{}
+	pdb := policyv1.PodDisruptionBudget{}
 
 	b, err := u.MarshalJSON()
 	if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
Tests doesn't check if there are any PDB leftovers, add this check.

**Special notes for your reviewer**:

**Release note**:
```release-note
None
```
