### PR TITLE
modules: Amend hashicorp filtering

### DIFF
--- a/.github/workflows/check_hashicorp_modules.yaml
+++ b/.github/workflows/check_hashicorp_modules.yaml
@@ -9,38 +9,18 @@ jobs:
     - name: Run script
       run: |
         allowed_hashicorp_modules=(
-            "github.com/hashicorp/consul/api"
-            "github.com/hashicorp/consul/sdk"
             "github.com/hashicorp/errwrap"
-            "github.com/hashicorp/hcl"
-            "github.com/hashicorp/logutils"
-            "github.com/hashicorp/mdns"
-            "github.com/hashicorp/memberlist"
-            "github.com/hashicorp/serf"
-            "github.com/hashicorp/go-cleanhttp"
-            "github.com/hashicorp/go-immutable-radix"
-            "github.com/hashicorp/golang-lru"
-            "github.com/hashicorp/go-msgpack"
             "github.com/hashicorp/go-multierror"
-            "github.com/hashicorp/go.net"
-            "github.com/hashicorp/go-retryablehttp"
-            "github.com/hashicorp/go-rootcerts"
-            "github.com/hashicorp/go-sockaddr"
-            "github.com/hashicorp/go-syslog"
-            "github.com/hashicorp/go-uuid"
-            "github.com/hashicorp/go-version"
+            "github.com/hashicorp/hcl"
         )
 
         error_found=false
         while read -r line; do
-            module=$(echo "$line" | cut -d ' ' -f 1)
-            if [[ $module == github.com/hashicorp/* ]]; then
-                if ! [[ " ${allowed_hashicorp_modules[*]} " == *" $module "* ]]; then
-                    echo "found non allowlisted hashicorp module: $module"
-                    error_found=true
-                fi
+            if ! [[ " ${allowed_hashicorp_modules[*]} " == *" $line "* ]]; then
+                echo "found non allowlisted hashicorp module: $line"
+                error_found=true
             fi
-        done < go.sum
+        done < <(grep -i hashicorp go.mod | grep -o 'github.com/[^ ]*')
 
         if [[ $error_found == true ]]; then
             echo "Non allowlisted hashicorp modules found, exiting with an error."

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,7 @@
 module github.com/kubevirt/cluster-network-addons-operator
 
+go 1.17
+
 require (
 	github.com/Masterminds/sprig v2.22.0+incompatible
 	github.com/blang/semver v3.5.1+incompatible
@@ -332,5 +334,3 @@ replace github.com/Microsoft/go-winio => github.com/Microsoft/go-winio v0.4.17
 replace bitbucket.org/ww/goautoneg => github.com/munnerz/goautoneg v0.0.0-20120707110453-a547fc61f48d
 
 replace github.com/Masterminds/goutils => github.com/Masterminds/goutils v1.1.1
-
-go 1.17


### PR DESCRIPTION
**What this PR does / why we need it**:
According [1] we need to look on go.mod only because we have "go 1.17" in go.mod.
Adapt git actions accordingly.


**Special notes for your reviewer**:
All the 3 modules whitelisted on this PR are approved by GB exception, example [2]
More reading about it [3]
(we might want to update the quick tip about it)

[1] https://github.com/cncf/foundation/issues/617#issuecomment-1681189207
[2] https://github.com/cncf/foundation/blob/e8bd39f52b9b577a0ba2fcb2bfa8e68b35ebc1e8/license-exceptions/cncf-exceptions-2022-04-12.json#L80
[3] https://github.com/cncf/foundation/issues/617#issuecomment-1695913854

**Release note**:
```release-note
None
```
