### PR TITLE
components/multus-dynamic-networks: Pin to v0.3.4

### DIFF
--- a/components.yaml
+++ b/components.yaml
@@ -43,10 +43,10 @@ components:
     metadata: v4.1.4
   multus-dynamic-networks:
     url: https://github.com/k8snetworkplumbingwg/multus-dynamic-networks-controller
-    commit: 0546691af236bf825d1822d2ad9e7d6a22e10088
+    commit: e328aeb727e70165a8c7275aafa7035c963a8e22
     branch: main
-    update-policy: tagged
-    metadata: v0.3.5
+    update-policy: static
+    metadata: v0.3.4
   ovs-cni:
     url: https://github.com/k8snetworkplumbingwg/ovs-cni
     commit: 641e6348f9a6ea234e216a84784f0e1d90c80ade

--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -31,7 +31,7 @@ var (
 
 const (
 	MultusImageDefault                 = "ghcr.io/k8snetworkplumbingwg/multus-cni@sha256:16030e8320088cf74dc5fbc7dccfea40169f09722dfad15765fa28bceb8de439"
-	MultusDynamicNetworksImageDefault  = "ghcr.io/k8snetworkplumbingwg/multus-dynamic-networks-controller@sha256:322e6fc4e7c3c5431e95e7613aa15c9a375f559b0f41a14a141f5facdba3452e"
+	MultusDynamicNetworksImageDefault  = "ghcr.io/k8snetworkplumbingwg/multus-dynamic-networks-controller@sha256:0bdf7dc9c15bdf7e5760955f05077c23868f3421141e8e623d75cf6b8cf36247"
 	LinuxBridgeCniImageDefault         = "quay.io/kubevirt/cni-default-plugins@sha256:0c354fa9d695b8cab97b459e8afea2f7662407a987e83f6f6f1a8af4b45726be"
 	LinuxBridgeMarkerImageDefault      = "quay.io/kubevirt/bridge-marker@sha256:e492ca4a6d1234781928aedefb096941d95babee4116baaba4d2a3834813826a"
 	KubeMacPoolImageDefault            = "quay.io/kubevirt/kubemacpool@sha256:eebb65b8a12cbfc20a429bbba399eb5a5c2279f8613c36965957ee7c36cfcbd6"

--- a/test/releases/99.0.0.go
+++ b/test/releases/99.0.0.go
@@ -18,7 +18,7 @@ func init() {
 				ParentName: "dynamic-networks-controller-ds",
 				ParentKind: "DaemonSet",
 				Name:       "dynamic-networks-controller",
-				Image:      "ghcr.io/k8snetworkplumbingwg/multus-dynamic-networks-controller@sha256:322e6fc4e7c3c5431e95e7613aa15c9a375f559b0f41a14a141f5facdba3452e",
+				Image:      "ghcr.io/k8snetworkplumbingwg/multus-dynamic-networks-controller@sha256:0bdf7dc9c15bdf7e5760955f05077c23868f3421141e8e623d75cf6b8cf36247",
 			},
 			{
 				ParentName: "multus",


### PR DESCRIPTION
**What this PR does / why we need it**:
multus-dynamic-networks v0.3.5 is breaking. Pin to latest successful version until the issue is resolved

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
