### PR TITLE
Allow restriction of Multus RBAC

### DIFF
--- a/tools/manifest-templator/manifest-templator.go
+++ b/tools/manifest-templator/manifest-templator.go
@@ -136,7 +136,7 @@ func marshallObject(obj interface{}, writer io.Writer) error {
 	return nil
 }
 
-func getCNA(data *templateData) {
+func getCNA(data *templateData, allowMultus bool) {
 	writer := strings.Builder{}
 
 	// Get CNA Deployment
@@ -177,7 +177,7 @@ func getCNA(data *templateData) {
 
 	// Get CNA ClusterRole
 	writer = strings.Builder{}
-	clusterRole := components.GetClusterRole()
+	clusterRole := components.GetClusterRole(allowMultus)
 	marshallObject(clusterRole, &writer)
 	clusterRoleString := writer.String()
 
@@ -240,6 +240,7 @@ func main() {
 	imageName := flag.String("image-name", components.Name, "The operator image's name")
 	containerTag := flag.String("container-tag", "latest", "The operator image's container tag")
 	imagePullPolicy := flag.String("image-pull-policy", "Always", "The pull policy to use on the operator image")
+	allowMultus := flag.Bool("allow-multus", true, "Install Multus RBAC, making it possible to deploy Multus through the operator (should be disabled on OpenShift to limit CNAO's RBAC to the necessary minimum)")
 	multusImage := flag.String("multus-image", components.MultusImageDefault, "The multus image managed by CNA")
 	linuxBridgeCniImage := flag.String("linux-bridge-cni-image", components.LinuxBridgeCniImageDefault, "The linux bridge cni image managed by CNA")
 	linuxBridgeMarkerImage := flag.String("linux-bridge-marker-image", components.LinuxBridgeMarkerImageDefault, "The linux bridge marker image managed by CNA")
@@ -280,7 +281,7 @@ func main() {
 	}
 
 	// Load in all CNA Resources
-	getCNA(&data)
+	getCNA(&data, *allowMultus)
 
 	if *inputFile == "" {
 		panic("Must specify input file")


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the main branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it

If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**What this PR does / why we need it**:

The Multus component requires an a powerful cluster-wide role to
operate:

```
  - apiGroups:
    - k8s.cni.cncf.io
    resources:
    - '*'
    verbs:
    - '*'
```

At the same time, Multus is an optional component.

As part of an effort to limit CNAO to the least amount of privileges it
must posses, this patch introduces a new flag to the CNAO manifest
generator, allowing to omit the Multus RBAC from the CNAO RBAC. Default
value of the flag is true, in this case Multus RBAC will be included.

* If this new flag is set to false and Multus is never deployed, it
  limits the possible attack surface.
* If this flag is set to false and a user attempts to deploy Multus,
  CNAO will turn into a degraded state, unable to deploy Multus because
  of missing RBAC permissions.

Typically, this flag should set to false on OpenShift, where Multus is
managed by the CNO, and thus these additional RBAC permissions on CNAO
aren't necessary.


**Special notes for your reviewer**:

This PR does not change any existing behavior. It only allows integrators to tweak CNAO manifests per their needs.

This change was successfully tested on OpenShift CRC as well.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
