### PR TITLE
tests: Fix isKindNotFound

### DIFF
--- a/test/check/check.go
+++ b/test/check/check.go
@@ -734,7 +734,7 @@ func checkForPrometheusRuleRemoval(name string) error {
 
 func checkForNetworkAttachmentDefinitionRemoval(name string) error {
 	err := testenv.Client.Get(context.Background(), types.NamespacedName{Name: name, Namespace: corev1.NamespaceDefault}, &k8snetworkplumbingwgv1.NetworkAttachmentDefinition{})
-	if isKindNotFound(err) {
+	if err != nil && isKindNotFound(err) {
 		return nil
 	}
 	return isNotFound("NetworkAttachmentDefinition", name, err)


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the main branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it

If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**What this PR does / why we need it**:
Fixes this nil ptr deref
https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_cluster-network-addons-operator/1850/pull-e2e-cluster-network-addons-operator-lifecycle-k8s/1821941283426406400#1:build-log.txt%3A871

**Special notes for your reviewer**:
Should fix https://github.com/kubevirt/cluster-network-addons-operator/pull/1850#issuecomment-2282653440

Same fix might need to be applied for `isNotSupportedKind`,
but for now the tests didnt trigger it, as they dont reach this case.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
None
```
