### PR TITLE
hack/deploy-kubevirt: Align wait kv ready to 15m

### DIFF
--- a/hack/deploy-kubevirt.sh
+++ b/hack/deploy-kubevirt.sh
@@ -26,6 +26,6 @@ until ./cluster/kubectl.sh -n kubevirt get kv kubevirt; do
     sleep 1
 done
 
-./cluster/kubectl.sh wait -n kubevirt kv kubevirt --for condition=Available --timeout 360s || (echo "KubeVirt not ready in time" && exit 1)
+./cluster/kubectl.sh wait -n kubevirt kv kubevirt --for condition=Available --timeout 15m || (echo "KubeVirt not ready in time" && exit 1)
 
 echo "basename -- $0 done"


### PR DESCRIPTION
**What this PR does / why we need it**:
kubevirt/kubevirt waits for 15m [0], there is no reason we should wait for less.

[0] https://github.com/kubevirt/kubevirt/blob/e18e89be39b705249ca87afae6e0369ce25dbc25/hack/ci/entrypoint.sh#L90

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
