### PR TITLE
Avoid to emit duplicates for enum fileds

### DIFF
--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -1036,9 +1036,14 @@ func GetCrd() *extv1.CustomResourceDefinition {
 
 	cipherSuites := func() []extv1.JSON {
 		suites := []extv1.JSON{}
+		m := make(map[string]bool)
 		for _, p := range tlsProfiles(ocpv1.TLSProfiles).sortedKeys() {
 			for _, c := range ocpv1.TLSProfiles[p].Ciphers {
-				suites = append(suites, extv1.JSON{Raw: []byte(fmt.Sprintf("\"%s\"", c))})
+				if m[c] {
+					continue
+				}
+				m[c] = true
+				suites = append(suites, extv1.JSON{Raw: []byte(fmt.Sprintf(`"%s"`, c))})
 			}
 		}
 		return suites

--- a/pkg/components/components_test.go
+++ b/pkg/components/components_test.go
@@ -94,4 +94,19 @@ var _ = Describe("Components", func() {
 			Expect(ris[2].Ref).To(Equal("quay.io/kubevirt/ovs-cni-marker@sha256:0f08d6b1550a90c9f10221f2bb07709d1090e7c675ee1a711981bd429074d620"))
 		})
 	})
+
+	Context("When calculating ciphers", func() {
+		It("should not generate duplicates", func() {
+			var ciphers = GetCrd().Spec.Versions[0].Schema.OpenAPIV3Schema.Properties["spec"].Properties["tlsSecurityProfile"].Properties["custom"].Properties["ciphers"].Items.Schema.Enum
+			var stringCiphers = make([]string, len(ciphers))
+			for i, c := range ciphers {
+				stringCiphers[i] = string(c.Raw[:])
+			}
+			for i, vi := range stringCiphers {
+				for j := i + 1; j < len(stringCiphers); j++ {
+					Expect(vi).ToNot(Equal(stringCiphers[j]))
+				}
+			}
+		})
+	})
 })

--- a/pkg/network/tlsSecurityProfile.go
+++ b/pkg/network/tlsSecurityProfile.go
@@ -11,10 +11,26 @@ func SelectCipherSuitesAndMinTLSVersion(profile *ocpv1.TLSSecurityProfile) ([]st
 			Intermediate: &ocpv1.IntermediateTLSProfile{},
 		}
 	}
+	var ciphers []string
+	var minTlsVersion ocpv1.TLSProtocolVersion
 	if profile.Custom != nil {
-		return profile.Custom.TLSProfileSpec.Ciphers, profile.Custom.TLSProfileSpec.MinTLSVersion
+		ciphers = profile.Custom.TLSProfileSpec.Ciphers
+		minTlsVersion = profile.Custom.TLSProfileSpec.MinTLSVersion
+	} else {
+		ciphers = ocpv1.TLSProfiles[profile.Type].Ciphers
+		minTlsVersion = ocpv1.TLSProfiles[profile.Type].MinTLSVersion
 	}
-	return ocpv1.TLSProfiles[profile.Type].Ciphers, ocpv1.TLSProfiles[profile.Type].MinTLSVersion
+	m := make(map[string]bool)
+	var result []string
+	for _, c := range ciphers {
+		if m[c] {
+			continue
+		}
+		m[c] = true
+		result = append(result, c)
+	}
+
+	return result, minTlsVersion
 }
 
 func TLSVersionToHumanReadable(version ocpv1.TLSProtocolVersion) string {

--- a/pkg/network/tlsSecurityProfile_test.go
+++ b/pkg/network/tlsSecurityProfile_test.go
@@ -63,4 +63,24 @@ var _ = Describe("Testing TLS Security Profile", func() {
 			expectedMinTLSVersion: testCustomTLSProfileSpec.MinTLSVersion,
 		}),
 	)
+
+	Context("When selecting ciphers", func() {
+		It("should not generate duplicates", func() {
+			var profile = &ocpv1.TLSSecurityProfile{
+				Type: ocpv1.TLSProfileCustomType,
+				Custom: &ocpv1.CustomTLSProfile{
+					TLSProfileSpec: ocpv1.TLSProfileSpec{
+						Ciphers: []string{"foo", "foo", "bar"},
+					},
+				},
+				Intermediate: &ocpv1.IntermediateTLSProfile{},
+			}
+			var ciphers, _ = SelectCipherSuitesAndMinTLSVersion(profile)
+			for i, vi := range ciphers {
+				for j := i + 1; j < len(ciphers); j++ {
+					Expect(vi).ToNot(Equal(ciphers[j]))
+				}
+			}
+		})
+	})
 })


### PR DESCRIPTION
**What this PR does / why we need it**:

The enum "ciphers" contains duplicated entries, since it's Json Schema it should have all unique elements:
https://json-schema.org/understanding-json-schema/reference/enum

**Special notes for your reviewer**:

The bug has been discovered by @iocanel in https://github.com/fabric8io/kubernetes-client/pull/5611

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
Fixed incorrect generation of ciphers to prevent duplicated enum values.
```
