### PR TITLE
Set PLATFORMS to "all" for multi-platform image support in release pr…

### DIFF
--- a/automation/release.sh
+++ b/automation/release.sh
@@ -11,4 +11,6 @@ git config credential.helper '!f() { sleep 1; echo "username=${GITHUB_USER}"; ec
 
 source automation/check-patch.setup.sh
 cd ${TMP_PROJECT_PATH}
+# Set the PLATFORMS to "all" to build an image that supports multiple platforms
+export PLATFORMS=all
 make release


### PR DESCRIPTION
…ocess

Added export of PLATFORMS=all to automation/release.sh to ensure the build supports multiple platforms.

**What this PR does / why we need it**:
The CNAO post-submit Prow job, defined [[here](https://github.com/kubevirt/project-infra/blob/d274a82bc8f88e6c5c4c35de60de9b357b34268d/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-postsubmits.yaml#L25)](https://github.com/kubevirt/project-infra/blob/d274a82bc8f88e6c5c4c35de60de9b357b34268d/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-postsubmits.yaml#L25), uses `./automation/release.sh` to build and post CNAO release images. By default, it posts an image for the amd64 architecture (based on the host system). To enable building of multi-platform images, the `PLATFORMS=all` variable is added, allowing the creation of images for additional architectures like arm64, s390x, and others.

**Special notes for your reviewer**:
Build instruction is available at: https://gist.github.com/ashokpariya0/19b6f235a3fe149d16d82d92c84ce542/edit

**Release note**:

```release-note
None
```
