### PR TITLE
Update linux-bridge component commit to plugin v1.5.1

### DIFF
--- a/components.yaml
+++ b/components.yaml
@@ -25,7 +25,7 @@ components:
     metadata: v0.1.9-alpha
   linux-bridge:
     url: https://github.com/containernetworking/plugins
-    commit: 14bdce598f9d332303c375c35719c4a158f1e7db
+    commit: c29dc79f96cd50452a247a4591443d2aac033429
     branch: main
     update-policy: static
     metadata: ""

--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -32,7 +32,7 @@ var (
 const (
 	MultusImageDefault                 = "ghcr.io/k8snetworkplumbingwg/multus-cni@sha256:16030e8320088cf74dc5fbc7dccfea40169f09722dfad15765fa28bceb8de439"
 	MultusDynamicNetworksImageDefault  = "ghcr.io/k8snetworkplumbingwg/multus-dynamic-networks-controller@sha256:0bdf7dc9c15bdf7e5760955f05077c23868f3421141e8e623d75cf6b8cf36247"
-	LinuxBridgeCniImageDefault         = "quay.io/kubevirt/cni-default-plugins@sha256:0c354fa9d695b8cab97b459e8afea2f7662407a987e83f6f6f1a8af4b45726be"
+	LinuxBridgeCniImageDefault         = "quay.io/kubevirt/cni-default-plugins@sha256:976a24392c2a096c38c2663d234b2d3131f5c24558889196d30b9ac1b6716788"
 	LinuxBridgeMarkerImageDefault      = "quay.io/kubevirt/bridge-marker@sha256:e492ca4a6d1234781928aedefb096941d95babee4116baaba4d2a3834813826a"
 	KubeMacPoolImageDefault            = "quay.io/kubevirt/kubemacpool@sha256:eebb65b8a12cbfc20a429bbba399eb5a5c2279f8613c36965957ee7c36cfcbd6"
 	OvsCniImageDefault                 = "ghcr.io/k8snetworkplumbingwg/ovs-cni-plugin@sha256:d088e47f181007fe4823f0384ebae071950d105cd36c9187f9d06fd815288990"

--- a/test/releases/99.0.0.go
+++ b/test/releases/99.0.0.go
@@ -36,7 +36,7 @@ func init() {
 				ParentName: "kube-cni-linux-bridge-plugin",
 				ParentKind: "DaemonSet",
 				Name:       "cni-plugins",
-				Image:      "quay.io/kubevirt/cni-default-plugins@sha256:0c354fa9d695b8cab97b459e8afea2f7662407a987e83f6f6f1a8af4b45726be",
+				Image:      "quay.io/kubevirt/cni-default-plugins@sha256:976a24392c2a096c38c2663d234b2d3131f5c24558889196d30b9ac1b6716788",
 			},
 			{
 				ParentName: "kubemacpool-mac-controller-manager",


### PR DESCRIPTION
These changes will allow us to bump the linux-bridge component whenever a new tag is available.

**What this PR does / why we need it**:
Bump the commit to use the tag [[v1.5.1](https://github.com/containernetworking/plugins/releases/tag/v1.5.1)](https://github.com/containernetworking/plugins/releases/tag/v1.5.1).

**Special notes for your reviewer**:
Please note that or the latest tags, [v1.6.0](https://github.com/containernetworking/plugins/releases/tag/v1.6.0) and [v1.6.1](https://github.com/containernetworking/plugins/releases/tag/v1.6.1), we need Go version 1.23.

I have created a PR for the changes mentioned above: [[PR #1953](https://github.com/kubevirt/cluster-network-addons-operator/pull/1953)](https://github.com/kubevirt/cluster-network-addons-operator/pull/1953). Once this PR is merged, we can update the strategy from `static` to `tagged`.

Here is some additional context:
As discussed in the PR https://github.com/kubevirt/cluster-network-addons-operator/pull/1767, it was necessary to change the update-policy of the linux-bridge component from static to tagged once a new tag is available in [containernetworking/plugins](https://github.com/containernetworking/plugins). However, it appears that the update-policy is still set to static in [this file](https://github.com/kubevirt/cluster-network-addons-operator/blob/0c6cac0593bf7aa1a4e50a1d5a31b2b70bb9e4d7/components.yaml#L30).

I assume that with the tagged policy, the bump script will be triggered and will use the latest tag from https://github.com/containernetworking/plugins/tags. It will then push the new images to quay.io/kubevirt/cni-default-plugins.

**Release note**:


```release-note
None
```
