### PR TITLE
ipam: Skip cleanup for non OpenShift types on OpenShift

### DIFF
--- a/pkg/network/network.go
+++ b/pkg/network/network.go
@@ -77,7 +77,7 @@ func SpecialCleanUp(conf *cnao.NetworkAddonsConfigSpec, client k8sclient.Client,
 	ctx := context.TODO()
 
 	errs = append(errs, cleanUpMultus(conf, ctx, client)...)
-	errs = append(errs, cleanUpKubevirtIpamController(conf, ctx, client)...)
+	errs = append(errs, cleanUpKubevirtIpamController(conf, ctx, client, clusterInfo.OpenShift4)...)
 	errs = append(errs, cleanUpNamespaceLabels(ctx, client)...)
 
 	if len(errs) > 0 {


### PR DESCRIPTION

<!-- Thanks for sending a pull request!

Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the main branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it

If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**What this PR does / why we need it**:
Since Certificate and Issuer are not deployed on OpenShift, 
trying to clean them will fail and block the whole flow. 
Filter them out from the cleaning on OpenShift.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
None
```
