### PR TITLE
bump kubevirt-ipam-controller to v0.1.7-alpha

### DIFF
--- a/automation/check-patch.e2e-kubevirt-ipam-controller-functests.sh
+++ b/automation/check-patch.e2e-kubevirt-ipam-controller-functests.sh
@@ -40,9 +40,9 @@ main() {
     COMPONENT="kubevirt-ipam-controller" source automation/components-functests.setup.sh
 
     cd ${TMP_COMPONENT_PATH}
+    export KUBECONFIG=${TMP_COMPONENT_PATH}/.output/kubeconfig
     export KIND_ARGS="-ic -i6 -mne"
     make cluster-up
-    export KUBECONFIG=${TMP_COMPONENT_PATH}/.output/kubeconfig
 
     trap teardown EXIT
 

--- a/components.yaml
+++ b/components.yaml
@@ -19,10 +19,10 @@ components:
     metadata: v0.44.0
   kubevirt-ipam-controller:
     url: https://github.com/kubevirt/ipam-extensions
-    commit: 83a65d3f76a2847b09847ee6aaccfea3fe49b635
+    commit: 74c7ef7860f52af37988d6777925c27c79564065
     branch: main
     update-policy: tagged
-    metadata: v0.1.6-alpha
+    metadata: v0.1.7-alpha
   linux-bridge:
     url: https://github.com/containernetworking/plugins
     commit: 14bdce598f9d332303c375c35719c4a158f1e7db

--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -40,8 +40,8 @@ const (
 	KubeRbacProxyImageDefault          = "quay.io/openshift/origin-kube-rbac-proxy@sha256:e2def4213ec0657e72eb790ae8a115511d5b8f164a62d3568d2f1bff189917e8"
 	KubeSecondaryDNSImageDefault       = "ghcr.io/kubevirt/kubesecondarydns@sha256:44489bdf8affb0e82b68a7100bbee7d289151ada54ab2e76a9d3afef769a1f54"
 	CoreDNSImageDefault                = "registry.k8s.io/coredns/coredns@sha256:a0ead06651cf580044aeb0a0feba63591858fb2e43ade8c9dea45a6a89ae7e5e"
-	KubevirtIpamControllerImageDefault = "ghcr.io/kubevirt/ipam-controller@sha256:88272174aa7d347e6ef92f3328a613c3821a3fa7b1bcb7a548dc8c3c5b46f96d"
-	PasstBindingCNIImageDefault        = "ghcr.io/kubevirt/passt-binding-cni@sha256:a5f38e7237535eacf0ceaa7b2fb5421433e230cf4df57db02240bf0d00af743a"
+	KubevirtIpamControllerImageDefault = "ghcr.io/kubevirt/ipam-controller@sha256:aad40edd34f65cf0e087969853d47065aaf411dccf618d196152b583d40300ba"
+	PasstBindingCNIImageDefault        = "ghcr.io/kubevirt/passt-binding-cni@sha256:981c01e0b94ae691ba8ced43c486930085186e9c40b22525c8f0229d1556ee69"
 )
 
 type AddonsImages struct {

--- a/test/releases/99.0.0.go
+++ b/test/releases/99.0.0.go
@@ -84,13 +84,13 @@ func init() {
 				ParentName: "kubevirt-ipam-controller-manager",
 				ParentKind: "Deployment",
 				Name:       "manager",
-				Image:      "ghcr.io/kubevirt/ipam-controller@sha256:88272174aa7d347e6ef92f3328a613c3821a3fa7b1bcb7a548dc8c3c5b46f96d",
+				Image:      "ghcr.io/kubevirt/ipam-controller@sha256:aad40edd34f65cf0e087969853d47065aaf411dccf618d196152b583d40300ba",
 			},
 			{
 				ParentName: "passt-binding-cni",
 				ParentKind: "DaemonSet",
 				Name:       "installer",
-				Image:      "ghcr.io/kubevirt/passt-binding-cni@sha256:a5f38e7237535eacf0ceaa7b2fb5421433e230cf4df57db02240bf0d00af743a",
+				Image:      "ghcr.io/kubevirt/passt-binding-cni@sha256:981c01e0b94ae691ba8ced43c486930085186e9c40b22525c8f0229d1556ee69",
 			},
 		},
 		SupportedSpec: cnao.NetworkAddonsConfigSpec{


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the main branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it

If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**What this PR does / why we need it**:
Beside the bump, adapt the automation script for this bump:
Since https://github.com/kubevirt/ipam-extensions/pull/60
allows custom kubeconfig, we should set the line before cluster-up,
so it won't take the value set by automation/components-functests.setup.sh
which is correct only for kubevirtci providers, not for external ones.
Hence set it just before cluster-up.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
bump kubevirt-ipam-controller to v0.1.7-alpha
```
