### PR TITLE
Kubemacpool: Parameterize "runAsNonRoot" in the yaml

### DIFF
--- a/data/kubemacpool/kubemacpool.yaml
+++ b/data/kubemacpool/kubemacpool.yaml
@@ -201,8 +201,8 @@ spec:
       priorityClassName: system-cluster-critical
       restartPolicy: Always
       securityContext:
-        runAsNonRoot: true
-        runAsUser: 107
+        runAsNonRoot: {{ .RunAsNonRoot }}
+        runAsUser: {{ .RunAsUser }}
         seccompProfile:
           type: RuntimeDefault
       terminationGracePeriodSeconds: 5
@@ -320,8 +320,8 @@ spec:
       priorityClassName: system-cluster-critical
       restartPolicy: Always
       securityContext:
-        runAsNonRoot: true
-        runAsUser: 107
+        runAsNonRoot: {{ .RunAsNonRoot }}
+        runAsUser: {{ .RunAsUser }}
         seccompProfile:
           type: RuntimeDefault
       terminationGracePeriodSeconds: 5

--- a/hack/components/bump-kubemacpool.sh
+++ b/hack/components/bump-kubemacpool.sh
@@ -82,6 +82,9 @@ spec:
       - image: "{{ .KubeRbacProxyImage }}"
         imagePullPolicy: "{{ .ImagePullPolicy }}"
         name: kube-rbac-proxy
+      securityContext:
+        runAsNonRoot: "{{ .RunAsNonRoot }}"
+        runAsUser: "{{ .RunAsUser }}"
 EOF
 
     cat <<EOF > config/cnao/cnao_cert-manager_patch.yaml
@@ -106,6 +109,9 @@ spec:
             value: "{{ .CertRotateInterval | default \"4380h0m0s\" }}"
           - name: CERT_OVERLAP_INTERVAL
             value: "{{ .CertOverlapInterval | default \"24h0m0s\" }}"
+      securityContext:
+        runAsNonRoot: "{{ .RunAsNonRoot }}"
+        runAsUser: "{{ .RunAsUser }}"
 EOF
 
     cat <<EOF > config/cnao/cnao_placement_patch.yaml
@@ -153,7 +159,7 @@ mv kustomize $KUBEMACPOOL_PATH
 rm kustomize.tar.gz
 (
     cd $KUBEMACPOOL_PATH
-    ./kustomize build config/cnao | sed "s/'{{ toYaml \(.*\)}}'/{{ toYaml \1}}/"
+    ./kustomize build config/cnao | sed "s/'{{ toYaml \(.*\)}}'/{{ toYaml \1}}/;s/'{{ .RunAsNonRoot }}'/{{ .RunAsNonRoot }}/g;s/'{{ .RunAsUser }}'/{{ .RunAsUser }}/g"
 ) > data/kubemacpool/kubemacpool.yaml
 
 echo 'Get kubemacpool image name and update it under CNAO'

--- a/pkg/network/kubemacpool.go
+++ b/pkg/network/kubemacpool.go
@@ -96,7 +96,7 @@ func changeSafeKubeMacPool(prev, next *cnao.NetworkAddonsConfigSpec) []error {
 }
 
 // renderLinuxBridge generates the manifests of Linux Bridge
-func renderKubeMacPool(conf *cnao.NetworkAddonsConfigSpec, manifestDir string) ([]*unstructured.Unstructured, error) {
+func renderKubeMacPool(conf *cnao.NetworkAddonsConfigSpec, manifestDir string, clusterInfo *ClusterInfo) ([]*unstructured.Unstructured, error) {
 	if conf.KubeMacPool == nil {
 		return nil, nil
 	}

--- a/pkg/network/kubemacpool.go
+++ b/pkg/network/kubemacpool.go
@@ -115,6 +115,14 @@ func renderKubeMacPool(conf *cnao.NetworkAddonsConfigSpec, manifestDir string, c
 	data.Data["CertRotateInterval"] = conf.SelfSignConfiguration.CertRotateInterval
 	data.Data["CertOverlapInterval"] = conf.SelfSignConfiguration.CertOverlapInterval
 
+	if clusterInfo.SCCAvailable {
+		data.Data["RunAsNonRoot"] = "null"
+		data.Data["RunAsUser"] = "null"
+	} else {
+		data.Data["RunAsNonRoot"] = "true"
+		data.Data["RunAsUser"] = "107"
+	}
+
 	ciphers, tlsMinVersion := SelectCipherSuitesAndMinTLSVersion(conf.TLSSecurityProfile)
 	data.Data["TLSSecurityProfileCiphers"] = strings.Join(ciphers, ",")
 	data.Data["TLSMinVersion"] = TLSVersionToHumanReadable(tlsMinVersion)

--- a/pkg/network/network.go
+++ b/pkg/network/network.go
@@ -134,7 +134,7 @@ func Render(conf *cnao.NetworkAddonsConfigSpec, manifestDir string, openshiftNet
 	objs = append(objs, o...)
 
 	// render kubeMacPool
-	o, err = renderKubeMacPool(conf, manifestDir)
+	o, err = renderKubeMacPool(conf, manifestDir, clusterInfo)
 	if err != nil {
 		return nil, err
 	}
@@ -206,7 +206,7 @@ func RenderObjsToRemove(prev, conf *cnao.NetworkAddonsConfigSpec, manifestDir st
 	}
 
 	if conf.KubeMacPool == nil {
-		o, err := renderKubeMacPool(prev, manifestDir)
+		o, err := renderKubeMacPool(prev, manifestDir, clusterInfo)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:
In order to make kubemacpool pods work with restricted psa policy it should have runAsNonRoot: true.
However, once the pod's securityContext has runAsNonRoot: true it should also have a specific rusAsUser.
Having a specific user is problematic on Openshift since it may configure a range of valid ids (example of a possible error - spec.containers[0].securityContext.runAsUser: Invalid value: 127: must be in the ranges: [1000670000, 1000679999]).
(issue [here](https://issues.redhat.com/browse/CNV-29823))

According to "What happens if I use runAsUser in my workloads?" section in https://github.com/redhat-openshift-ecosystem/community-operators-prod/discussions/1417 the suggested solution is -
```
If you are unable to change the image, for Openshift distributions you MUST leave the RunAsUser and RunAsNonRoot fields empty and let the Openshift SCC inject the values when your workload is qualified to the SCC policy.
```
In order to support both cases where SCC is deployed or not, this is the solution chosen.

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
