### PR TITLE
Enable multi-platform support for operator image builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -12,9 +12,6 @@
 _kubevirtci
 
 # No need for source code is already compiled
-pkg
-cmd
-tools
 vendor
 docs
 

--- a/build/operator/Dockerfile
+++ b/build/operator/Dockerfile
@@ -1,4 +1,24 @@
-FROM quay.io/centos/centos:stream9
+ARG BUILD_ARCH=amd64
+FROM --platform=linux/${BUILD_ARCH} quay.io/centos/centos:stream9 AS builder
+
+RUN dnf install -y tar gzip jq && dnf clean all
+RUN ARCH=$(uname -m | sed 's/x86_64/amd64/') && \
+    GO_VERSION=$(curl -L -s "https://go.dev/dl/?mode=json" | jq -r '.[0].version') && \
+    curl -L "https://go.dev/dl/${GO_VERSION}.linux-${ARCH}.tar.gz" -o go.tar.gz && \
+    tar -C /usr/local -xzf go.tar.gz && \
+    rm go.tar.gz
+ENV PATH=$PATH:/usr/local/go/bin
+WORKDIR /go/src/cluster-network-addons-operator
+COPY . .
+
+ARG TARGETOS
+ARG TARGETARCH
+
+RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -o build/_output/bin/manager ./cmd/... && \
+    CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -o build/_output/bin/manifest-templator ./tools/manifest-templator/...
+
+FROM --platform=linux/${TARGETARCH} quay.io/centos/centos:stream9 AS final
+
 ENV ENTRYPOINT=/entrypoint \
     OPERATOR=/cluster-network-addons-operator \
     MANIFEST_TEMPLATOR=/manifest-templator \
@@ -8,13 +28,16 @@ ENV ENTRYPOINT=/entrypoint \
 RUN \
     yum -y update && \
     yum clean all
+
 COPY build/operator/bin/user_setup /user_setup
 COPY build/operator/bin/csv-generator /usr/bin/csv-generator
 COPY templates/cluster-network-addons/VERSION/cluster-network-addons-operator.VERSION.clusterserviceversion.yaml.in cluster-network-addons-operator.VERSION.clusterserviceversion.yaml.in
 RUN /user_setup
 COPY data /data
-COPY build/_output/bin/manager $OPERATOR
-COPY build/_output/bin/manifest-templator $MANIFEST_TEMPLATOR
+
+COPY --from=builder /go/src/cluster-network-addons-operator/build/_output/bin/manager $OPERATOR
+COPY --from=builder /go/src/cluster-network-addons-operator/build/_output/bin/manifest-templator $MANIFEST_TEMPLATOR
 COPY build/operator/bin/entrypoint $ENTRYPOINT
+
 ENTRYPOINT $ENTRYPOINT
 USER $USER_UID

