### PR TITLE
multus: Bump to v4.0.2

### DIFF
--- a/components.yaml
+++ b/components.yaml
@@ -31,10 +31,10 @@ components:
     metadata: v0.11.0
   multus:
     url: https://github.com/k8snetworkplumbingwg/multus-cni
-    commit: 77aac95dfc67ae7662fdab8f406b15330c9b44a6
+    commit: f03765681fe81ee1e0633ee1734bf48ab3bccf2b
     branch: master
     update-policy: tagged
-    metadata: "v4.0.1"
+    metadata: "v4.0.2"
   multus-dynamic-networks:
     url: https://github.com/k8snetworkplumbingwg/multus-dynamic-networks-controller
     commit: 82597aa703a8b40d68c8c2feea94d509786d9d1a

--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -30,7 +30,7 @@ var (
 )
 
 const (
-	MultusImageDefault                = "ghcr.io/k8snetworkplumbingwg/multus-cni@sha256:42dc78591161880fadd741ccdbc1c6997d47122c4827dbc128ff591b0960b697"
+	MultusImageDefault                = "ghcr.io/k8snetworkplumbingwg/multus-cni@sha256:3fbcc32bd4e4d15bd93c96def784a229cd84cca27942bf4858b581f31c97ee02"
 	MultusDynamicNetworksImageDefault = "ghcr.io/k8snetworkplumbingwg/multus-dynamic-networks-controller@sha256:dee1979d92f0a31598a6e3569ac7004be7d29e7ca9e31db23753ef263110dc04"
 	LinuxBridgeCniImageDefault        = "quay.io/kubevirt/cni-default-plugins@sha256:406b43253fb5d45f50d1543879353822e3f746e2794b65ab30754e800386b76d"
 	LinuxBridgeMarkerImageDefault     = "quay.io/kubevirt/bridge-marker@sha256:5d24c6d1ecb0556896b7b81c7e5260b54173858425777b7a84df8a706c07e6d2"

--- a/test/releases/99.0.0.go
+++ b/test/releases/99.0.0.go
@@ -13,7 +13,7 @@ func init() {
 				ParentName: "multus",
 				ParentKind: "DaemonSet",
 				Name:       "kube-multus",
-				Image:      "ghcr.io/k8snetworkplumbingwg/multus-cni@sha256:42dc78591161880fadd741ccdbc1c6997d47122c4827dbc128ff591b0960b697",
+				Image:      "ghcr.io/k8snetworkplumbingwg/multus-cni@sha256:3fbcc32bd4e4d15bd93c96def784a229cd84cca27942bf4858b581f31c97ee02",
 			},
 			{
 				ParentName: "dynamic-networks-controller-ds",
@@ -25,7 +25,7 @@ func init() {
 				ParentName: "multus",
 				ParentKind: "DaemonSet",
 				Name:       "install-multus-binary",
-				Image:      "ghcr.io/k8snetworkplumbingwg/multus-cni@sha256:42dc78591161880fadd741ccdbc1c6997d47122c4827dbc128ff591b0960b697",
+				Image:      "ghcr.io/k8snetworkplumbingwg/multus-cni@sha256:3fbcc32bd4e4d15bd93c96def784a229cd84cca27942bf4858b581f31c97ee02",
 			},
 			{
 				ParentName: "bridge-marker",


### PR DESCRIPTION
**What this PR does / why we need it**:
In order to have a fix for
https://github.com/k8snetworkplumbingwg/multus-cni/pull/1084 which hit us on lifecycle tests / cluster-sync.

See
https://github.com/kubevirt/cluster-network-addons-operator/issues/1543

**Special notes for your reviewer**:

**Release note**:
```release-note
None
```
