### PR TITLE
Update workflow to use Ubuntu 22.04

### DIFF
--- a/.github/workflows/kubevirt-ipam-controller.yaml
+++ b/.github/workflows/kubevirt-ipam-controller.yaml
@@ -2,7 +2,7 @@ name: Kubevirt IPAM controller Tests
 on: [pull_request]
 jobs:
   e2e:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
 
     - uses: actions/checkout@v3


### PR DESCRIPTION
It has been observed that build actions, such as free disk space, are broken with ubuntu-latest, which now points to Ubuntu 24.04. To resolve this, we are switching to the ubuntu-22.04 tag, which was previously used by ubuntu-latest.


**What this PR does / why we need it**:
ubuntu-latest now uses Ubuntu 24.04, while it used to use 22.04. 
To unblock Github CI in  the short term, we can switch to ubuntu-22.04,
Error log with ubuntu-latest is available at : https://github.com/ovn-kubernetes/ovn-kubernetes/pull/4914

**Special notes for your reviewer**:

**Release note**:


```release-note
None
```
