### PR TITLE
Bump kube-rbac-proxy

### DIFF
--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -37,7 +37,7 @@ const (
 	KubeMacPoolImageDefault           = "quay.io/kubevirt/kubemacpool@sha256:2f7a4ed0532909176b21eb3b80dec88a14e4f23d0c0aae129acd699636d058a3"
 	OvsCniImageDefault                = "quay.io/kubevirt/ovs-cni-plugin@sha256:e16ac74343da21abb8fb668ce71e728053d00503a992dae2164b9e94a280113e"
 	MacvtapCniImageDefault            = "quay.io/kubevirt/macvtap-cni@sha256:850b89343ace7c7ea6b18dd8e11964613974e9d1f7377af03854d407fb15230a"
-	KubeRbacProxyImageDefault         = "quay.io/openshift/origin-kube-rbac-proxy@sha256:baedb268ac66456018fb30af395bb3d69af5fff3252ff5d549f0231b1ebb6901"
+	KubeRbacProxyImageDefault         = "quay.io/openshift/origin-kube-rbac-proxy@sha256:e2def4213ec0657e72eb790ae8a115511d5b8f164a62d3568d2f1bff189917e8"
 	KubeSecondaryDNSImageDefault      = "ghcr.io/kubevirt/kubesecondarydns@sha256:e87e829380a1e576384145f78ccaa885ba1d5690d5de7d0b73d40cfb804ea24d"
 	CoreDNSImageDefault               = "registry.k8s.io/coredns/coredns@sha256:a0ead06651cf580044aeb0a0feba63591858fb2e43ade8c9dea45a6a89ae7e5e"
 )

