### PR TITLE
[release-0.85] components: Bump bridge-marker to 0.11.0

### DIFF
--- a/components.yaml
+++ b/components.yaml
@@ -1,10 +1,10 @@
 components:
   bridge-marker:
     url: https://github.com/kubevirt/bridge-marker
-    commit: 965fe62eb9c1c3f076f04c0e9a694c49e2066925
+    commit: 1ef932df7470bc6d73bf4111d1c43632d99bcde2
     branch: main
     update-policy: static
-    metadata: 0.10.0
+    metadata: 0.11.0
   kube-secondary-dns:
     url: https://github.com/kubevirt/kubesecondarydns
     commit: 95109fde2bf82984a702dac5d83f1ae67c595b6b

--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -32,7 +32,7 @@ const (
 	MultusImageDefault                = "ghcr.io/k8snetworkplumbingwg/multus-cni@sha256:4e336bd177b5c60e753be48484abb48edb002c7207de9f265fff2e00e8f5106e"
 	MultusDynamicNetworksImageDefault = "ghcr.io/k8snetworkplumbingwg/multus-dynamic-networks-controller@sha256:ef8fe97a52eb9b3c03e99979a42cf2edaa7b3365cb3eb4dd1654b1bb9e73d7a3"
 	LinuxBridgeCniImageDefault        = "quay.io/kubevirt/cni-default-plugins@sha256:406b43253fb5d45f50d1543879353822e3f746e2794b65ab30754e800386b76d"
-	LinuxBridgeMarkerImageDefault     = "quay.io/kubevirt/bridge-marker@sha256:5d24c6d1ecb0556896b7b81c7e5260b54173858425777b7a84df8a706c07e6d2"
+	LinuxBridgeMarkerImageDefault     = "quay.io/kubevirt/bridge-marker@sha256:e86b54b96e59679e938ab817d1d69751ce833ee7fa2cc15a09399c74ad715cbf"
 	KubeMacPoolImageDefault           = "quay.io/kubevirt/kubemacpool@sha256:1214dbe44786493733930d9ac195b0222c3e5c50dfec4fd2071956abcd3d3924"
 	OvsCniImageDefault                = "quay.io/kubevirt/ovs-cni-plugin@sha256:b1a73e039f7ef75994e1ae7997a233526dfa808c0260f91de6e1eb9f491fa796"
 	MacvtapCniImageDefault            = "quay.io/kubevirt/macvtap-cni@sha256:5a288f1f9956c2ea8127fa736b598326852d2aa58a8469fa663a1150c2313b02"

--- a/test/releases/99.0.0.go
+++ b/test/releases/99.0.0.go
@@ -31,7 +31,7 @@ func init() {
 				ParentName: "bridge-marker",
 				ParentKind: "DaemonSet",
 				Name:       "bridge-marker",
-				Image:      "quay.io/kubevirt/bridge-marker@sha256:5d24c6d1ecb0556896b7b81c7e5260b54173858425777b7a84df8a706c07e6d2",
+				Image:      "quay.io/kubevirt/bridge-marker@sha256:e86b54b96e59679e938ab817d1d69751ce833ee7fa2cc15a09399c74ad715cbf",
 			},
 			{
 				ParentName: "kube-cni-linux-bridge-plugin",


### PR DESCRIPTION
**What this PR does / why we need it**:

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
