### PR TITLE
go.mod: Bump go version to 1.19

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kubevirt/cluster-network-addons-operator
 
-go 1.17
+go 1.19
 
 require (
 	github.com/Masterminds/sprig v2.22.0+incompatible

--- a/pkg/apis/networkaddonsoperator/v1/group_info.go
+++ b/pkg/apis/networkaddonsoperator/v1/group_info.go
@@ -15,8 +15,8 @@ limitations under the License.
 */
 
 // Package v1 contains API Schema definitions for the networkaddonsoperator.network.kubevirt.io v1 API group
-//+kubebuilder:object:generate=true
-//+groupName=networkaddonsoperator.network.kubevirt.io
+// +kubebuilder:object:generate=true
+// +groupName=networkaddonsoperator.network.kubevirt.io
 package v1
 
 import (

--- a/pkg/apis/networkaddonsoperator/v1alpha1/group_info.go
+++ b/pkg/apis/networkaddonsoperator/v1alpha1/group_info.go
@@ -15,8 +15,8 @@ limitations under the License.
 */
 
 // Package v1alpha1 contains API Schema definitions for the networkaddonsoperator.network.kubevirt.io v1alpha1 API group
-//+kubebuilder:object:generate=true
-//+groupName=networkaddonsoperator.network.kubevirt.io
+// +kubebuilder:object:generate=true
+// +groupName=networkaddonsoperator.network.kubevirt.io
 package v1alpha1
 
 import (

--- a/test/e2e/workflow/recovery_test.go
+++ b/test/e2e/workflow/recovery_test.go
@@ -10,7 +10,7 @@ import (
 	. "github.com/kubevirt/cluster-network-addons-operator/test/operations"
 )
 
-//2297
+// 2297
 var _ = Describe("NetworkAddonsConfig", func() {
 	gvk := GetCnaoV1GroupVersionKind()
 	Context("when invalid config is applied", func() {


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR is bumping the go.mod go version to 1.19

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
