### PR TITLE
[release-0.76] cluster-up: Fix cluster-up flow

### DIFF
--- a/cluster/up.sh
+++ b/cluster/up.sh
@@ -35,12 +35,8 @@ if [[ "$KUBEVIRT_PROVIDER" =~ (ocp|okd)- ]]; then
 fi
 
 if [[ "$KUBEVIRT_PROVIDER" =~ k8s- ]]; then
-    echo 'Installing Open vSwitch'
+    echo 'Enable Open vSwitch'
     for node in $(./cluster/kubectl.sh get nodes --no-headers | awk '{print $1}'); do
-        ./cluster/cli.sh ssh ${node} -- sudo dnf install -y centos-release-nfv-openvswitch
-        ./cluster/cli.sh ssh ${node} -- sudo dnf install -y openvswitch2.16 libibverbs
-        ./cluster/cli.sh ssh ${node} -- sudo systemctl daemon-reload
         ./cluster/cli.sh ssh ${node} -- sudo systemctl enable --now openvswitch
-        ./cluster/cli.sh ssh ${node} -- sudo systemctl restart openvswitch
     done
 fi

--- a/hack/components/git-utils.sh
+++ b/hack/components/git-utils.sh
@@ -23,7 +23,7 @@ function git-utils::get_component_tag() {
 
     (
         cd ${component_dir}
-        git describe --tags
+        git describe --tags --abbrev=7
     )
 }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the main branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it

If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**What this PR does / why we need it**:
Fixes [1]

Openvswitch is already installed in kubevirtci, and NA when trying to dnf install it again.
Remove it to overcome the problem, as it is not necessary.
See https://github.com/kubevirt/cluster-network-addons-operator/pull/1482

[1] https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_cluster-network-addons-operator/1644/pull-e2e-cnao-ovs-cni-functests-release-0.76/1719701128226017280

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
None
```
