### PR TITLE
Nominate Or Shoval for the maintainer role

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -2,9 +2,11 @@ approvers:
   - RamLavi
   - phoracek
   - qinqon
+  - oshoval
 reviewers:
   - RamLavi
   - alonSadan
   - phoracek
   - qinqon
   - rhrazdil
+  - oshoval


### PR DESCRIPTION
**What this PR does / why we need it**:

I would like to nominate Or Shoval for the role of CNAO maintainer. Or has been consistently contributing to the project since 2020 and he has been a de facto maintainer for some time now.

Some of his recent contributions were licensing compliance, RBAC audit, or placement API.

Or is also caring for the integration of our adjacent project into CNAO. He understands how CNAO fits into HCO and how it is registered in project-infra. He is an active contributor of kubevirtci which we use to power CNAO's CI.

In the past few months, we have been working closely together, covering all the maintainer duties and I'm fully confident in him taking the responsibility over CNAO.

**Special notes for your reviewer**:

CC @RamLavi @qinqon @oshoval 

**Release note**:

```release-note
NONE
```
