### PR TITLE
primary-udn: Match NAD type to binary name

### DIFF
--- a/data/kubevirt-ipam-controller/004-primary-udn-kubevirt-binding-networkattachdef.yaml
+++ b/data/kubevirt-ipam-controller/004-primary-udn-kubevirt-binding-networkattachdef.yaml
@@ -10,7 +10,7 @@ spec:
   "name": "primary-udn-kubevirt-binding",
   "plugins": [
     {
-      "type": "cni-passt-binding-plugin"
+      "type": "network-passt-binding"
     }
   ]
 }'


### PR DESCRIPTION
**What this PR does / why we need it**:
the NAD type introduced to support primary UDN is using
the binary deployed by passt-binding-cni daemonset to the 
node. therefore, the type name should match the binary.
Matching the binary name.

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
