### PR TITLE
[release-0.89] components, kubemacpool: Follow release-0.41 stable branch

### DIFF
--- a/components.yaml
+++ b/components.yaml
@@ -14,8 +14,8 @@ components:
   kubemacpool:
     url: https://github.com/k8snetworkplumbingwg/kubemacpool
     commit: 09d6598c46192921fb35099223070f05ca80b237
-    branch: main
-    update-policy: static
+    branch: release-0.41
+    update-policy: tagged
     metadata: v0.41.0
   linux-bridge:
     url: https://github.com/containernetworking/plugins


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR changes the components.yaml to follow the kubemacpool `release-0.41` stable branch

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
