### PR TITLE
ipam: Reduce git actions noise

### DIFF
--- a/.github/workflows/kubevirt-ipam-controller.yaml
+++ b/.github/workflows/kubevirt-ipam-controller.yaml
@@ -1,5 +1,5 @@
 name: Kubevirt IPAM controller Tests
-on: [push, pull_request]
+on: [pull_request]
 jobs:
   e2e:
     runs-on: ubuntu-latest


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the main branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it

If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**What this PR does / why we need it**:
When kubevirt-bot creates PRs, it will trigger the IPAM lane twice, because both
`push` and `pull_request` events occur (the bot creates a branch on main, hence `push` event happens).
The IPAM lane also runs after a PR is merged, because it triggers `push`.
In order to reduce this noise, lets remove the `push` event.
The `pull_request` is enough as long as PRs are used 
(and not direct pushes which aren't encouraged, nor monitored anyhow).

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
None
```
