### PR TITLE
ipam,e2e: Add disableSerialConsoleLog

### DIFF
--- a/automation/check-patch.e2e-kubevirt-ipam-controller-functests.sh
+++ b/automation/check-patch.e2e-kubevirt-ipam-controller-functests.sh
@@ -53,6 +53,7 @@ main() {
     deploy_cnao
     deploy_cnao_cr
     ./hack/deploy-kubevirt.sh
+    ./cluster/kubectl.sh -n kubevirt patch kubevirt kubevirt --type=merge --patch '{"spec":{"configuration":{"virtualMachineOptions":{"disableSerialConsoleLog":{}}}}}'
 
     cd ${TMP_COMPONENT_PATH}
     echo "Run kubevirt-ipam-controller functional tests"


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the main branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it

If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**What this PR does / why we need it**:
When testing ipam on kind, the `guest-console-log` readiness flakes.
It is not related to IPAM lane, and it is also disabled on OVN-K8s repo once kubevirt is deployed and tested.
Disable it also when deploying kubevirt via helper scripts on CNAO.

**Special notes for your reviewer**:
Worth to raise it to the virt team in parallel, atm lets just line up as OVN-K8s repo does.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
None
```
