### PR TITLE
events: Remove duplicated 'Available' events

### DIFF
--- a/pkg/controller/statusmanager/status_manager.go
+++ b/pkg/controller/statusmanager/status_manager.go
@@ -159,7 +159,11 @@ func (status *StatusManager) set(reachedAvailableLevel bool, conditions ...condi
 		)
 	} else if reachedAvailableLevel {
 		// If successfully deployed all components and is not failing on anything, mark as Available
-		status.eventEmitter.EmitAvailableForConfig()
+		if conditionsv1.IsStatusConditionFalse(config.Status.Conditions, conditionsv1.ConditionAvailable) {
+			// Emit event only if conditions changes from false to true to
+			// so we don't duplicate events
+			status.eventEmitter.EmitAvailableForConfig()
+		}
 		conditionsv1.SetStatusConditionNoHeartbeat(&config.Status.Conditions,
 			conditionsv1.Condition{
 				Type:   conditionsv1.ConditionAvailable,


### PR DESCRIPTION
**What this PR does / why we need it**:
CNAO is emitting  config 'Availabe' event after each reconcile even when nothing changes, this add noise to users. This change emits the event only if Available changes from false to true.

**Special notes for your reviewer**:
Some test suites like openshift tests fail if it sees too many duplicated events during a period of times, so it's fair to fix that by not sending events when the state didn't change.

**Release note**:

```release-note
events: Remove duplicated 'Available' events
```