--- a/hack/build-operator-docker.sh
+++ b/hack/build-operator-docker.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+if [ -z "$ARCH" ] || [ -z "$PLATFORMS" ] || [ -z "$OPERATOR_IMAGE_TAGGED" ]; then
+    echo "Error: ARCH, PLATFORMS and OPERATOR_IMAGE_TAGGED must be set."
+    exit 1
+fi
+
+IFS=',' read -r -a PLATFORM_LIST <<< "$PLATFORMS"
+
+BUILD_ARGS="--build-arg BUILD_ARCH=$ARCH -f build/operator/Dockerfile -t $OPERATOR_IMAGE_TAGGED --push ."
+
+if [ ${#PLATFORM_LIST[@]} -eq 1 ]; then
+    docker build --platform "$PLATFORMS" $BUILD_ARGS
+else
+    ./hack/init-buildx.sh "$DOCKER_BUILDER"
+    docker buildx build --platform "$PLATFORMS" $BUILD_ARGS
+fi

--- a/hack/build-operator-podman.sh
+++ b/hack/build-operator-podman.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+if [ -z "$ARCH" ] || [ -z "$PLATFORMS" ] || [ -z "$OPERATOR_IMAGE_TAGGED" ]; then
+    echo "Error: ARCH, PLATFORMS, and OPERATOR_IMAGE_TAGGED must be set."
+    exit 1
+fi
+
+IFS=',' read -r -a PLATFORM_LIST <<< "$PLATFORMS"
+
+# Remove any existing manifest and image
+podman manifest rm "${OPERATOR_IMAGE_TAGGED}" || true
+podman rmi "${OPERATOR_IMAGE_TAGGED}" || true
+
+podman manifest create "${OPERATOR_IMAGE_TAGGED}"
+
+for platform in "${PLATFORM_LIST[@]}"; do
+    podman build \
+        --no-cache \
+        --build-arg BUILD_ARCH="$ARCH" \
+        --platform "$platform" \
+        --manifest "${OPERATOR_IMAGE_TAGGED}" \
+        -f build/operator/Dockerfile \
+        .
+done

--- a/hack/init-buildx.sh
+++ b/hack/init-buildx.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+check_buildx() {
+  export DOCKER_CLI_EXPERIMENTAL=enabled
+
+  if ! docker buildx > /dev/null 2>&1; then
+     mkdir -p ~/.docker/cli-plugins
+     BUILDX_VERSION=$(curl -s https://api.github.com/repos/docker/buildx/releases/latest | jq -r .tag_name)
+     curl -L https://github.com/docker/buildx/releases/download/"${BUILDX_VERSION}"/buildx-"${BUILDX_VERSION}".linux-amd64 --output ~/.docker/cli-plugins/docker-buildx
+     chmod a+x ~/.docker/cli-plugins/docker-buildx
+  fi
+}
+
+create_or_use_buildx_builder() {
+  local builder_name=$1
+  if [ -z "$builder_name" ]; then
+    echo "Error: Builder name is required."
+    exit 1
+  fi
+
+  check_buildx
+
+  current_builder="$(docker buildx inspect "${builder_name}")"
+
+  if ! grep -q "^Driver: docker$" <<<"${current_builder}" && \
+     grep -q "linux/amd64" <<<"${current_builder}" && \
+     grep -q "linux/arm64" <<<"${current_builder}" && \
+     grep -q "linux/s390x" <<<"${current_builder}"; then
+    echo "The current builder already has multi-architecture support (amd64, arm64, s390x)."
+    echo "Skipping setup as the builder is already configured correctly."
+    exit 0
+  fi
+
+  # Check if the builder already exists by parsing the output of `docker buildx ls`
+  # We check if the builder_name appears in the list of active builders
+  existing_builder=$(docker buildx ls | grep -w "$builder_name" | awk '{print $1}')
+
+  if [ -n "$existing_builder" ]; then
+    echo "Builder '$builder_name' already exists."
+    echo "Using existing builder '$builder_name'."
+    docker buildx use "$builder_name"
+  else
+    echo "Creating a new Docker Buildx builder: $builder_name"
+    docker buildx create --driver-opt network=host --use --name "$builder_name"
+    echo "The new builder '$builder_name' has been created and set as active."
+  fi
+}
+
+if [ $# -eq 1 ]; then
+  create_or_use_buildx_builder "$1"
+else
+  echo "Usage: $0 <builder_name>"
+  echo "Example: $0 mybuilder"
+  exit 1
+fi


### PR DESCRIPTION
These changes enable building and pushing CNAO operator image for multiple platforms (amd64, s390x, arm64) from a single Dockerfile. Enhanced multi-platform support in the build process by adding a PLATFORMS argument in the Makefile for amd64, s390x, and arm64 architectures. Updated the docker-build-operator target to support builds with docker buildx and podman, and added new targets for creating Docker Buildx builders and pushing multi-platform images.

**What this PR does / why we need it**:
The existing CNAO operator ([link](https://quay.io/repository/kubevirt/cluster-network-addons-operator?tab=tags&tag=latest)) currently supports only the amd64 architecture. These changes extend multi-platform support to include arm64 and s390x architectures, enabling broader compatibility for the CNAO operator image.

**Special notes for your reviewer**:
Please note that Docker and Podman handle multi-architecture image builds differently. As a result, the changes have been made accordingly. Additionally, Go cross-compilation support has been added to build binaries for the target architecture.
Added a PLATFORMS argument in the Makefile to support building images for multiple architectures (amd64, s390x, arm64).
Updated the Dockerfile to dynamically handle multi-architecture builds.
Added Go cross-compilation support in Dockerfile to build binaries for the target architecture.
Enhanced the docker-build-operator target to enable multi-platform builds using both docker buildx and podman.
Introduced a new build-multiarch-operator-image target to build and push multi-platform images using podman.
Added a create-builder target to generate Docker Buildx builders for multi-platform image support.

**Release note**:
```release-note
None
```
