### PR TITLE
components, kubemacpool: Follow stable branch release-0.45

### DIFF
--- a/components.yaml
+++ b/components.yaml
@@ -14,8 +14,8 @@ components:
   kubemacpool:
     url: https://github.com/k8snetworkplumbingwg/kubemacpool
     commit: e47689f5de8ef4e2fca5751db25b1a77a61d7930
-    branch: main
-    update-policy: static
+    branch: release-0.45
+    update-policy: latest
     metadata: v0.45.0
   kubevirt-ipam-controller:
     url: https://github.com/kubevirt/ipam-extensions


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR set CNAO to follow KMP stable branch [release-0.45](https://github.com/k8snetworkplumbingwg/kubemacpool/tree/release-0.45) on it's release-0.97 stable branch

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
