### PR TITLE
auto bumper: Fix in case there is only one page

### DIFF
--- a/tools/bumper/component_commands.go
+++ b/tools/bumper/component_commands.go
@@ -220,14 +220,15 @@ func (componentOps *gitComponent) getLatestTaggedFromBranch(repo, owner, branch,
 			if err != nil {
 				return "", "", errors.Wrap(err, "Failed to get release tag refs from github client API")
 			}
-			if resp.NextPage == 0 {
-				break
-			}
 
 			for _, commit := range branchCommits {
 				if commit.GetSHA() == commitShaOfTag {
 					return tagName, commit.GetSHA(), nil
 				}
+			}
+
+			if resp.NextPage == 0 {
+				break
 			}
 		}
 	}


### PR DESCRIPTION
We first need to consume the page, then to break if this is the last page, else we would directly fail.

<!-- Thanks for sending a pull request!

Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the main branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it

If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note

```
