### PR TITLE
kubemacpool: Remove namespace labels

### DIFF
--- a/automation/components-functests.setup.sh
+++ b/automation/components-functests.setup.sh
@@ -32,6 +32,18 @@ export KUBECONFIG=$(cluster::kubeconfig)
 make cluster-operator-push
 make cluster-operator-install
 
+# Test kubemacpool with restricted
+if [ "$COMPONENT" == "kubemacpool" ]; then
+    cluster/kubectl.sh apply -f - <<EOF
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: cluster-network-addons
+  labels:
+    pod-security.kubernetes.io/enforce: restricted
+EOF
+fi
+
 # Deploy all network addons components with CNAO
     cat <<EOF | cluster/kubectl.sh apply -f -
 apiVersion: networkaddonsoperator.network.kubevirt.io/v1

--- a/data/kubemacpool/kubemacpool.yaml
+++ b/data/kubemacpool/kubemacpool.yaml
@@ -1,9 +1,6 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  labels:
-    control-plane: mac-controller-manager
-    pod-security.kubernetes.io/enforce: restricted
   name: '{{ .Namespace }}'
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/hack/components/bump-kubemacpool.sh
+++ b/hack/components/bump-kubemacpool.sh
@@ -49,12 +49,16 @@ patches:
     kind: Deployment
     name: mac-controller-manager
     namespace: system
-- path: cnao_mac-range_patch.json
+- path: cnao_mac-range_patch.yaml
   target:
     version: v1
     kind: ConfigMap
     name: mac-range-config
     namespace: system
+- path: cnao_remove-labels_patch.yaml
+  target:
+    version: v1
+    kind: Namespace
 EOF
 
     cat <<EOF > config/cnao/cnao_kubemacpool_manager_patch.yaml
@@ -116,13 +120,17 @@ EOF
   value: "{{ toYaml .Placement.Tolerations | nindent 8 }}"
 EOF
 
-    cat <<EOF > config/cnao/cnao_mac-range_patch.json
+    cat <<EOF > config/cnao/cnao_mac-range_patch.yaml
 - op: replace
   path: /data/RANGE_START
   value: "{{ .RangeStart }}"
 - op: replace
   path: /data/RANGE_END
   value: "{{ .RangeEnd }}"
+EOF
+    cat <<EOF > config/cnao/cnao_remove-labels_patch.yaml
+- op: remove
+  path: /metadata/labels
 EOF
 
 


### PR DESCRIPTION
**What this PR does / why we need it**:
The kubemacpool project was adding restricted label to test security context. This change remove labels altogether and configure them at CI to test it.

**Special notes for your reviewer**:
Since the CNAO namespace is shared between components is done there instead of kubemacpool that has it's own namespace.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
Remove kubemacpool namespace labels.
```
