### PR TITLE
tests: Fix expected CoreDNS image

### DIFF
--- a/automation/check-patch.e2e-lifecycle-k8s.sh
+++ b/automation/check-patch.e2e-lifecycle-k8s.sh
@@ -30,7 +30,7 @@ main() {
         export E2E_TEST_TIMEOUT=4h
     else
         # Don't run all upgrade tests in regular PRs, stick to those released under HCO
-        export RELEASES_SELECTOR="{0.65.10,0.76.3,0.79.1,99.0.0}"
+        export RELEASES_SELECTOR="{0.65.10,0.76.3,0.79.1,0.85.0,99.0.0}"
     fi
 
     make cluster-down

--- a/hack/components/bump-kube-secondary-dns.sh
+++ b/hack/components/bump-kube-secondary-dns.sh
@@ -99,3 +99,4 @@ sed -i -r "s#\"${KUBE_SECONDARY_DNS_IMAGE}(@sha256)?:.*\"#\"${KUBE_SECONDARY_DNS
 sed -i -r "s#\"${KUBE_SECONDARY_DNS_IMAGE}(@sha256)?:.*\"#\"${KUBE_SECONDARY_DNS_IMAGE_DIGEST}\"#" test/releases/${CNAO_VERSION}.go
 
 sed -i -r "s#\"${CORE_DNS_IMAGE}(@sha256)?:.*\"#\"${CORE_DNS_IMAGE_DIGEST}\"#" pkg/components/components.go
+sed -i -r "s#\"${CORE_DNS_IMAGE}(@sha256)?:.*\"#\"${CORE_DNS_IMAGE_DIGEST}\"#" test/releases/${CNAO_VERSION}.go

--- a/test/releases/0.83.0.go
+++ b/test/releases/0.83.0.go
@@ -81,7 +81,7 @@ func init() {
 				ParentName: secondaryDNSDeployment,
 				ParentKind: "Deployment",
 				Name:       "secondary-dns",
-				Image:      components.CoreDNSImageDefault,
+				Image:      "k8s.gcr.io/coredns/coredns@sha256:5b6ec0d6de9baaf3e92d0f66cd96a25b9edbce8716f5f15dcd1a616b3abd590e",
 			},
 		},
 		SupportedSpec: cnao.NetworkAddonsConfigSpec{

--- a/test/releases/0.83.1.go
+++ b/test/releases/0.83.1.go
@@ -79,7 +79,7 @@ func init() {
 				ParentName: "secondary-dns",
 				ParentKind: "Deployment",
 				Name:       "secondary-dns",
-				Image:      components.CoreDNSImageDefault,
+				Image:      "k8s.gcr.io/coredns/coredns@sha256:5b6ec0d6de9baaf3e92d0f66cd96a25b9edbce8716f5f15dcd1a616b3abd590e",
 			},
 		},
 		SupportedSpec: cnao.NetworkAddonsConfigSpec{

--- a/test/releases/0.84.0.go
+++ b/test/releases/0.84.0.go
@@ -79,7 +79,7 @@ func init() {
 				ParentName: "secondary-dns",
 				ParentKind: "Deployment",
 				Name:       "secondary-dns",
-				Image:      components.CoreDNSImageDefault,
+				Image:      "k8s.gcr.io/coredns/coredns@sha256:5b6ec0d6de9baaf3e92d0f66cd96a25b9edbce8716f5f15dcd1a616b3abd590e",
 			},
 		},
 		SupportedSpec: cnao.NetworkAddonsConfigSpec{

--- a/test/releases/0.85.0.go
+++ b/test/releases/0.85.0.go
@@ -79,7 +79,7 @@ func init() {
 				ParentName: "secondary-dns",
 				ParentKind: "Deployment",
 				Name:       "secondary-dns",
-				Image:      components.CoreDNSImageDefault,
+				Image:      "k8s.gcr.io/coredns/coredns@sha256:5b6ec0d6de9baaf3e92d0f66cd96a25b9edbce8716f5f15dcd1a616b3abd590e",
 			},
 		},
 		SupportedSpec: cnao.NetworkAddonsConfigSpec{

--- a/test/releases/99.0.0.go
+++ b/test/releases/99.0.0.go
@@ -79,7 +79,7 @@ func init() {
 				ParentName: "secondary-dns",
 				ParentKind: "Deployment",
 				Name:       "secondary-dns",
-				Image:      components.CoreDNSImageDefault,
+				Image:      "registry.k8s.io/coredns/coredns@sha256:a0ead06651cf580044aeb0a0feba63591858fb2e43ade8c9dea45a6a89ae7e5e",
 			},
 		},
 		SupportedSpec: cnao.NetworkAddonsConfigSpec{


### PR DESCRIPTION
**What this PR does / why we need it**:
Since the CoreDNS image might change, it can't use
the variable which exists only on the latest candid 99.0.0,
but should have an hardcoded value per each release.

Fix the KSD bump script to update the 99.0.0 file when bumping.

Beside that, add v0.85.x so we can test this fix without
a release PR, which checks update to all the versions beside the
pending release.

**Special notes for your reviewer**:
Took v0.85.0 even that we already have v0.85.2 because just this one has a file under `test/releases`.
It allows the non release PR to test the CoreDNS image as well.

Note: not related to this PR but once `KubeRbacProxyImageDefault` changes, 
we will need to do the same for that as well.

**Release note**:
```release-note
None
```
