### PR TITLE
[release-0.85] Update coredns container and image SHAs

### DIFF
--- a/hack/components/bump-kube-secondary-dns.sh
+++ b/hack/components/bump-kube-secondary-dns.sh
@@ -91,5 +91,11 @@ KUBE_SECONDARY_DNS_IMAGE=ghcr.io/kubevirt/kubesecondarydns
 KUBE_SECONDARY_DNS_IMAGE_TAGGED=${KUBE_SECONDARY_DNS_IMAGE}:${KUBE_SECONDARY_DNS_TAG}
 KUBE_SECONDARY_DNS_IMAGE_DIGEST="$(docker-utils::get_image_digest "${KUBE_SECONDARY_DNS_IMAGE_TAGGED}" "${KUBE_SECONDARY_DNS_IMAGE}")"
 
+CORE_DNS_IMAGE=registry.k8s.io/coredns/coredns
+CORE_DNS_IMAGE_TAGGED=$(grep $CORE_DNS_IMAGE ${KUBE_SECONDARY_DNS_PATH}/manifests/secondarydns.yaml | awk -F": " '{print $2}')
+CORE_DNS_IMAGE_DIGEST="$(docker-utils::get_image_digest "${CORE_DNS_IMAGE_TAGGED}" "${CORE_DNS_IMAGE}")"
+
 sed -i -r "s#\"${KUBE_SECONDARY_DNS_IMAGE}(@sha256)?:.*\"#\"${KUBE_SECONDARY_DNS_IMAGE_DIGEST}\"#" pkg/components/components.go
 sed -i -r "s#\"${KUBE_SECONDARY_DNS_IMAGE}(@sha256)?:.*\"#\"${KUBE_SECONDARY_DNS_IMAGE_DIGEST}\"#" test/releases/${CNAO_VERSION}.go
+
+sed -i -r "s#\"${CORE_DNS_IMAGE}(@sha256)?:.*\"#\"${CORE_DNS_IMAGE_DIGEST}\"#" pkg/components/components.go

--- a/hack/components/bump-kube-secondary-dns.sh
+++ b/hack/components/bump-kube-secondary-dns.sh
@@ -99,3 +99,4 @@ sed -i -r "s#\"${KUBE_SECONDARY_DNS_IMAGE}(@sha256)?:.*\"#\"${KUBE_SECONDARY_DNS
 sed -i -r "s#\"${KUBE_SECONDARY_DNS_IMAGE}(@sha256)?:.*\"#\"${KUBE_SECONDARY_DNS_IMAGE_DIGEST}\"#" test/releases/${CNAO_VERSION}.go
 
 sed -i -r "s#\"${CORE_DNS_IMAGE}(@sha256)?:.*\"#\"${CORE_DNS_IMAGE_DIGEST}\"#" pkg/components/components.go
+sed -i -r "s#\"${CORE_DNS_IMAGE}(@sha256)?:.*\"#\"${CORE_DNS_IMAGE_DIGEST}\"#" test/releases/${CNAO_VERSION}.go

