### PR TITLE
Improve alert rules sanity test

### DIFF
--- a/test/e2e/monitoring/rules_test.go
+++ b/test/e2e/monitoring/rules_test.go
@@ -46,8 +46,7 @@ var _ = Context("Prometheus Rules", func() {
 					for _, rule := range group.Rules {
 						if len(rule.Alert) > 0 {
 							Expect(rule.Annotations).ToNot(BeNil())
-							checkForRunbookURL(rule)
-							checkForSummary(rule)
+							checkRequiredAnnotations(rule)
 						}
 					}
 				}
@@ -58,10 +57,7 @@ var _ = Context("Prometheus Rules", func() {
 					for _, rule := range group.Rules {
 						if len(rule.Alert) > 0 {
 							Expect(rule.Labels).ToNot(BeNil())
-							checkForSeverityLabel(rule)
-							checkForHealthImpactLabel(rule)
-							checkForPartOfLabel(rule)
-							checkForComponentLabel(rule)
+							checkRequiredLabels(rule)
 						}
 					}
 				}
@@ -78,40 +74,26 @@ var _ = Context("Prometheus Rules", func() {
 	})
 })
 
-func checkForRunbookURL(rule monitoringv1.Rule) {
-	url, ok := rule.Annotations["runbook_url"]
-	ExpectWithOffset(1, ok).To(BeTrue(), fmt.Sprintf("%s does not have runbook_url annotation", rule.Alert))
-	resp, err := http.Head(url)
+func checkRequiredAnnotations(rule monitoringv1.Rule) {
+	ExpectWithOffset(1, rule.Annotations).To(HaveKeyWithValue("summary", Not(BeEmpty())),
+		"%s summary is missing or empty", rule.Alert)
+	ExpectWithOffset(1, rule.Annotations).To(HaveKey("runbook_url"),
+		"%s runbook_url is missing", rule.Alert)
+	ExpectWithOffset(1, rule.Annotations).To(HaveKeyWithValue("runbook_url", HaveSuffix(rule.Alert)),
+		"%s runbook is not equal to alert name", rule.Alert)
+
+	resp, err := http.Head(rule.Annotations["runbook_url"])
 	ExpectWithOffset(1, err).ToNot(HaveOccurred(), fmt.Sprintf("%s runbook is not available", rule.Alert))
 	ExpectWithOffset(1, resp.StatusCode).Should(Equal(http.StatusOK), fmt.Sprintf("%s runbook is not available", rule.Alert))
 }
 
-func checkForSummary(rule monitoringv1.Rule) {
-	summary, ok := rule.Annotations["summary"]
-	ExpectWithOffset(1, ok).To(BeTrue(), fmt.Sprintf("%s does not have summary annotation", rule.Alert))
-	ExpectWithOffset(1, summary).ToNot(BeEmpty(), fmt.Sprintf("%s has an empty summary", rule.Alert))
-}
-
-func checkForSeverityLabel(rule monitoringv1.Rule) {
-	severity, ok := rule.Labels["severity"]
-	ExpectWithOffset(1, ok).To(BeTrue(), fmt.Sprintf("%s does not have severity label", rule.Alert))
-	ExpectWithOffset(1, severity).To(BeElementOf("info", "warning", "critical"), fmt.Sprintf("%s severity label is not valid", rule.Alert))
-}
-
-func checkForHealthImpactLabel(rule monitoringv1.Rule) {
-	operatorHealthImpact, ok := rule.Labels["operator_health_impact"]
-	ExpectWithOffset(1, ok).To(BeTrue(), fmt.Sprintf("%s does not have operator_health_impact label", rule.Alert))
-	ExpectWithOffset(1, operatorHealthImpact).To(BeElementOf("none", "warning", "critical"), fmt.Sprintf("%s operator_health_impact label is not valid", rule.Alert))
-}
-
-func checkForPartOfLabel(rule monitoringv1.Rule) {
-	kubernetesOperatorPartOf, ok := rule.Labels["kubernetes_operator_part_of"]
-	ExpectWithOffset(1, ok).To(BeTrue(), fmt.Sprintf("%s does not have kubernetes_operator_part_of label", rule.Alert))
-	ExpectWithOffset(1, kubernetesOperatorPartOf).To(Equal("kubevirt"), fmt.Sprintf("%s kubernetes_operator_part_of label is not valid", rule.Alert))
-}
-
-func checkForComponentLabel(rule monitoringv1.Rule) {
-	kubernetesOperatorComponent, ok := rule.Labels["kubernetes_operator_component"]
-	ExpectWithOffset(1, ok).To(BeTrue(), fmt.Sprintf("%s does not have kubernetes_operator_component label", rule.Alert))
-	ExpectWithOffset(1, kubernetesOperatorComponent).To(Equal("cluster-network-addons-operator"), fmt.Sprintf("%s kubernetes_operator_component label is not valid", rule.Alert))
+func checkRequiredLabels(rule monitoringv1.Rule) {
+	ExpectWithOffset(1, rule.Labels).To(HaveKeyWithValue("severity", BeElementOf("info", "warning", "critical")),
+		"%s severity label is missing or not valid", rule.Alert)
+	ExpectWithOffset(1, rule.Labels).To(HaveKeyWithValue("operator_health_impact", BeElementOf("none", "warning", "critical")),
+		"%s operator_health_impact label is missing or not valid", rule.Alert)
+	ExpectWithOffset(1, rule.Labels).To(HaveKeyWithValue("kubernetes_operator_part_of", "kubevirt"),
+		"%s kubernetes_operator_part_of label is missing or not valid", rule.Alert)
+	ExpectWithOffset(1, rule.Labels).To(HaveKeyWithValue("kubernetes_operator_component", "cluster-network-addons-operator"),
+		"%s kubernetes_operator_component label is missing or not valid", rule.Alert)
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This PR improves the alerts rules test readability and maintainability. In addition, it adds a check to the alerts rules test, which verifies that the alerts `runbook_url` annotations have a suffix with the alerts names.

**Which issue(s) this PR fixes**: https://issues.redhat.com/browse/CNV-30798


**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
