### PR TITLE
[release-0.79] components: Bump bridge-marker to 0.11.0

### DIFF
--- a/components.yaml
+++ b/components.yaml
@@ -1,10 +1,10 @@
 components:
   bridge-marker:
     url: https://github.com/kubevirt/bridge-marker
-    commit: 965fe62eb9c1c3f076f04c0e9a694c49e2066925
+    commit: 1ef932df7470bc6d73bf4111d1c43632d99bcde2
     branch: main
     update-policy: static
-    metadata: 0.10.0
+    metadata: 0.11.0
   kubemacpool:
     url: https://github.com/k8snetworkplumbingwg/kubemacpool
     commit: fce2cd6a5a654f93209868ee9f3c3d03f639801d

--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -31,7 +31,7 @@ var (
 const (
 	MultusImageDefault            = "ghcr.io/k8snetworkplumbingwg/multus-cni@sha256:829c27e9392d013eee5086ca7670d7326d723ebaec526237215e86086b5a3234"
 	LinuxBridgeCniImageDefault    = "quay.io/kubevirt/cni-default-plugins@sha256:406b43253fb5d45f50d1543879353822e3f746e2794b65ab30754e800386b76d"
-	LinuxBridgeMarkerImageDefault = "quay.io/kubevirt/bridge-marker@sha256:5d24c6d1ecb0556896b7b81c7e5260b54173858425777b7a84df8a706c07e6d2"
+	LinuxBridgeMarkerImageDefault = "quay.io/kubevirt/bridge-marker@sha256:e86b54b96e59679e938ab817d1d69751ce833ee7fa2cc15a09399c74ad715cbf"
 	KubeMacPoolImageDefault       = "quay.io/kubevirt/kubemacpool@sha256:31cc0e9820c0a11fb488e3687c041340e7fbdfba233484054a3e916e7b631f0f"
 	OvsCniImageDefault            = "quay.io/kubevirt/ovs-cni-plugin@sha256:b9bda9757ae1fc1611c6a2f7e2dc3dbd4f9de607b551f4704326686733ad1d26"
 	MacvtapCniImageDefault        = "quay.io/kubevirt/macvtap-cni@sha256:583a3346cdb04374d4d802d5f5d37c4dc2f6897e6e62010648f8f28c9a5a5a07"

--- a/test/releases/99.0.0.go
+++ b/test/releases/99.0.0.go
@@ -25,7 +25,7 @@ func init() {
 				ParentName: "bridge-marker",
 				ParentKind: "DaemonSet",
 				Name:       "bridge-marker",
-				Image:      "quay.io/kubevirt/bridge-marker@sha256:5d24c6d1ecb0556896b7b81c7e5260b54173858425777b7a84df8a706c07e6d2",
+				Image:      "quay.io/kubevirt/bridge-marker@sha256:e86b54b96e59679e938ab817d1d69751ce833ee7fa2cc15a09399c74ad715cbf",
 			},
 			{
 				ParentName: "kube-cni-linux-bridge-plugin",


### PR DESCRIPTION

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
