### PR TITLE
kubevirtci: Bump version

### DIFF
--- a/automation/check-patch.e2e-lifecycle-k8s.sh
+++ b/automation/check-patch.e2e-lifecycle-k8s.sh
@@ -18,8 +18,6 @@ versionChanged() {
 }
 
 main() {
-    export KUBEVIRT_PROVIDER='k8s-1.25'
-
     source automation/check-patch.setup.sh
     cd ${TMP_PROJECT_PATH}
 

--- a/automation/check-patch.e2e-monitoring-k8s.sh
+++ b/automation/check-patch.e2e-monitoring-k8s.sh
@@ -14,8 +14,6 @@ teardown() {
 }
 
 main() {
-    export KUBEVIRT_PROVIDER='k8s-1.25'
-
     source automation/check-patch.setup.sh
     cd ${TMP_PROJECT_PATH}
 

--- a/automation/check-patch.e2e-workflow-k8s.sh
+++ b/automation/check-patch.e2e-workflow-k8s.sh
@@ -14,8 +14,6 @@ teardown() {
 }
 
 main() {
-    export KUBEVIRT_PROVIDER='k8s-1.25'
-
     source automation/check-patch.setup.sh
     cd ${TMP_PROJECT_PATH}
 

--- a/cluster/cluster.sh
+++ b/cluster/cluster.sh
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-export KUBEVIRT_PROVIDER=${KUBEVIRT_PROVIDER:-'k8s-1.25'}
-export KUBEVIRTCI_TAG='2303201102-ef46217'
+export KUBEVIRT_PROVIDER=${KUBEVIRT_PROVIDER:-'k8s-1.28'}
+export KUBEVIRTCI_TAG=${KUBEVIRTCI_TAG:-2406041642-8d359a3}
 
 KUBEVIRTCI_REPO='https://github.com/kubevirt/kubevirtci.git'
 # The CLUSTER_PATH var is used in cluster folder and points to the _kubevirtci where the cluster is deployed from.

--- a/hack/bump-kubevirtci.sh
+++ b/hack/bump-kubevirtci.sh
@@ -3,6 +3,6 @@
 KUBEVIRTCI_TAG=$(curl -L -Ss https://storage.googleapis.com/kubevirt-prow/release/kubevirt/kubevirtci/latest)
 [[ ${#KUBEVIRTCI_TAG} != "18" ]] && echo "error getting KUBEVIRTCI_TAG" && exit 1
 
-sed -i "s/export KUBEVIRTCI_TAG=.*/export KUBEVIRTCI_TAG='${KUBEVIRTCI_TAG}'/g" cluster/cluster.sh
+sed -i "s/\(KUBEVIRTCI_TAG:-\)[^}]*/\1${KUBEVIRTCI_TAG}/" cluster/cluster.sh
 
 git --no-pager diff cluster/cluster.sh | grep KUBEVIRTCI_TAG || true


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the main branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it

If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**What this PR does / why we need it**:
Bump kubevirtci and cleanup unrequired exports.

Allow pinning specific kubevirtci per lane.
It will allow decoupling kubevirtci tag version between the lanes.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
None
```
