### PR TITLE
Bump k8s provider to 1.30

### DIFF
--- a/README.md
+++ b/README.md
@@ -355,8 +355,8 @@ make docker-build-registry
 # bring up a local cluster with Kubernetes
 make cluster-up
 
-# bridge up a local cluster with kubernetes 1.25
-export KUBEVIRT_PROVIDER=k8s-1.25
+# bridge up a local cluster with supported kubernetes provider
+export KUBEVIRT_PROVIDER=k8s-1.30
 make cluster-up
 
 # build images and push them to the local cluster

--- a/cluster/cluster.sh
+++ b/cluster/cluster.sh
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 export KUBEVIRT_PROVIDER=${KUBEVIRT_PROVIDER:-'k8s-1.28'}
-export KUBEVIRTCI_TAG=${KUBEVIRTCI_TAG:-2406041642-8d359a3}
+export KUBEVIRTCI_TAG=${KUBEVIRTCI_TAG:-2409241245-d93dec16}
 
 KUBEVIRTCI_REPO='https://github.com/kubevirt/kubevirtci.git'
 # The CLUSTER_PATH var is used in cluster folder and points to the _kubevirtci where the cluster is deployed from.

--- a/cluster/cluster.sh
+++ b/cluster/cluster.sh
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-export KUBEVIRT_PROVIDER=${KUBEVIRT_PROVIDER:-'k8s-1.28'}
+export KUBEVIRT_PROVIDER=${KUBEVIRT_PROVIDER:-'k8s-1.30'}
 export KUBEVIRTCI_TAG=${KUBEVIRTCI_TAG:-2409241245-d93dec16}
 
 KUBEVIRTCI_REPO='https://github.com/kubevirt/kubevirtci.git'


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR bumps KUBEVIRT_PROVIDER and KUBEVIRTCI_TAG to more updated values.

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
