### PR TITLE
KIC: Cleanup of old named resources

### DIFF
--- a/pkg/network/kubevirt_ipam_controller.go
+++ b/pkg/network/kubevirt_ipam_controller.go
@@ -1,11 +1,18 @@
 package network
 
 import (
+	"context"
+	"fmt"
+	"log"
 	"os"
 	"path/filepath"
 
 	"github.com/pkg/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	cnao "github.com/kubevirt/cluster-network-addons-operator/pkg/apis/networkaddonsoperator/shared"
 	"github.com/kubevirt/cluster-network-addons-operator/pkg/render"
@@ -44,4 +51,93 @@ func renderKubevirtIPAMController(conf *cnao.NetworkAddonsConfigSpec, manifestDi
 	}
 
 	return objs, nil
+}
+
+// cleanUpKubevirtIpamController checks specific kic outdated objects or ones that are no longer compatible and deletes them.
+func cleanUpKubevirtIpamController(conf *cnao.NetworkAddonsConfigSpec, ctx context.Context, client k8sclient.Client) []error {
+	if conf.KubevirtIpamController == nil {
+		return []error{}
+	}
+
+	errList := []error{}
+	errList = append(errList, cleanUpKubevirtIpamControllerOldNames(ctx, client)...)
+	return errList
+}
+
+// cleanUpKubevirtIpamControllerOldNames deletes kic objects with old name after a new name was introduces in version 0.94.1
+// REQUIRED_FOR upgrade from kubevirt-ipam-controller == 0.94.0
+func cleanUpKubevirtIpamControllerOldNames(ctx context.Context, client k8sclient.Client) []error {
+	namespace := os.Getenv("OPERAND_NAMESPACE")
+
+	resources := []struct {
+		gvk  schema.GroupVersionKind
+		name string
+	}{
+		{
+			gvk:  schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "Deployment"},
+			name: "kubevirt-ipam-claims-controller-manager",
+		},
+		{
+			gvk:  schema.GroupVersionKind{Group: "", Version: "v1", Kind: "ServiceAccount"},
+			name: "kubevirt-ipam-claims-controller-manager",
+		},
+		{
+			gvk:  schema.GroupVersionKind{Group: "rbac.authorization.k8s.io", Version: "v1", Kind: "Role"},
+			name: "kubevirt-ipam-claims-leader-election-role",
+		},
+		{
+			gvk:  schema.GroupVersionKind{Group: "rbac.authorization.k8s.io", Version: "v1", Kind: "ClusterRole"},
+			name: "kubevirt-ipam-claims-manager-role",
+		},
+		{
+			gvk:  schema.GroupVersionKind{Group: "rbac.authorization.k8s.io", Version: "v1", Kind: "RoleBinding"},
+			name: "kubevirt-ipam-claims-leader-election-rolebinding",
+		},
+		{
+			gvk:  schema.GroupVersionKind{Group: "rbac.authorization.k8s.io", Version: "v1", Kind: "ClusterRoleBinding"},
+			name: "kubevirt-ipam-claims-manager-rolebinding",
+		},
+		{
+			gvk:  schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Service"},
+			name: "kubevirt-ipam-claims-webhook-service",
+		},
+		{
+			gvk:  schema.GroupVersionKind{Group: "cert-manager.io", Version: "v1", Kind: "Certificate"},
+			name: "kubevirt-ipam-claims-serving-cert",
+		},
+		{
+			gvk:  schema.GroupVersionKind{Group: "cert-manager.io", Version: "v1", Kind: "Issuer"},
+			name: "kubevirt-ipam-claims-selfsigned-issuer",
+		},
+		{
+			gvk:  schema.GroupVersionKind{Group: "admissionregistration.k8s.io", Version: "v1", Kind: "MutatingWebhookConfiguration"},
+			name: "kubevirt-ipam-claims-mutating-webhook-configuration",
+		},
+	}
+
+	var errors []error
+	for _, resource := range resources {
+		existing := &unstructured.Unstructured{}
+		existing.SetGroupVersionKind(resource.gvk)
+
+		err := client.Get(ctx, types.NamespacedName{Name: resource.name, Namespace: namespace}, existing)
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				continue
+			}
+			errors = append(errors, err)
+			continue
+		}
+
+		objDesc := fmt.Sprintf("(%s) %s/%s", resource.gvk.String(), namespace, resource.name)
+		log.Printf("Cleaning up %s Object", objDesc)
+
+		err = client.Delete(ctx, existing)
+		if err != nil {
+			log.Printf("Failed Cleaning up %s Object", objDesc)
+			errors = append(errors, err)
+		}
+	}
+
+	return errors
 }

--- a/pkg/network/network.go
+++ b/pkg/network/network.go
@@ -77,6 +77,7 @@ func SpecialCleanUp(conf *cnao.NetworkAddonsConfigSpec, client k8sclient.Client,
 	ctx := context.TODO()
 
 	errs = append(errs, cleanUpMultus(conf, ctx, client)...)
+	errs = append(errs, cleanUpKubevirtIpamController(conf, ctx, client)...)
 	errs = append(errs, cleanUpNamespaceLabels(ctx, client)...)
 
 	if len(errs) > 0 {


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the main branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it

If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**What this PR does / why we need it**:
Since Kubevirt ipam controller resource names were renamed [1]
since 0.94.0, we introduce the special remove that in case the old named
objects exist, will remove them.
This allows the lifecycle lane to pass, as it checks for leftovers,
which otherwise exists.

[1] https://github.com/kubevirt/cluster-network-addons-operator/pull/1816

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
None
```
