### PR TITLE
components/kmp: Follow stable branch

### DIFF
--- a/components.yaml
+++ b/components.yaml
@@ -14,8 +14,8 @@ components:
   kubemacpool:
     url: https://github.com/k8snetworkplumbingwg/kubemacpool
     commit: 98d8b8233b860598ee9dd5a7ba159971e5e99be2
-    branch: main
-    update-policy: static
+    branch: release-0.44
+    update-policy: latest
     metadata: v0.44.0
   kubevirt-ipam-controller:
     url: https://github.com/kubevirt/ipam-extensions


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR set CNAO to follow the latest commit of the kubmacpool relevant stable branch.

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
