### PR TITLE
fix KubemacpoolDown runbook

### DIFF
--- a/data/monitoring/prom-rule.yaml
+++ b/data/monitoring/prom-rule.yaml
@@ -57,7 +57,7 @@ spec:
         - alert: KubemacpoolDown
           annotations:
             summary: KubeMacpool is deployed by CNAO CR but KubeMacpool pod is down.
-            runbook_url: '{{ .RunbookURLTemplate }}KubeMacPoolDown'
+            runbook_url: '{{ .RunbookURLTemplate }}KubemacpoolDown'
           expr: kubevirt_cnao_cr_kubemacpool_deployed_total == 1 and kubevirt_cnao_kubemacpool_manager_num_up_pods_total == 0
           for: 5m
           labels:

--- a/hack/prom-rule-ci/prom-rules-tests.yaml
+++ b/hack/prom-rule-ci/prom-rules-tests.yaml
@@ -121,7 +121,7 @@ tests:
         exp_alerts:
           - exp_annotations:
               summary: "KubeMacpool is deployed by CNAO CR but KubeMacpool pod is down."
-              runbook_url: "https://kubevirt.io/monitoring/runbooks/KubeMacPoolDown"
+              runbook_url: "https://kubevirt.io/monitoring/runbooks/KubemacpoolDown"
             exp_labels:
               severity: "critical"
               operator_health_impact: "critical"


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the main branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it

If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**What this PR does / why we need it**:
Currently, [KubemacpoolDown alert](https://github.com/kubevirt/cluster-network-addons-operator/blob/main/data/monitoring/prom-rule.yaml#L57) has a runbook with the name `KubeMacPoolDown`. This PR, https://github.com/kubevirt/monitoring/pull/187 and https://github.com/openshift/runbooks/pull/128 are fixing it.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
None
```
