### PR TITLE
feat: enable s390x prometheus check

### DIFF
--- a/tools/prom-rule-ci/verify-rules.go
+++ b/tools/prom-rule-ci/verify-rules.go
@@ -8,7 +8,7 @@ import (
 	"github.com/kubevirt/cluster-network-addons-operator/pkg/monitoring/rules"
 )
 
-const promImage = "quay.io/prometheus/prometheus:v2.15.2"
+const promImage = "quay.io/prometheus/prometheus:v2.25.2"
 
 func main() {
 	if len(os.Args) != 4 {


### PR DESCRIPTION
As of version 2.15.2, there is no available container image for s390x. However, version 2.25.2 does provide support for this architecture. This update enables the checks to run on s390x.

<!-- Thanks for sending a pull request!

Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the main branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it

If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**What this PR does / why we need it**: s390x enablement

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note NONE

```
