### PR TITLE
bumper: Paginate over commits on tagged update policy

### DIFF
--- a/tools/bumper/git_fakes.go
+++ b/tools/bumper/git_fakes.go
@@ -42,7 +42,7 @@ func (g mockGithubApi) listCommits(owner, repo string, opts *github.CommitsListO
 		return nil, nil, errors.Wrap(err, "failed performing mock git log")
 	}
 
-	return convertLogToRepositoryCommitList(gitCommitObjList), nil, nil
+	return convertLogToRepositoryCommitList(gitCommitObjList), &github.Response{NextPage: 1}, nil
 }
 
 func (g mockGithubApi) getBranchRef(owner string, repo string, ref string) (*github.Reference, *github.Response, error) {


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR expands the commits range used to find the latest tag when bumping using "tagged" update policy

**Special notes for your reviewer**:
Fixes https://github.com/kubevirt/cluster-network-addons-operator/issues/1813

**Release note**:

```release-note
NONE
```
