### PR TITLE
feat: clean task in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,8 @@ E2E_SUITES = \
 	test/e2e/workflow \
 	test/e2e/monitoring
 
-BIN_DIR = $(CURDIR)/build/_output/bin/
+OUTPUT_DIR = $(CURDIR)/build/_output/
+BIN_DIR = $(OUTPUT_DIR)/bin/
 export GOROOT=$(BIN_DIR)/go/
 export GOBIN = $(GOROOT)/bin/
 export PATH := $(GOBIN):$(PATH)
@@ -223,6 +224,9 @@ lint-monitoring:
 	GOBIN=$$(pwd)/build/_output/bin/ $(GO) install -mod=mod github.com/kubevirt/monitoring/monitoringlinter/cmd/monitoringlinter@e2be790
 	$(MONITORING_LINTER) ./...
 
+clean:
+	rm -rf $(OUTPUT_DIR)
+
 .PHONY: \
 	$(E2E_SUITES) \
 	all \
@@ -257,5 +261,6 @@ lint-monitoring:
 	release \
 	update-workflows-branches \
 	statify-components \
-	lint-monitoring
+	lint-monitoring \
+	clean
 


### PR DESCRIPTION
This update is beneficial for enabling multiarch support. By default, some tooling is downloaded specifically for amd64. Even with changes in the scripts, the tool does not get updated.

<!-- Thanks for sending a pull request!

Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the main branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it

If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**What this PR does / why we need it**: s390x enablement

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note NONE

```
