### PR TITLE
tools/bumper: Fix latest vtag check

### DIFF
--- a/tools/bumper/cnao_repo_commands.go
+++ b/tools/bumper/cnao_repo_commands.go
@@ -136,7 +136,7 @@ func (cnaoRepoOps *gitCnaoRepo) isComponentBumpNeeded(currentReleaseVersion, lat
 
 	// if one of the tags is in vtag format (e.g 0.39.0-32-g1fcbe815), and not equal, then always bump
 	if isVtagFormat(currentReleaseVersion) || isVtagFormat(latestReleaseVersion) {
-		return currentReleaseVersion == latestReleaseVersion, nil
+		return currentReleaseVersion != latestReleaseVersion, nil
 	}
 
 	currentVersion, err := canonicalizeVersion(currentReleaseVersion)
@@ -378,7 +378,7 @@ func canonicalizeVersion(version string) (*semver.Version, error) {
 
 // check vtag format (example: 0.39.0-32-g1fcbe815)
 func isVtagFormat(tagVersion string) bool {
-	var vtagSyntax = regexp.MustCompile(`^[0-9]\.[0-9]+\.*[0-9]*-[0-9]+-g[0-9,a-f]{7}`)
+	var vtagSyntax = regexp.MustCompile(`^v[0-9]\.[0-9]+\.*[0-9]*-[0-9]+-g[0-9,a-f]{8}`)
 	return vtagSyntax.MatchString(tagVersion)
 }
 

--- a/tools/bumper/cnao_repo_commands_test.go
+++ b/tools/bumper/cnao_repo_commands_test.go
@@ -189,7 +189,7 @@ var _ = Describe("Testing internal git CNAO Repo", func() {
 			expectedResult: false,
 		}),
 		Entry("When using vtag version format, Should recognize as vtag format", isVtagFormatParams{
-			version:        "0.39.0-32-g1fcbe815",
+			version:        "v0.39.0-32-g1fcbe815",
 			expectedResult: true,
 		}),
 	)
@@ -228,20 +228,12 @@ var _ = Describe("Testing internal git CNAO Repo", func() {
 			isBumpExpected:        false,
 			isValid:               true,
 		}),
-		Entry("Should not bump since there is updatePolicy static (vtag-format)", isComponentBumpNeededParams{
-			currentReleaseVersion: "v0.11.0-3-g1be91ab",
-			latestReleaseVersion:  "v0.11.0-4-g1ar46a5",
+		Entry("Should bump when latestReleaseVersion is in vtag-format", isComponentBumpNeededParams{
+			currentReleaseVersion: "v0.20.9",
+			latestReleaseVersion:  "v0.20.9-1-g4cd31235",
 			updatePolicy:          "latest",
 			prTitle:               dummyPRTitle,
 			isBumpExpected:        true,
-			isValid:               true,
-		}),
-		Entry("Should not bump since latest version is the same as current", isComponentBumpNeededParams{
-			currentReleaseVersion: "v3.6.2",
-			latestReleaseVersion:  "v3.6.2",
-			updatePolicy:          "tagged",
-			prTitle:               dummyPRTitle,
-			isBumpExpected:        false,
 			isValid:               true,
 		}),
 		Entry("Should not bump since latest version is not bigger than current", isComponentBumpNeededParams{
@@ -268,14 +260,6 @@ var _ = Describe("Testing internal git CNAO Repo", func() {
 			isBumpExpected:        true,
 			isValid:               true,
 		}),
-		Entry("Should bump since latest is in vtag-format and different than current", isComponentBumpNeededParams{
-			currentReleaseVersion: "v0.11.0-3-g1be91ab",
-			latestReleaseVersion:  "v0.11.0-4-g1ar46a5",
-			updatePolicy:          "latest",
-			prTitle:               dummyPRTitle,
-			isBumpExpected:        true,
-			isValid:               true,
-		}),
 		Entry("Should return error since current is not in correct semver version format", isComponentBumpNeededParams{
 			currentReleaseVersion: "ver1.2.3",
 			latestReleaseVersion:  "v3.6.2",
@@ -291,6 +275,30 @@ var _ = Describe("Testing internal git CNAO Repo", func() {
 			prTitle:               dummyPRTitle,
 			isBumpExpected:        false,
 			isValid:               false,
+		}),
+		Entry("Should bump when currentReleaseVersion is in vtag-format", isComponentBumpNeededParams{
+			currentReleaseVersion: "v0.44.1-4-g4cd33665",
+			latestReleaseVersion:  "v0.43.1",
+			updatePolicy:          "latest",
+			prTitle:               dummyPRTitle,
+			isBumpExpected:        true,
+			isValid:               true,
+		}),
+		Entry("Should not bump when currentReleaseVersion is in vtag-format and equals latestReleaseVersion", isComponentBumpNeededParams{
+			currentReleaseVersion: "v0.36.2-5-g4cd4566",
+			latestReleaseVersion:  "v0.36.2-5-g4cd4566",
+			updatePolicy:          "latest",
+			prTitle:               dummyPRTitle,
+			isBumpExpected:        false,
+			isValid:               true,
+		}),
+		Entry("Should not bump since latest version is the same as current", isComponentBumpNeededParams{
+			currentReleaseVersion: "v3.6.2",
+			latestReleaseVersion:  "v3.6.2",
+			updatePolicy:          "tagged",
+			prTitle:               dummyPRTitle,
+			isBumpExpected:        false,
+			isValid:               true,
 		}),
 	)
 


### PR DESCRIPTION
**What this PR does / why we need it**:
In the bumper logic, in case either currentReleaseVersion or latestReleaseVersion are in virtual-tag format (i.e. v0.44.1-1-g4cd33665) - then the bump should be initiated. However the logic implementing it is wrong.
Fixing logic, adding unit tests.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
