### PR TITLE
kubevirtci: Bump version to consume newer Calico

### DIFF
--- a/cluster/cluster.sh
+++ b/cluster/cluster.sh
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 export KUBEVIRT_PROVIDER=${KUBEVIRT_PROVIDER:-'k8s-1.30'}
-export KUBEVIRTCI_TAG=${KUBEVIRTCI_TAG:-2409241245-d93dec16}
+export KUBEVIRTCI_TAG=${KUBEVIRTCI_TAG:-2409281627-d5c1f38a}
 
 KUBEVIRTCI_REPO='https://github.com/kubevirt/kubevirtci.git'
 # The CLUSTER_PATH var is used in cluster folder and points to the _kubevirtci where the cluster is deployed from.

--- a/components.yaml
+++ b/components.yaml
@@ -37,10 +37,10 @@ components:
     metadata: v0.11.1
   multus:
     url: https://github.com/k8snetworkplumbingwg/multus-cni
-    commit: f03765681fe81ee1e0633ee1734bf48ab3bccf2b
+    commit: f1e887e2396c98e9aee6417723f2c5cd433a1cd2
     branch: master
     update-policy: tagged
-    metadata: v4.0.2
+    metadata: v4.1.1
   multus-dynamic-networks:
     url: https://github.com/k8snetworkplumbingwg/multus-dynamic-networks-controller
     commit: e328aeb727e70165a8c7275aafa7035c963a8e22

--- a/data/multus/001-multus.yaml
+++ b/data/multus/001-multus.yaml
@@ -61,7 +61,9 @@ rules:
       - pods/status
     verbs:
       - get
+      - list
       - update
+      - watch
   - apiGroups:
       - ""
       - events.k8s.io
@@ -103,13 +105,13 @@ data:
   daemon-config.json: |
     {
         "chrootDir": "/hostroot",
-        "confDir": "/host/etc/cni/net.d",
-        "logLevel": "verbose",
-        "socketDir": "/host/run/multus/",
         "cniVersion": "0.3.1",
+        "logLevel": "verbose",
+        "logToStderr": true,
         "cniConfigDir": "/host/etc/cni/net.d",
+        "multusAutoconfigDir": "/host/etc/cni/net.d",
         "multusConfigFile": "auto",
-        "multusAutoconfigDir": "/host/etc/cni/net.d"
+        "socketDir": "/host/run/multus/"
     }
 ---
 apiVersion: apps/v1
@@ -148,15 +150,22 @@ spec:
               memory: "15Mi"
           securityContext:
             privileged: true
+          terminationMessagePolicy: FallbackToLogsOnError
           volumeMounts:
             - name: cni
               mountPath: /host/etc/cni/net.d
+            # multus-daemon expects that cnibin path must be identical between pod and container host.
+            # e.g. if the cni bin is in /opt/cni/bin on the container host side, then it should be mount to /opt/cni/bin in multus-daemon,
+            # not to any other directory, like /opt/bin or /usr/bin.
+            - name: cnibin
+              mountPath: /opt/cni/bin
             - name: host-run
               mountPath: /host/run
             - name: host-var-lib-cni-multus
               mountPath: /var/lib/cni/multus
             - name: host-var-lib-kubelet
               mountPath: /var/lib/kubelet
+              mountPropagation: HostToContainer
             - name: host-run-k8s-cni-cncf-io
               mountPath: /run/k8s.cni.cncf.io
             - name: host-run-netns
@@ -168,6 +177,11 @@ spec:
             - name: hostroot
               mountPath: /hostroot
               mountPropagation: HostToContainer
+          env:
+            - name: MULTUS_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
           imagePullPolicy: {{ .ImagePullPolicy }}
           lifecycle:
             preStop:
@@ -186,6 +200,7 @@ spec:
               memory: "15Mi"
           securityContext:
             privileged: true
+          terminationMessagePolicy: FallbackToLogsOnError
           volumeMounts:
             - name: cnibin
               mountPath: /host/opt/cni/bin

--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -30,7 +30,7 @@ var (
 )
 
 const (
-	MultusImageDefault                 = "ghcr.io/k8snetworkplumbingwg/multus-cni@sha256:3fbcc32bd4e4d15bd93c96def784a229cd84cca27942bf4858b581f31c97ee02"
+	MultusImageDefault                 = "ghcr.io/k8snetworkplumbingwg/multus-cni@sha256:fbe669471066f99f37f33bfc362f30f6c473c3850cb21f44813b84a5c3837e8f"
 	MultusDynamicNetworksImageDefault  = "ghcr.io/k8snetworkplumbingwg/multus-dynamic-networks-controller@sha256:0bdf7dc9c15bdf7e5760955f05077c23868f3421141e8e623d75cf6b8cf36247"
 	LinuxBridgeCniImageDefault         = "quay.io/kubevirt/cni-default-plugins@sha256:0c354fa9d695b8cab97b459e8afea2f7662407a987e83f6f6f1a8af4b45726be"
 	LinuxBridgeMarkerImageDefault      = "quay.io/kubevirt/bridge-marker@sha256:18d954d58b9830738df9bf5c9a575d22b33096d1af26fb6bc2da09fb31c9f73a"

--- a/test/releases/99.0.0.go
+++ b/test/releases/99.0.0.go
@@ -12,7 +12,7 @@ func init() {
 				ParentName: "multus",
 				ParentKind: "DaemonSet",
 				Name:       "kube-multus",
-				Image:      "ghcr.io/k8snetworkplumbingwg/multus-cni@sha256:3fbcc32bd4e4d15bd93c96def784a229cd84cca27942bf4858b581f31c97ee02",
+				Image:      "ghcr.io/k8snetworkplumbingwg/multus-cni@sha256:fbe669471066f99f37f33bfc362f30f6c473c3850cb21f44813b84a5c3837e8f",
 			},
 			{
 				ParentName: "dynamic-networks-controller-ds",
@@ -24,7 +24,7 @@ func init() {
 				ParentName: "multus",
 				ParentKind: "DaemonSet",
 				Name:       "install-multus-binary",
-				Image:      "ghcr.io/k8snetworkplumbingwg/multus-cni@sha256:3fbcc32bd4e4d15bd93c96def784a229cd84cca27942bf4858b581f31c97ee02",
+				Image:      "ghcr.io/k8snetworkplumbingwg/multus-cni@sha256:fbe669471066f99f37f33bfc362f30f6c473c3850cb21f44813b84a5c3837e8f",
 			},
 			{
 				ParentName: "bridge-marker",


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the main branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it

If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**What this PR does / why we need it**:
Also includes https://github.com/kubevirt/cluster-network-addons-operator/pull/1910
to see if it fix the problems

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note

```
