### PR TITLE
Bump ipam to v0.1.9-alpha and enable managed tap

### DIFF
--- a/automation/check-patch.e2e-kubevirt-ipam-controller-functests.sh
+++ b/automation/check-patch.e2e-kubevirt-ipam-controller-functests.sh
@@ -56,7 +56,7 @@ main() {
 
     cd ${TMP_COMPONENT_PATH}
     export KUBECONFIG=${TMP_COMPONENT_PATH}/.output/kubeconfig
-    export KIND_ARGS="-ic -i6 -mne"
+    export KIND_ARGS="-ic -i6 -mne -nse"
     make cluster-up
 
     trap teardown EXIT

--- a/automation/check-patch.e2e-kubevirt-ipam-controller-functests.sh
+++ b/automation/check-patch.e2e-kubevirt-ipam-controller-functests.sh
@@ -69,6 +69,8 @@ main() {
     deploy_cnao
     deploy_cnao_cr
     ./hack/deploy-kubevirt.sh
+    ./cluster/kubectl.sh -n kubevirt patch kubevirt kubevirt --type=json --patch '[{"op":"add","path":"/spec/configuration/developerConfiguration","value":{"featureGates":[]}},{"op":"add","path":"/spec/configuration/developerConfiguration/featureGates/-","value":"NetworkBindingPlugins"},{"op":"add","path":"/spec/configuration/developerConfiguration/featureGates/-","value":"DynamicPodInterfaceNaming"}]'
+    ./cluster/kubectl.sh -n kubevirt patch kubevirt kubevirt --type=json --patch '[{"op":"add","path":"/spec/configuration/network","value":{"binding":{"managedTap":{"domainAttachmentType":"managedTap","migration":{}}}}}]'
     ./cluster/kubectl.sh -n kubevirt patch kubevirt kubevirt --type=merge --patch '{"spec":{"configuration":{"virtualMachineOptions":{"disableSerialConsoleLog":{}}}}}'
 
     cd ${TMP_COMPONENT_PATH}

--- a/components.yaml
+++ b/components.yaml
@@ -19,10 +19,10 @@ components:
     metadata: v0.45.0
   kubevirt-ipam-controller:
     url: https://github.com/kubevirt/ipam-extensions
-    commit: 74c7ef7860f52af37988d6777925c27c79564065
+    commit: 5e1af1665a9241c92dfc179bf1347630a62f05b8
     branch: main
     update-policy: tagged
-    metadata: v0.1.7-alpha
+    metadata: v0.1.9-alpha
   linux-bridge:
     url: https://github.com/containernetworking/plugins
     commit: 14bdce598f9d332303c375c35719c4a158f1e7db

--- a/data/kubevirt-ipam-controller/001-kubevirtipamcontroller.yaml
+++ b/data/kubevirt-ipam-controller/001-kubevirtipamcontroller.yaml
@@ -217,6 +217,7 @@ spec:
               name: cert
               readOnly: true
           imagePullPolicy: {{ .ImagePullPolicy }}
+      priorityClassName: system-cluster-critical
       securityContext:
         runAsNonRoot: true
         seccompProfile:

--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -40,8 +40,8 @@ const (
 	KubeRbacProxyImageDefault          = "quay.io/brancz/kube-rbac-proxy@sha256:e6a323504999b2a4d2a6bf94f8580a050378eba0900fd31335cf9df5787d9a9b"
 	KubeSecondaryDNSImageDefault       = "ghcr.io/kubevirt/kubesecondarydns@sha256:8273cdbc438e06864eaa8e47947bea18fa5118a97cdaddc41b5dfa6e13474c79"
 	CoreDNSImageDefault                = "registry.k8s.io/coredns/coredns@sha256:a0ead06651cf580044aeb0a0feba63591858fb2e43ade8c9dea45a6a89ae7e5e"
-	KubevirtIpamControllerImageDefault = "ghcr.io/kubevirt/ipam-controller@sha256:aad40edd34f65cf0e087969853d47065aaf411dccf618d196152b583d40300ba"
-	PasstBindingCNIImageDefault        = "ghcr.io/kubevirt/passt-binding-cni@sha256:981c01e0b94ae691ba8ced43c486930085186e9c40b22525c8f0229d1556ee69"
+	KubevirtIpamControllerImageDefault = "ghcr.io/kubevirt/ipam-controller@sha256:41c3a436d871110f995af6d0b3cff7a90fb53a5bad4d4e99ab0954c3e1b79279"
+	PasstBindingCNIImageDefault        = "ghcr.io/kubevirt/passt-binding-cni@sha256:21093fe555e8962f666002258ae3402315fae3d9ec2ae10128529ec0a305bad4"
 )
 
 type AddonsImages struct {

--- a/test/releases/99.0.0.go
+++ b/test/releases/99.0.0.go
@@ -84,13 +84,13 @@ func init() {
 				ParentName: "kubevirt-ipam-controller-manager",
 				ParentKind: "Deployment",
 				Name:       "manager",
-				Image:      "ghcr.io/kubevirt/ipam-controller@sha256:aad40edd34f65cf0e087969853d47065aaf411dccf618d196152b583d40300ba",
+				Image:      "ghcr.io/kubevirt/ipam-controller@sha256:41c3a436d871110f995af6d0b3cff7a90fb53a5bad4d4e99ab0954c3e1b79279",
 			},
 			{
 				ParentName: "passt-binding-cni",
 				ParentKind: "DaemonSet",
 				Name:       "installer",
-				Image:      "ghcr.io/kubevirt/passt-binding-cni@sha256:981c01e0b94ae691ba8ced43c486930085186e9c40b22525c8f0229d1556ee69",
+				Image:      "ghcr.io/kubevirt/passt-binding-cni@sha256:21093fe555e8962f666002258ae3402315fae3d9ec2ae10128529ec0a305bad4",
 			},
 		},
 		SupportedSpec: cnao.NetworkAddonsConfigSpec{


### PR DESCRIPTION
**What this PR does / why we need it**:
Bump kubevirt-ipam-controller to v0.1.9-alpha
Adapt to support IPAM UDN tests with managedTap binding on CNAO.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
