### PR TITLE
workflows, auto-bumper: Update supported stable branches

### DIFF
--- a/.github/workflows/component-bumper.yaml
+++ b/.github/workflows/component-bumper.yaml
@@ -14,11 +14,10 @@ jobs:
       matrix:
         branch:
           - main
-          - release-0.53
-          - release-0.58
           - release-0.65
           - release-0.76
           - release-0.79
+          - release-0.85
           - release-0.89
     steps:
       - name: Login to Quay


### PR DESCRIPTION
**What this PR does / why we need it**:
CNAO will auto bump only the stable branches that are set on the workflow branch matrix.
Updating the supported branches.

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
