### PR TITLE
manifest templator: Fix var names

### DIFF
--- a/tools/manifest-templator/manifest-templator.go
+++ b/tools/manifest-templator/manifest-templator.go
@@ -251,13 +251,26 @@ func main() {
 	coreDNSImage := flag.String("core-dns-image", components.CoreDNSImageDefault, "The coredns image used by CNA")
 	multusDynamicNetworksImage := flag.String("multus-dynamic-networks-image", components.MultusDynamicNetworksImageDefault, "The multus dynamic networks controller image managed by CNA")
 	kubeSecondaryDNSImage := flag.String("kube-secondary-dns", components.KubeSecondaryDNSImageDefault, "The kubesecondarydns-image managed by CNA")
+	kubeSecondaryDNSImageNew := flag.String("kube-secondary-dns-image", components.KubeSecondaryDNSImageDefault, "The kubesecondarydns-image managed by CNA")
 	kubevirtIpamControllerImage := flag.String("kubevirt-ipam-controller", components.KubevirtIpamControllerImageDefault, "The kubevirtipamcontroller-image managed by CNA")
+	kubevirtIpamControllerImageNew := flag.String("kubevirt-ipam-controller-image", components.KubevirtIpamControllerImageDefault, "The kubevirtipamcontroller-image managed by CNA")
 	passtBindingCNI := flag.String("passt-binding-cni", components.PasstBindingCNIImageDefault, "The passt binding cni image managed by CNA")
+	passtBindingCNIImage := flag.String("passt-binding-cni-image", components.PasstBindingCNIImageDefault, "The passt binding cni image managed by CNA")
 	dumpOperatorCRD := flag.Bool("dump-crds", false, "Append operator CRD to bottom of template. Used for csv-generator")
 	inputFile := flag.String("input-file", "", "Not used for csv-generator")
 	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
 	pflag.CommandLine.ParseErrorsWhitelist.UnknownFlags = true
 	pflag.Parse()
+
+	if *kubeSecondaryDNSImage == components.KubeSecondaryDNSImageDefault {
+		*kubeSecondaryDNSImage = *kubeSecondaryDNSImageNew
+	}
+	if *kubevirtIpamControllerImage == components.KubevirtIpamControllerImageDefault {
+		*kubevirtIpamControllerImage = *kubevirtIpamControllerImageNew
+	}
+	if *passtBindingCNI == components.PasstBindingCNIImageDefault {
+		*passtBindingCNI = *passtBindingCNIImage
+	}
 
 	data := templateData{
 		Version:         *version,


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the main branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it

If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**What this PR does / why we need it**:
Command line variables of manifest generator should have `_image` suffix for the image related ones.
Also `passtBindingCNIImage` variable was missing "Image" suffix.

**Special notes for your reviewer**:
In order to be backward compatible, lets first add those variables, use them, and then
we would able to drop the older ones, and the related code that was added for this reason.
The logic is if the old var is set, use that, else use the newer one.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
None
```
