### PR TITLE
[release-0.85] components, Kubemacpool: Follow release-0.40 stable branch

### DIFF
--- a/components.yaml
+++ b/components.yaml
@@ -14,8 +14,8 @@ components:
   kubemacpool:
     url: https://github.com/k8snetworkplumbingwg/kubemacpool
     commit: f559c0725c4d315d1bf48fbc380c25a19ddf9c10
-    branch: main
-    update-policy: static
+    branch: release-0.40
+    update-policy: tagged
     metadata: v0.40.0
   linux-bridge:
     url: https://github.com/containernetworking/plugins


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR changes the components.yaml to follow the kubemacpool `release-0.40` stable branch

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
