### PR TITLE
Enable dynamic host architecture detection.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,13 +13,13 @@ OPERATOR_IMAGE ?= cluster-network-addons-operator
 REGISTRY_IMAGE ?= cluster-network-addons-registry
 export OCI_BIN ?= $(shell if podman ps >/dev/null 2>&1; then echo podman; elif docker ps >/dev/null 2>&1; then echo docker; fi)
 TLS_SETTING := $(if $(filter $(OCI_BIN),podman),--tls-verify=false,)
-PLATFORMS ?= linux/amd64
+ARCH := $(shell uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')
+PLATFORMS ?= linux/${ARCH}
 # Set the platforms for building a multi-platform supported image.
 # Example:
 # PLATFORMS ?= linux/amd64,linux/arm64,linux/s390x
 # Alternatively, you can export the PLATFORMS variable like this:
 # export PLATFORMS=linux/arm64,linux/s390x,linux/amd64
-ARCH := $(shell uname -m | sed 's/x86_64/amd64/')
 DOCKER_BUILDER ?= cnao-docker-builder
 OPERATOR_IMAGE_TAGGED := $(IMAGE_REGISTRY)/$(OPERATOR_IMAGE):$(IMAGE_TAG)
 


### PR DESCRIPTION
This update sets the platform dynamically based on the host architecture, enhancing flexibility for building multi-platform images across different architectures.


**What this PR does / why we need it**:
Instead of setting the platform value to `amd64`, these changes configure it dynamically based on the host architecture.

**Special notes for your reviewer**:

**Release note**:

```release-note
None
```
