### PR TITLE
arm: Remove amd64 node selector

### DIFF
--- a/pkg/network/placement_configuration.go
+++ b/pkg/network/placement_configuration.go
@@ -65,7 +65,7 @@ func GetDefaultPlacementConfiguration() cnao.PlacementConfiguration {
 		},
 		Workloads: &cnao.Placement{
 			NodeSelector: map[string]string{
-				"kubernetes.io/arch": "amd64",
+				"kubernetes.io/os": "linux",
 			},
 			Tolerations: []corev1.Toleration{
 				corev1.Toleration{

--- a/pkg/network/placement_configuration_test.go
+++ b/pkg/network/placement_configuration_test.go
@@ -55,7 +55,7 @@ var _ = Describe("Testing PlacementConfiguration", func() {
 				PlacementConfiguration: &cnao.PlacementConfiguration{
 					Workloads: &cnao.Placement{
 						NodeSelector: map[string]string{
-							"kubernetes.io/arch": "amd64",
+							"kubernetes.io/os": "linux",
 						},
 					},
 					Infra: &cnao.Placement{
@@ -68,7 +68,7 @@ var _ = Describe("Testing PlacementConfiguration", func() {
 			expectedConfig: cnao.PlacementConfiguration{
 				Workloads: &cnao.Placement{
 					NodeSelector: map[string]string{
-						"kubernetes.io/arch": "amd64",
+						"kubernetes.io/os": "linux",
 					},
 				},
 				Infra: &cnao.Placement{


### PR DESCRIPTION
**What this PR does / why we need it**:
In order to allow running on ARM, remove "kubernetes.io/arch": "amd64" node selectors
from default placement.
Replace them with simple "kubernetes.io/os": "linux", which is part of the default selector if none.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=2238723

**Special notes for your reviewer**:
* Bridge market repo itself also have this selector, but it doesn't affect CNAO, because CNAO
replace it when bumping bridge market.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
None
```
