### PR TITLE
[release-0.79] Bump Bridge CNI to fix VLAN leakage

### DIFF
--- a/components.yaml
+++ b/components.yaml
@@ -13,7 +13,7 @@ components:
     metadata: v0.39.1
   linux-bridge:
     url: https://github.com/containernetworking/plugins
-    commit: f1f128e3c9220634d3f26b96950271f87c34e424
+    commit: c10af01dfb619b37ad631a84b823f99510151ee3
     branch: main
     update-policy: static
     metadata: ""

--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -30,7 +30,7 @@ var (
 
 const (
 	MultusImageDefault            = "ghcr.io/k8snetworkplumbingwg/multus-cni@sha256:829c27e9392d013eee5086ca7670d7326d723ebaec526237215e86086b5a3234"
-	LinuxBridgeCniImageDefault    = "quay.io/kubevirt/cni-default-plugins@sha256:5d9442c26f8750d44f97175f36dbd74bef503f782b9adefcfd08215d065c437a"
+	LinuxBridgeCniImageDefault    = "quay.io/kubevirt/cni-default-plugins@sha256:406b43253fb5d45f50d1543879353822e3f746e2794b65ab30754e800386b76d"
 	LinuxBridgeMarkerImageDefault = "quay.io/kubevirt/bridge-marker@sha256:5d24c6d1ecb0556896b7b81c7e5260b54173858425777b7a84df8a706c07e6d2"
 	KubeMacPoolImageDefault       = "quay.io/kubevirt/kubemacpool@sha256:9dee66dba5655e2dc70561d4d882d7ee204735ad82f81b24d0b338c428cb918b"
 	OvsCniImageDefault            = "quay.io/kubevirt/ovs-cni-plugin@sha256:74a98ef62ca88eba48f35b733711d5e37f81bec06934d94b6a039a5cd92d5499"

--- a/test/releases/99.0.0.go
+++ b/test/releases/99.0.0.go
@@ -31,7 +31,7 @@ func init() {
 				ParentName: "kube-cni-linux-bridge-plugin",
 				ParentKind: "DaemonSet",
 				Name:       "cni-plugins",
-				Image:      "quay.io/kubevirt/cni-default-plugins@sha256:5d9442c26f8750d44f97175f36dbd74bef503f782b9adefcfd08215d065c437a",
+				Image:      "quay.io/kubevirt/cni-default-plugins@sha256:406b43253fb5d45f50d1543879353822e3f746e2794b65ab30754e800386b76d",
 			},
 			{
 				ParentName: "kubemacpool-mac-controller-manager",


### PR DESCRIPTION
**What this PR does / why we need it**:

This bump brings in https://github.com/containernetworking/plugins/pull/875

This change is required to improve the VLAN isolation done by bridge CNI. This bump is unorthodox since it does not only cherry-pick the bug fix, but also a few other patches. This is due to the lack of a stable branch in CNI plugins. We reviewed the parasiting patches that are introduced by this bump and evaluated that they are not disruptive to our typical use of the bridge CNI.

**Special notes for your reviewer**:

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2209318

```release-note
Bump bridge CNI.
```
