### PR TITLE
macvtap: Block deployment on Openshift

### DIFF
--- a/pkg/network/macvtap.go
+++ b/pkg/network/macvtap.go
@@ -1,9 +1,11 @@
 package network
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 
+	openshiftoperatorv1 "github.com/openshift/api/operator/v1"
 	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
@@ -57,4 +59,16 @@ func fillMacvtapDefaults(conf *cnao.NetworkAddonsConfigSpec, previousConf *cnao.
 
 func hasDevicePluginConfigMapNameDefined(conf *cnao.NetworkAddonsConfigSpec) bool {
 	return conf != nil && conf.MacvtapCni != nil && conf.MacvtapCni.DevicePluginConfig != ""
+}
+
+func validateMacvtap(conf *cnao.NetworkAddonsConfigSpec, openshiftNetworkConfig *openshiftoperatorv1.Network) []error {
+	if conf.MacvtapCni == nil {
+		return nil
+	}
+
+	if openshiftNetworkConfig != nil {
+		return []error{fmt.Errorf("`macvtap` has been requested, but is not supported on OpenShift")}
+	}
+
+	return nil
 }

--- a/pkg/network/network.go
+++ b/pkg/network/network.go
@@ -42,6 +42,7 @@ func Validate(conf *cnao.NetworkAddonsConfigSpec, openshiftNetworkConfig *osv1.N
 	errs = append(errs, validateImagePullPolicy(conf)...)
 	errs = append(errs, validateSelfSignConfiguration(conf)...)
 	errs = append(errs, validateMultusDynamicNetworks(conf, openshiftNetworkConfig)...)
+	errs = append(errs, validateMacvtap(conf, openshiftNetworkConfig)...)
 
 	if len(errs) > 0 {
 		return errors.Errorf("invalid configuration:\n%s", errorListToMultiLineString(errs))


### PR DESCRIPTION
**What this PR does / why we need it**:
We don't support Macvtap on Openshift.
It is better to fail with explicit error in case it is part of the CR.

**Special notes for your reviewer**:

**Release note**:
```release-note
Block deploying Macvtap on Openshift because it is not supported.
```
