### PR TITLE
Remove non-existent package msbuild from latest ubuntu images.

### DIFF
--- a/.github/workflows/kubevirt-ipam-controller.yaml
+++ b/.github/workflows/kubevirt-ipam-controller.yaml
@@ -2,7 +2,7 @@ name: Kubevirt IPAM controller Tests
 on: [pull_request]
 jobs:
   e2e:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
 
     - uses: actions/checkout@v3
@@ -20,7 +20,7 @@ jobs:
           azure-cli aspnetcore-* dotnet-* ghc-* firefox \
           google-chrome-stable \
           llvm-* microsoft-edge-stable mono-* \
-          msbuild mysql-server-core-* php-* php7* \
+          mysql-server-core-* php-* php7* \
           powershell temurin-* zulu-*
 
     - name: Run e2e tests


### PR DESCRIPTION
**What this PR does / why we need it**:
Build actions, including free disk space, are broken on ubuntu-latest, which now points to Ubuntu 24.04. To resolve this, we have removed the non-existent package from ubuntu-latest.

**Special notes for your reviewer**:
We are making these changes to align with the updates in OVN-Kubernetes, as seen in https://github.com/ovn-kubernetes/ovn-kubernetes/pull/4920.

**Release note**:

```release-note
None
```
