### PR TITLE
e2e: Fix leftover check

### DIFF
--- a/test/check/check.go
+++ b/test/check/check.go
@@ -228,7 +228,7 @@ func CheckForLeftoverObjects(currentVersion string) {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(clusterRoles.Items).To(BeEmpty(), "Found leftover objects from the previous operator version")
 
-		clusterRoleBindings := rbacv1.ClusterRoleList{}
+		clusterRoleBindings := rbacv1.ClusterRoleBindingList{}
 		err = testenv.Client.List(context.Background(), &clusterRoleBindings, &listOptions)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(clusterRoleBindings.Items).To(BeEmpty(), "Found leftover objects from the previous operator version")


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the main branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it

If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**What this PR does / why we need it**:
Wrong type (ClusterRole) was checked twice.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
None
```
