### PR TITLE
The origin-kube-rbac-proxy image is not compatible with the s390x

### DIFF
--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -37,7 +37,7 @@ const (
 	KubeMacPoolImageDefault            = "quay.io/kubevirt/kubemacpool@sha256:677971a25ff3ce95d9e6ecc86090a09f0ae691ce67b8349384f1881562feed7b"
 	OvsCniImageDefault                 = "ghcr.io/k8snetworkplumbingwg/ovs-cni-plugin@sha256:54be8fcacee50af64deafa9e99f3fe079033630c00c4ed9f74d17b0d91009f10"
 	MacvtapCniImageDefault             = "quay.io/kubevirt/macvtap-cni@sha256:850b89343ace7c7ea6b18dd8e11964613974e9d1f7377af03854d407fb15230a"
-	KubeRbacProxyImageDefault          = "quay.io/openshift/origin-kube-rbac-proxy@sha256:e2def4213ec0657e72eb790ae8a115511d5b8f164a62d3568d2f1bff189917e8"
+	KubeRbacProxyImageDefault          = "quay.io/brancz/kube-rbac-proxy@sha256:e6a323504999b2a4d2a6bf94f8580a050378eba0900fd31335cf9df5787d9a9b"
 	KubeSecondaryDNSImageDefault       = "ghcr.io/kubevirt/kubesecondarydns@sha256:44489bdf8affb0e82b68a7100bbee7d289151ada54ab2e76a9d3afef769a1f54"
 	CoreDNSImageDefault                = "registry.k8s.io/coredns/coredns@sha256:a0ead06651cf580044aeb0a0feba63591858fb2e43ade8c9dea45a6a89ae7e5e"
 	KubevirtIpamControllerImageDefault = "ghcr.io/kubevirt/ipam-controller@sha256:aad40edd34f65cf0e087969853d47065aaf411dccf618d196152b583d40300ba"

--- a/test/releases/99.0.0.go
+++ b/test/releases/99.0.0.go
@@ -48,7 +48,7 @@ func init() {
 				ParentName: "kubemacpool-mac-controller-manager",
 				ParentKind: "Deployment",
 				Name:       "kube-rbac-proxy",
-				Image:      "quay.io/openshift/origin-kube-rbac-proxy@sha256:e2def4213ec0657e72eb790ae8a115511d5b8f164a62d3568d2f1bff189917e8",
+				Image:      "quay.io/brancz/kube-rbac-proxy@sha256:e6a323504999b2a4d2a6bf94f8580a050378eba0900fd31335cf9df5787d9a9b",
 			},
 			{
 				ParentName: "kubemacpool-cert-manager",


### PR DESCRIPTION
architecture. This change deploys an image that is compatible with amd64, arm and s390x architecture.

**What this PR does / why we need it**:
The origin-kube-rbac-proxy image is not compatible with the s390x
architecture. This change deploys an image that is compatible with
amd64, arm and s390x.

**Special notes for your reviewer**:

**Release note**:

```release-note
This change addresses the compatibility issues with the origin-kube-rbac-proxy image on the s390x architecture. The updated deployment now uses an image that supports the amd64, arm and s390x architectures.
This enhancement ensures broader support and improved functionality across diverse environments.

```
