### PR TITLE
build, test: adapt to go1.21 toolchain

### DIFF
--- a/hack/install-go.sh
+++ b/hack/install-go.sh
@@ -2,6 +2,9 @@
 
 destination=$1
 version=$(grep "^go " go.mod |awk '{print $2}')
+if [ $version == "1.21" ]; then
+    version="1.21.6"
+fi
 tarball=go$version.linux-amd64.tar.gz
 url=https://dl.google.com/go/
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the main branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it

If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**What this PR does / why we need it**:
As part of the 1.21 release, golang now uses `x.y.z` releases - it furthermore allows per command (using an environment variable) updating the golang version used; quoting from golang's release notes:

"""
Go 1.21 introduces a small change to the numbering of releases. In the past, we used Go 1.N to refer to both the overall Go language version and release family as well as the first release in that family. Starting in Go 1.21, the first release is now Go 1.N.0. Today we are releasing both the Go 1.21 language and its initial implementation, the Go 1.21.0 release. These notes refer to "Go 1.21"; tools like go version will report "go1.21.0" (until you upgrade to Go 1.21.1). See "Go versions" in the "Go Toolchains" documentation for details about the new version numbering.
"""

This is not a long-term solution (integrating with go toolchain is) but allows us to start testing multus-dynamic-networks new release, which theoretically is no longer flaky.

[0] - https://go.dev/doc/go1.21#introduction

**Special notes for your reviewer**:
Unlocks PR #1764 which bumps the multus dynamic component to version (theoretically ...) flaky free (at least it is on containerd providers).

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