--- a/test/releases/0.76.0.go
+++ b/test/releases/0.76.0.go
@@ -2,7 +2,6 @@ package releases
 
 import (
 	cnao "github.com/kubevirt/cluster-network-addons-operator/pkg/apis/networkaddonsoperator/shared"
-	"github.com/kubevirt/cluster-network-addons-operator/pkg/components"
 )
 
 func init() {
@@ -37,7 +36,7 @@ func init() {
 				ParentName: "kubemacpool-mac-controller-manager",
 				ParentKind: "Deployment",
 				Name:       "kube-rbac-proxy",
-				Image:      components.KubeRbacProxyImageDefault,
+				Image:      "quay.io/openshift/origin-kube-rbac-proxy@sha256:baedb268ac66456018fb30af395bb3d69af5fff3252ff5d549f0231b1ebb6901",
 			},
 			{
 				ParentName: "kubemacpool-cert-manager",

--- a/test/releases/0.76.3.go
+++ b/test/releases/0.76.3.go
@@ -2,7 +2,6 @@ package releases
 
 import (
 	cnao "github.com/kubevirt/cluster-network-addons-operator/pkg/apis/networkaddonsoperator/shared"
-	"github.com/kubevirt/cluster-network-addons-operator/pkg/components"
 )
 
 func init() {
@@ -37,7 +36,7 @@ func init() {
 				ParentName: "kubemacpool-mac-controller-manager",
 				ParentKind: "Deployment",
 				Name:       "kube-rbac-proxy",
-				Image:      components.KubeRbacProxyImageDefault,
+				Image:      "quay.io/openshift/origin-kube-rbac-proxy@sha256:baedb268ac66456018fb30af395bb3d69af5fff3252ff5d549f0231b1ebb6901",
 			},
 			{
 				ParentName: "kubemacpool-cert-manager",

--- a/test/releases/0.77.0.go
+++ b/test/releases/0.77.0.go
@@ -2,7 +2,6 @@ package releases
 
 import (
 	cnao "github.com/kubevirt/cluster-network-addons-operator/pkg/apis/networkaddonsoperator/shared"
-	"github.com/kubevirt/cluster-network-addons-operator/pkg/components"
 )
 
 func init() {
@@ -37,7 +36,7 @@ func init() {
 				ParentName: "kubemacpool-mac-controller-manager",
 				ParentKind: "Deployment",
 				Name:       "kube-rbac-proxy",
-				Image:      components.KubeRbacProxyImageDefault,
+				Image:      "quay.io/openshift/origin-kube-rbac-proxy@sha256:baedb268ac66456018fb30af395bb3d69af5fff3252ff5d549f0231b1ebb6901",
 			},
 			{
 				ParentName: "kubemacpool-cert-manager",

--- a/test/releases/0.78.0.go
+++ b/test/releases/0.78.0.go
@@ -2,7 +2,6 @@ package releases
 
 import (
 	cnao "github.com/kubevirt/cluster-network-addons-operator/pkg/apis/networkaddonsoperator/shared"
-	"github.com/kubevirt/cluster-network-addons-operator/pkg/components"
 )
 
 func init() {
@@ -43,7 +42,7 @@ func init() {
 				ParentName: "kubemacpool-mac-controller-manager",
 				ParentKind: "Deployment",
 				Name:       "kube-rbac-proxy",
-				Image:      components.KubeRbacProxyImageDefault,
+				Image:      "quay.io/openshift/origin-kube-rbac-proxy@sha256:baedb268ac66456018fb30af395bb3d69af5fff3252ff5d549f0231b1ebb6901",
 			},
 			{
 				ParentName: "kubemacpool-cert-manager",

--- a/test/releases/0.79.0.go
+++ b/test/releases/0.79.0.go
@@ -2,7 +2,6 @@ package releases
 
 import (
 	cnao "github.com/kubevirt/cluster-network-addons-operator/pkg/apis/networkaddonsoperator/shared"
-	"github.com/kubevirt/cluster-network-addons-operator/pkg/components"
 )
 
 func init() {
@@ -43,7 +42,7 @@ func init() {
 				ParentName: "kubemacpool-mac-controller-manager",
 				ParentKind: "Deployment",
 				Name:       "kube-rbac-proxy",
-				Image:      components.KubeRbacProxyImageDefault,
+				Image:      "quay.io/openshift/origin-kube-rbac-proxy@sha256:baedb268ac66456018fb30af395bb3d69af5fff3252ff5d549f0231b1ebb6901",
 			},
 			{
 				ParentName: "kubemacpool-cert-manager",

--- a/test/releases/0.79.1.go
+++ b/test/releases/0.79.1.go
@@ -2,7 +2,6 @@ package releases
 
 import (
 	cnao "github.com/kubevirt/cluster-network-addons-operator/pkg/apis/networkaddonsoperator/shared"
-	"github.com/kubevirt/cluster-network-addons-operator/pkg/components"
 )
 
 func init() {
@@ -43,7 +42,7 @@ func init() {
 				ParentName: "kubemacpool-mac-controller-manager",
 				ParentKind: "Deployment",
 				Name:       "kube-rbac-proxy",
-				Image:      components.KubeRbacProxyImageDefault,
+				Image:      "quay.io/openshift/origin-kube-rbac-proxy@sha256:baedb268ac66456018fb30af395bb3d69af5fff3252ff5d549f0231b1ebb6901",
 			},
 			{
 				ParentName: "kubemacpool-cert-manager",

--- a/test/releases/0.79.2.go
+++ b/test/releases/0.79.2.go
@@ -2,7 +2,6 @@ package releases
 
 import (
 	cnao "github.com/kubevirt/cluster-network-addons-operator/pkg/apis/networkaddonsoperator/shared"
-	"github.com/kubevirt/cluster-network-addons-operator/pkg/components"
 )
 
 func init() {
@@ -43,7 +42,7 @@ func init() {
 				ParentName: "kubemacpool-mac-controller-manager",
 				ParentKind: "Deployment",
 				Name:       "kube-rbac-proxy",
-				Image:      components.KubeRbacProxyImageDefault,
+				Image:      "quay.io/openshift/origin-kube-rbac-proxy@sha256:baedb268ac66456018fb30af395bb3d69af5fff3252ff5d549f0231b1ebb6901",
 			},
 			{
 				ParentName: "kubemacpool-cert-manager",

--- a/test/releases/0.80.0.go
+++ b/test/releases/0.80.0.go
@@ -2,7 +2,6 @@ package releases
 
 import (
 	cnao "github.com/kubevirt/cluster-network-addons-operator/pkg/apis/networkaddonsoperator/shared"
-	"github.com/kubevirt/cluster-network-addons-operator/pkg/components"
 )
 
 func init() {
@@ -43,7 +42,7 @@ func init() {
 				ParentName: "kubemacpool-mac-controller-manager",
 				ParentKind: "Deployment",
 				Name:       "kube-rbac-proxy",
-				Image:      components.KubeRbacProxyImageDefault,
+				Image:      "quay.io/openshift/origin-kube-rbac-proxy@sha256:baedb268ac66456018fb30af395bb3d69af5fff3252ff5d549f0231b1ebb6901",
 			},
 			{
 				ParentName: "kubemacpool-cert-manager",

--- a/test/releases/0.81.0.go
+++ b/test/releases/0.81.0.go
@@ -2,7 +2,6 @@ package releases
 
 import (
 	cnao "github.com/kubevirt/cluster-network-addons-operator/pkg/apis/networkaddonsoperator/shared"
-	"github.com/kubevirt/cluster-network-addons-operator/pkg/components"
 )
 
 func init() {
@@ -49,7 +48,7 @@ func init() {
 				ParentName: "kubemacpool-mac-controller-manager",
 				ParentKind: "Deployment",
 				Name:       "kube-rbac-proxy",
-				Image:      components.KubeRbacProxyImageDefault,
+				Image:      "quay.io/openshift/origin-kube-rbac-proxy@sha256:baedb268ac66456018fb30af395bb3d69af5fff3252ff5d549f0231b1ebb6901",
 			},
 			{
 				ParentName: "kubemacpool-cert-manager",

--- a/test/releases/0.82.0.go
+++ b/test/releases/0.82.0.go
@@ -2,7 +2,6 @@ package releases
 
 import (
 	cnao "github.com/kubevirt/cluster-network-addons-operator/pkg/apis/networkaddonsoperator/shared"
-	"github.com/kubevirt/cluster-network-addons-operator/pkg/components"
 )
 
 func init() {
@@ -49,7 +48,7 @@ func init() {
 				ParentName: "kubemacpool-mac-controller-manager",
 				ParentKind: "Deployment",
 				Name:       "kube-rbac-proxy",
-				Image:      components.KubeRbacProxyImageDefault,
+				Image:      "quay.io/openshift/origin-kube-rbac-proxy@sha256:baedb268ac66456018fb30af395bb3d69af5fff3252ff5d549f0231b1ebb6901",
 			},
 			{
 				ParentName: "kubemacpool-cert-manager",

--- a/test/releases/0.83.0.go
+++ b/test/releases/0.83.0.go
@@ -2,7 +2,6 @@ package releases
 
 import (
 	cnao "github.com/kubevirt/cluster-network-addons-operator/pkg/apis/networkaddonsoperator/shared"
-	"github.com/kubevirt/cluster-network-addons-operator/pkg/components"
 )
 
 const secondaryDNSDeployment = "secondary-dns"
@@ -51,7 +50,7 @@ func init() {
 				ParentName: "kubemacpool-mac-controller-manager",
 				ParentKind: "Deployment",
 				Name:       "kube-rbac-proxy",
-				Image:      components.KubeRbacProxyImageDefault,
+				Image:      "quay.io/openshift/origin-kube-rbac-proxy@sha256:baedb268ac66456018fb30af395bb3d69af5fff3252ff5d549f0231b1ebb6901",
 			},
 			{
 				ParentName: "kubemacpool-cert-manager",

--- a/test/releases/0.83.1.go
+++ b/test/releases/0.83.1.go
@@ -2,7 +2,6 @@ package releases
 
 import (
 	cnao "github.com/kubevirt/cluster-network-addons-operator/pkg/apis/networkaddonsoperator/shared"
-	"github.com/kubevirt/cluster-network-addons-operator/pkg/components"
 )
 
 func init() {
@@ -49,7 +48,7 @@ func init() {
 				ParentName: "kubemacpool-mac-controller-manager",
 				ParentKind: "Deployment",
 				Name:       "kube-rbac-proxy",
-				Image:      components.KubeRbacProxyImageDefault,
+				Image:      "quay.io/openshift/origin-kube-rbac-proxy@sha256:baedb268ac66456018fb30af395bb3d69af5fff3252ff5d549f0231b1ebb6901",
 			},
 			{
 				ParentName: "kubemacpool-cert-manager",

--- a/test/releases/0.84.0.go
+++ b/test/releases/0.84.0.go
@@ -2,7 +2,6 @@ package releases
 
 import (
 	cnao "github.com/kubevirt/cluster-network-addons-operator/pkg/apis/networkaddonsoperator/shared"
-	"github.com/kubevirt/cluster-network-addons-operator/pkg/components"
 )
 
 func init() {
@@ -49,7 +48,7 @@ func init() {
 				ParentName: "kubemacpool-mac-controller-manager",
 				ParentKind: "Deployment",
 				Name:       "kube-rbac-proxy",
-				Image:      components.KubeRbacProxyImageDefault,
+				Image:      "quay.io/openshift/origin-kube-rbac-proxy@sha256:baedb268ac66456018fb30af395bb3d69af5fff3252ff5d549f0231b1ebb6901",
 			},
 			{
 				ParentName: "kubemacpool-cert-manager",

--- a/test/releases/0.85.0.go
+++ b/test/releases/0.85.0.go
@@ -2,7 +2,6 @@ package releases
 
 import (
 	cnao "github.com/kubevirt/cluster-network-addons-operator/pkg/apis/networkaddonsoperator/shared"
-	"github.com/kubevirt/cluster-network-addons-operator/pkg/components"
 )
 
 func init() {
@@ -49,7 +48,7 @@ func init() {
 				ParentName: "kubemacpool-mac-controller-manager",
 				ParentKind: "Deployment",
 				Name:       "kube-rbac-proxy",
-				Image:      components.KubeRbacProxyImageDefault,
+				Image:      "quay.io/openshift/origin-kube-rbac-proxy@sha256:baedb268ac66456018fb30af395bb3d69af5fff3252ff5d549f0231b1ebb6901",
 			},
 			{
 				ParentName: "kubemacpool-cert-manager",

--- a/test/releases/0.85.1.go
+++ b/test/releases/0.85.1.go
@@ -2,7 +2,6 @@ package releases
 
 import (
 	cnao "github.com/kubevirt/cluster-network-addons-operator/pkg/apis/networkaddonsoperator/shared"
-	"github.com/kubevirt/cluster-network-addons-operator/pkg/components"
 )
 
 func init() {
@@ -49,7 +48,7 @@ func init() {
 				ParentName: "kubemacpool-mac-controller-manager",
 				ParentKind: "Deployment",
 				Name:       "kube-rbac-proxy",
-				Image:      components.KubeRbacProxyImageDefault,
+				Image:      "quay.io/openshift/origin-kube-rbac-proxy@sha256:baedb268ac66456018fb30af395bb3d69af5fff3252ff5d549f0231b1ebb6901",
 			},
 			{
 				ParentName: "kubemacpool-cert-manager",

--- a/test/releases/0.85.2.go
+++ b/test/releases/0.85.2.go
@@ -2,7 +2,6 @@ package releases
 
 import (
 	cnao "github.com/kubevirt/cluster-network-addons-operator/pkg/apis/networkaddonsoperator/shared"
-	"github.com/kubevirt/cluster-network-addons-operator/pkg/components"
 )
 
 func init() {
@@ -49,7 +48,7 @@ func init() {
 				ParentName: "kubemacpool-mac-controller-manager",
 				ParentKind: "Deployment",
 				Name:       "kube-rbac-proxy",
-				Image:      components.KubeRbacProxyImageDefault,
+				Image:      "quay.io/openshift/origin-kube-rbac-proxy@sha256:baedb268ac66456018fb30af395bb3d69af5fff3252ff5d549f0231b1ebb6901",
 			},
 			{
 				ParentName: "kubemacpool-cert-manager",

--- a/test/releases/0.85.3.go
+++ b/test/releases/0.85.3.go
@@ -2,7 +2,6 @@ package releases
 
 import (
 	cnao "github.com/kubevirt/cluster-network-addons-operator/pkg/apis/networkaddonsoperator/shared"
-	"github.com/kubevirt/cluster-network-addons-operator/pkg/components"
 )
 
 func init() {
@@ -49,7 +48,7 @@ func init() {
 				ParentName: "kubemacpool-mac-controller-manager",
 				ParentKind: "Deployment",
 				Name:       "kube-rbac-proxy",
-				Image:      components.KubeRbacProxyImageDefault,
+				Image:      "quay.io/openshift/origin-kube-rbac-proxy@sha256:baedb268ac66456018fb30af395bb3d69af5fff3252ff5d549f0231b1ebb6901",
 			},
 			{
 				ParentName: "kubemacpool-cert-manager",

--- a/test/releases/0.86.0.go
+++ b/test/releases/0.86.0.go
@@ -2,7 +2,6 @@ package releases
 
 import (
 	cnao "github.com/kubevirt/cluster-network-addons-operator/pkg/apis/networkaddonsoperator/shared"
-	"github.com/kubevirt/cluster-network-addons-operator/pkg/components"
 )
 
 func init() {
@@ -49,7 +48,7 @@ func init() {
 				ParentName: "kubemacpool-mac-controller-manager",
 				ParentKind: "Deployment",
 				Name:       "kube-rbac-proxy",
-				Image:      components.KubeRbacProxyImageDefault,
+				Image:      "quay.io/openshift/origin-kube-rbac-proxy@sha256:baedb268ac66456018fb30af395bb3d69af5fff3252ff5d549f0231b1ebb6901",
 			},
 			{
 				ParentName: "kubemacpool-cert-manager",

--- a/test/releases/0.86.1.go
+++ b/test/releases/0.86.1.go
@@ -2,7 +2,6 @@ package releases
 
 import (
 	cnao "github.com/kubevirt/cluster-network-addons-operator/pkg/apis/networkaddonsoperator/shared"
-	"github.com/kubevirt/cluster-network-addons-operator/pkg/components"
 )
 
 func init() {
@@ -49,7 +48,7 @@ func init() {
 				ParentName: "kubemacpool-mac-controller-manager",
 				ParentKind: "Deployment",
 				Name:       "kube-rbac-proxy",
-				Image:      components.KubeRbacProxyImageDefault,
+				Image:      "quay.io/openshift/origin-kube-rbac-proxy@sha256:baedb268ac66456018fb30af395bb3d69af5fff3252ff5d549f0231b1ebb6901",
 			},
 			{
 				ParentName: "kubemacpool-cert-manager",

--- a/test/releases/0.87.0.go
+++ b/test/releases/0.87.0.go
@@ -2,7 +2,6 @@ package releases
 
 import (
 	cnao "github.com/kubevirt/cluster-network-addons-operator/pkg/apis/networkaddonsoperator/shared"
-	"github.com/kubevirt/cluster-network-addons-operator/pkg/components"
 )
 
 func init() {
@@ -49,7 +48,7 @@ func init() {
 				ParentName: "kubemacpool-mac-controller-manager",
 				ParentKind: "Deployment",
 				Name:       "kube-rbac-proxy",
-				Image:      components.KubeRbacProxyImageDefault,
+				Image:      "quay.io/openshift/origin-kube-rbac-proxy@sha256:baedb268ac66456018fb30af395bb3d69af5fff3252ff5d549f0231b1ebb6901",
 			},
 			{
 				ParentName: "kubemacpool-cert-manager",

--- a/test/releases/0.88.0.go
+++ b/test/releases/0.88.0.go
@@ -2,7 +2,6 @@ package releases
 
 import (
 	cnao "github.com/kubevirt/cluster-network-addons-operator/pkg/apis/networkaddonsoperator/shared"
-	"github.com/kubevirt/cluster-network-addons-operator/pkg/components"
 )
 
 func init() {
@@ -49,7 +48,7 @@ func init() {
 				ParentName: "kubemacpool-mac-controller-manager",
 				ParentKind: "Deployment",
 				Name:       "kube-rbac-proxy",
-				Image:      components.KubeRbacProxyImageDefault,
+				Image:      "quay.io/openshift/origin-kube-rbac-proxy@sha256:baedb268ac66456018fb30af395bb3d69af5fff3252ff5d549f0231b1ebb6901",
 			},
 			{
 				ParentName: "kubemacpool-cert-manager",

--- a/test/releases/0.89.0.go
+++ b/test/releases/0.89.0.go
@@ -2,7 +2,6 @@ package releases
 
 import (
 	cnao "github.com/kubevirt/cluster-network-addons-operator/pkg/apis/networkaddonsoperator/shared"
-	"github.com/kubevirt/cluster-network-addons-operator/pkg/components"
 )
 
 func init() {
@@ -49,7 +48,7 @@ func init() {
 				ParentName: "kubemacpool-mac-controller-manager",
 				ParentKind: "Deployment",
 				Name:       "kube-rbac-proxy",
-				Image:      components.KubeRbacProxyImageDefault,
+				Image:      "quay.io/openshift/origin-kube-rbac-proxy@sha256:baedb268ac66456018fb30af395bb3d69af5fff3252ff5d549f0231b1ebb6901",
 			},
 			{
 				ParentName: "kubemacpool-cert-manager",

--- a/test/releases/0.90.0.go
+++ b/test/releases/0.90.0.go
@@ -2,7 +2,6 @@ package releases
 
 import (
 	cnao "github.com/kubevirt/cluster-network-addons-operator/pkg/apis/networkaddonsoperator/shared"
-	"github.com/kubevirt/cluster-network-addons-operator/pkg/components"
 )
 
 func init() {
@@ -49,7 +48,7 @@ func init() {
 				ParentName: "kubemacpool-mac-controller-manager",
 				ParentKind: "Deployment",
 				Name:       "kube-rbac-proxy",
-				Image:      components.KubeRbacProxyImageDefault,
+				Image:      "quay.io/openshift/origin-kube-rbac-proxy@sha256:baedb268ac66456018fb30af395bb3d69af5fff3252ff5d549f0231b1ebb6901",
 			},
 			{
 				ParentName: "kubemacpool-cert-manager",

--- a/test/releases/0.90.1.go
+++ b/test/releases/0.90.1.go
@@ -2,7 +2,6 @@ package releases
 
 import (
 	cnao "github.com/kubevirt/cluster-network-addons-operator/pkg/apis/networkaddonsoperator/shared"
-	"github.com/kubevirt/cluster-network-addons-operator/pkg/components"
 )
 
 func init() {
@@ -49,7 +48,7 @@ func init() {
 				ParentName: "kubemacpool-mac-controller-manager",
 				ParentKind: "Deployment",
 				Name:       "kube-rbac-proxy",
-				Image:      components.KubeRbacProxyImageDefault,
+				Image:      "quay.io/openshift/origin-kube-rbac-proxy@sha256:baedb268ac66456018fb30af395bb3d69af5fff3252ff5d549f0231b1ebb6901",
 			},
 			{
 				ParentName: "kubemacpool-cert-manager",

--- a/test/releases/99.0.0.go
+++ b/test/releases/99.0.0.go
@@ -2,7 +2,6 @@ package releases
 
 import (
 	cnao "github.com/kubevirt/cluster-network-addons-operator/pkg/apis/networkaddonsoperator/shared"
-	"github.com/kubevirt/cluster-network-addons-operator/pkg/components"
 )
 
 func init() {
@@ -49,7 +48,7 @@ func init() {
 				ParentName: "kubemacpool-mac-controller-manager",
 				ParentKind: "Deployment",
 				Name:       "kube-rbac-proxy",
-				Image:      components.KubeRbacProxyImageDefault,
+				Image:      "quay.io/openshift/origin-kube-rbac-proxy@sha256:e2def4213ec0657e72eb790ae8a115511d5b8f164a62d3568d2f1bff189917e8",
 			},
 			{
 				ParentName: "kubemacpool-cert-manager",


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the main branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it

If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**What this PR does / why we need it**:
Includes https://github.com/openshift/kube-rbac-proxy/pull/80
Affects CNAO and KMP.

`KubeRbacProxyImageDefault` was updated manually to a version
that contains the mention fix (we don't have automation, nor need atm for kube-rbac-proxy).

Before this PR we used `baedb268ac66456018fb30af395bb3d69af5fff3252ff5d549f0231b1ebb6901`
everywhere (via variable).

This PR did the following:
1. Changed from using variable to use static hash, because it is wrong to use variable which exists only at 
`pkg/components/components.go` but might be different between versions.
Since the image might change, it can't use the variable which exists only on `pkg/components/components.go`,
but should have an hard coded value per each release.
See https://github.com/kubevirt/cluster-network-addons-operator/pull/1563 for more info.

2. Now that [1] is fixed, manually bump the latest release candid (`test/releases/99.0.0.go`) and `components.go` to the new hash.

Note: since the tests validate the release on the upgrade test,
both for the old and latest, if there were any errors we would see.

**Special notes for your reviewer**:
We might want to backport it, but each release will need its own version (4.14, 4.13 etc).
Note that this affects only U/S, so not a must imo.

Automation is not needed but note that when a bump happens next time
only those file should be updated with the new hash: 
`pkg/components/components.go`
`test/releases/99.0.0.go`
It is safe because once one is updated, the tests would fail if the 2nd isn't.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If no release note is required, just write "NONE".
-->

```release-note
None
```
