### PR TITLE
lifecycle: Add helper script to fetch missing manifests

### DIFF
--- a/hack/update_releases.sh
+++ b/hack/update_releases.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+# This script pulls release manifests needed for lifecycle tests.
+#
+# Usage example:
+# export RELEASES_SELECTOR="{0.89.3,0.91.1,0.93.0,0.95.0,99.0.0}"
+# ./hack/update_releases.sh
+
+set -ue
+RELEASES=${RELEASES_SELECTOR//[\{\}]}
+
+IFS=',' read -ra RELEASES_ARRAY <<< "$RELEASES"
+
+for ((i = 0; i < ${#RELEASES_ARRAY[@]} - 1; i++)); do
+    VERSION=${RELEASES_ARRAY[i]}
+    if [ -d "manifests/cluster-network-addons/${VERSION}" ]; then
+      continue
+    fi
+    echo "Processing release: ${VERSION}"
+
+    mkdir -p manifests/cluster-network-addons/${VERSION}
+    pushd manifests/cluster-network-addons/${VERSION} > /dev/null
+    curl -sLO https://github.com/kubevirt/cluster-network-addons-operator/releases/download/v${VERSION}/cluster-network-addons-operator.${VERSION}.clusterserviceversion.yaml
+    curl -sLO https://github.com/kubevirt/cluster-network-addons-operator/releases/download/v${VERSION}/namespace.yaml
+    curl -sLO https://github.com/kubevirt/cluster-network-addons-operator/releases/download/v${VERSION}/network-addons-config-example.cr.yaml
+    curl -sLO https://github.com/kubevirt/cluster-network-addons-operator/releases/download/v${VERSION}/network-addons-config.crd.yaml
+    curl -sLO https://github.com/kubevirt/cluster-network-addons-operator/releases/download/v${VERSION}/operator.yaml
+    popd > /dev/null
+
+    pushd test/releases > /dev/null
+    curl -sLO https://raw.githubusercontent.com/kubevirt/cluster-network-addons-operator/release-${VERSION%.*}/test/releases/${VERSION}.go
+    popd > /dev/null
+done
+


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the main branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it

If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**What this PR does / why we need it**:
Also fetches required missing test/releases files.
Helps in creating PRs such as https://github.com/kubevirt/cluster-network-addons-operator/pull/1869

**Special notes for your reviewer**:
Can be improved to read `RELEASES_SELECTOR` directly from
`automation/check-patch.e2e-lifecycle-k8s.sh`.
Can also be improved to purge non supported versions according
lowest `RELEASES_SELECTOR` element.

Script assumes that if the manifests exists, then the test/releases file also exists
(can be improved later according needs).
Script assumes last element is `99.0.0` so it skips it (it is prerequisite).

We can't make it part of the automation (and not even sanity check due to the following reasons)
because sometimes small changes are needed
for the test/releases files [1], unless those were also fixed on the branch itself.
Anyhow we can consider that later if desired.
Helper scripts are good enough for now.

[1] For example https://github.com/kubevirt/cluster-network-addons-operator/compare/6d41e113ea20005c25b45bd896499f31b4e15711..23c5c735e74e854ed5434b0ccf59e3ddf1b2074a
There was a bug, that was fixed on main but not on branch, as it affected only main iirc.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
None
```
