### PR TITLE
Apply monitoring linter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,8 @@ GITHUB_RELEASE ?= $(BIN_DIR)/github-release
 
 CONTROLLER_GEN ?= $(BIN_DIR)/controller-gen
 
+MONITORING_LINTER ?= $(BIN_DIR)/monitoringlinter
+
 GO := $(GOBIN)/go
 
 $(GO):
@@ -214,6 +216,9 @@ generate-doc:
 lint-metrics:
 	./hack/prom_metric_linter.sh --operator-name="kubevirt" --sub-operator-name="cnao"
 
+lint-monitoring:
+	GOBIN=$$(pwd)/build/_output/bin/ $(GO) install -mod=mod github.com/kubevirt/monitoring/monitoringlinter/cmd/monitoringlinter@e2be790
+	$(MONITORING_LINTER) ./...
 
 .PHONY: \
 	$(E2E_SUITES) \
@@ -248,5 +253,6 @@ lint-metrics:
 	prom-rules-verify \
 	release \
 	update-workflows-branches \
-	statify-components
+	statify-components \
+	lint-monitoring
 

--- a/automation/check-patch.unit-test.sh
+++ b/automation/check-patch.unit-test.sh
@@ -16,6 +16,7 @@ main() {
     make check
     verify_metrics_docs_updated
     make lint-metrics
+    make lint-monitoring
     make docker-build
 }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the main branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it

If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**What this PR does / why we need it**:
Apply [monitoringlinter](https://github.com/kubevirt/monitoring/tree/main/monitoringlinter) that was implemented in https://github.com/kubevirt/monitoring/pull/221, and was designed to enforce https://github.com/kubevirt/community/pull/219.
This linter ensures that all monitoring-related practices are implemented within the `pkg/monitoring` directory using [operator-observability](https://github.com/machadovilaca/operator-observability/tree/main) methods. It verifies that all metrics, alerts and recording rules registrations are centralized in this directory, and restricts the direct use of [Prometheus registration methods](https://pkg.go.dev/github.com/prometheus/client_golang/prometheus#Registerer).
Example for a message reported by the linter:

  ```
  kubevirt/pkg/virt-controller/watch/workload-updater/workload-updater.go:67:2: monitoring-linter: metrics should be registered only within pkg/monitoring directory, using operator-observability packages.
  ```

Fixes https://issues.redhat.com/browse/CNV-36763
Other PRs references: https://github.com/kubevirt/hyperconverged-cluster-operator/pull/2827, https://github.com/kubevirt/kubevirt/pull/11454, https://github.com/kubevirt/ssp-operator/pull/932 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
None
```