--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -38,7 +38,7 @@ const (
 	MacvtapCniImageDefault            = "quay.io/kubevirt/macvtap-cni@sha256:5a288f1f9956c2ea8127fa736b598326852d2aa58a8469fa663a1150c2313b02"
 	KubeRbacProxyImageDefault         = "quay.io/openshift/origin-kube-rbac-proxy@sha256:baedb268ac66456018fb30af395bb3d69af5fff3252ff5d549f0231b1ebb6901"
 	KubeSecondaryDNSImageDefault      = "ghcr.io/kubevirt/kubesecondarydns@sha256:e87e829380a1e576384145f78ccaa885ba1d5690d5de7d0b73d40cfb804ea24d"
-	CoreDNSImageDefault               = "k8s.gcr.io/coredns/coredns@sha256:5b6ec0d6de9baaf3e92d0f66cd96a25b9edbce8716f5f15dcd1a616b3abd590e"
+	CoreDNSImageDefault               = "registry.k8s.io/coredns/coredns@sha256:a0ead06651cf580044aeb0a0feba63591858fb2e43ade8c9dea45a6a89ae7e5e"
 )
 
 type AddonsImages struct {

--- a/test/releases/0.83.0.go
+++ b/test/releases/0.83.0.go
@@ -81,7 +81,7 @@ func init() {
 				ParentName: secondaryDNSDeployment,
 				ParentKind: "Deployment",
 				Name:       "secondary-dns",
-				Image:      components.CoreDNSImageDefault,
+				Image:      "k8s.gcr.io/coredns/coredns@sha256:5b6ec0d6de9baaf3e92d0f66cd96a25b9edbce8716f5f15dcd1a616b3abd590e",
 			},
 		},
 		SupportedSpec: cnao.NetworkAddonsConfigSpec{

--- a/test/releases/0.83.1.go
+++ b/test/releases/0.83.1.go
@@ -79,7 +79,7 @@ func init() {
 				ParentName: "secondary-dns",
 				ParentKind: "Deployment",
 				Name:       "secondary-dns",
-				Image:      components.CoreDNSImageDefault,
+				Image:      "k8s.gcr.io/coredns/coredns@sha256:5b6ec0d6de9baaf3e92d0f66cd96a25b9edbce8716f5f15dcd1a616b3abd590e",
 			},
 		},
 		SupportedSpec: cnao.NetworkAddonsConfigSpec{

--- a/test/releases/0.84.0.go
+++ b/test/releases/0.84.0.go
@@ -79,7 +79,7 @@ func init() {
 				ParentName: "secondary-dns",
 				ParentKind: "Deployment",
 				Name:       "secondary-dns",
-				Image:      components.CoreDNSImageDefault,
+				Image:      "k8s.gcr.io/coredns/coredns@sha256:5b6ec0d6de9baaf3e92d0f66cd96a25b9edbce8716f5f15dcd1a616b3abd590e",
 			},
 		},
 		SupportedSpec: cnao.NetworkAddonsConfigSpec{

--- a/test/releases/0.85.0.go
+++ b/test/releases/0.85.0.go
@@ -79,7 +79,7 @@ func init() {
 				ParentName: "secondary-dns",
 				ParentKind: "Deployment",
 				Name:       "secondary-dns",
-				Image:      components.CoreDNSImageDefault,
+				Image:      "k8s.gcr.io/coredns/coredns@sha256:5b6ec0d6de9baaf3e92d0f66cd96a25b9edbce8716f5f15dcd1a616b3abd590e",
 			},
 		},
 		SupportedSpec: cnao.NetworkAddonsConfigSpec{

--- a/test/releases/0.85.1.go
+++ b/test/releases/0.85.1.go
@@ -79,7 +79,7 @@ func init() {
 				ParentName: "secondary-dns",
 				ParentKind: "Deployment",
 				Name:       "secondary-dns",
-				Image:      components.CoreDNSImageDefault,
+				Image:      "k8s.gcr.io/coredns/coredns@sha256:5b6ec0d6de9baaf3e92d0f66cd96a25b9edbce8716f5f15dcd1a616b3abd590e",
 			},
 		},
 		SupportedSpec: cnao.NetworkAddonsConfigSpec{

--- a/test/releases/0.85.2.go
+++ b/test/releases/0.85.2.go
@@ -79,7 +79,7 @@ func init() {
 				ParentName: "secondary-dns",
 				ParentKind: "Deployment",
 				Name:       "secondary-dns",
-				Image:      components.CoreDNSImageDefault,
+				Image:      "k8s.gcr.io/coredns/coredns@sha256:5b6ec0d6de9baaf3e92d0f66cd96a25b9edbce8716f5f15dcd1a616b3abd590e",
 			},
 		},
 		SupportedSpec: cnao.NetworkAddonsConfigSpec{

--- a/test/releases/0.85.3.go
+++ b/test/releases/0.85.3.go
@@ -79,7 +79,7 @@ func init() {
 				ParentName: "secondary-dns",
 				ParentKind: "Deployment",
 				Name:       "secondary-dns",
-				Image:      components.CoreDNSImageDefault,
+				Image:      "k8s.gcr.io/coredns/coredns@sha256:5b6ec0d6de9baaf3e92d0f66cd96a25b9edbce8716f5f15dcd1a616b3abd590e",
 			},
 		},
 		SupportedSpec: cnao.NetworkAddonsConfigSpec{

--- a/test/releases/99.0.0.go
+++ b/test/releases/99.0.0.go
@@ -79,7 +79,7 @@ func init() {
 				ParentName: "secondary-dns",
 				ParentKind: "Deployment",
 				Name:       "secondary-dns",
-				Image:      components.CoreDNSImageDefault,
+				Image:      "registry.k8s.io/coredns/coredns@sha256:a0ead06651cf580044aeb0a0feba63591858fb2e43ade8c9dea45a6a89ae7e5e",
 			},
 		},
 		SupportedSpec: cnao.NetworkAddonsConfigSpec{


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR updates the coreDNS image sha on the bump script and all the relevant test manifests.

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
