### PR TITLE
tools/bumper: Refactor using DeferCleanup

### DIFF
--- a/tools/bumper/cnao_repo_commands_test.go
+++ b/tools/bumper/cnao_repo_commands_test.go
@@ -30,7 +30,7 @@ var _ = Describe("Testing internal git CNAO Repo", func() {
 		gitCnaoRepo = newFakeGitCnaoRepo(githubApi, repoDir, &component{}, expectedTagCommitMap)
 
 		DeferCleanup(func() {
-			Expect(os.RemoveAll(gitCnaoRepo.gitRepo.localDir)).To(Succeed())
+			Expect(os.RemoveAll(tempDir)).To(Succeed())
 		})
 	})
 

--- a/tools/bumper/cnao_repo_commands_test.go
+++ b/tools/bumper/cnao_repo_commands_test.go
@@ -28,6 +28,10 @@ var _ = Describe("Testing internal git CNAO Repo", func() {
 		githubApi = newFakeGithubApi(repoDir)
 
 		gitCnaoRepo = newFakeGitCnaoRepo(githubApi, repoDir, &component{}, expectedTagCommitMap)
+
+		DeferCleanup(func() {
+			Expect(os.RemoveAll(gitCnaoRepo.gitRepo.localDir)).To(Succeed())
+		})
 	})
 
 	Context("Creating fake PRs", func() {
@@ -55,10 +59,6 @@ var _ = Describe("Testing internal git CNAO Repo", func() {
 
 		DescribeTable("and checking isPrAlreadyOpened function",
 			func(r isPrAlreadyOpenedParams) {
-				DeferCleanup(func() {
-					Expect(os.RemoveAll(gitCnaoRepo.gitRepo.localDir)).To(Succeed())
-				})
-
 				gitCnaoRepo.configParams.Url = repoDir
 				gitCnaoRepo.configParams.Branch = r.branch
 
@@ -114,10 +114,6 @@ var _ = Describe("Testing internal git CNAO Repo", func() {
 	}
 	DescribeTable("canonicalizeVersion function",
 		func(v canonicalizeVersionParams) {
-			DeferCleanup(func() {
-				Expect(os.RemoveAll(gitCnaoRepo.gitRepo.localDir)).To(Succeed())
-			})
-
 			By("Parsing the version string")
 			formattedVersion, err := canonicalizeVersion(v.version)
 
@@ -164,10 +160,6 @@ var _ = Describe("Testing internal git CNAO Repo", func() {
 	}
 	DescribeTable("isVtagFormat function",
 		func(p isVtagFormatParams) {
-			DeferCleanup(func() {
-				Expect(os.RemoveAll(gitCnaoRepo.gitRepo.localDir)).To(Succeed())
-			})
-
 			By("Checking if the version string of vtag format")
 			isVtag := isVtagFormat(p.version)
 
@@ -219,9 +211,6 @@ var _ = Describe("Testing internal git CNAO Repo", func() {
 	dummyPRTitle := "dummy new PR title"
 	DescribeTable("isComponentBumpNeeded function",
 		func(b isComponentBumpNeededParams) {
-			DeferCleanup(func() {
-				Expect(os.RemoveAll(gitCnaoRepo.gitRepo.localDir)).To(Succeed())
-			})
 			gitCnaoRepo.configParams.Url = repoDir
 
 			By("Checking if bump is needed")
@@ -326,9 +315,6 @@ var _ = Describe("Testing internal git CNAO Repo", func() {
 
 	DescribeTable("resetInAllowedList function",
 		func(r resetInAllowedListParams) {
-			DeferCleanup(func() {
-				Expect(os.RemoveAll(gitCnaoRepo.gitRepo.localDir)).To(Succeed())
-			})
 			worktree, err := gitCnaoRepo.gitRepo.repo.Worktree()
 
 			By("Modifying files in the Repo")
@@ -391,10 +377,6 @@ var _ = Describe("Testing internal git CNAO Repo", func() {
 
 	DescribeTable("fileInGlobList function",
 		func(r fileInGlobListParams) {
-			DeferCleanup(func() {
-				Expect(os.RemoveAll(gitCnaoRepo.gitRepo.localDir)).To(Succeed())
-			})
-
 			By("Running fileInGlobList on given input")
 			result := fileInGlobList(r.fileName, r.globList)
 
@@ -433,10 +415,6 @@ var _ = Describe("Testing internal git CNAO Repo", func() {
 
 	DescribeTable("collectModifiedToTreeList function",
 		func(r collectModifiedToTreeListParams) {
-			DeferCleanup(func() {
-				Expect(os.RemoveAll(gitCnaoRepo.gitRepo.localDir)).To(Succeed())
-			})
-
 			if len(r.files) != 0 {
 				By("Modifying files in the Repo")
 				modifyFiles(gitCnaoRepo.gitRepo.localDir, r.files)

--- a/tools/bumper/cnao_repo_commands_test.go
+++ b/tools/bumper/cnao_repo_commands_test.go
@@ -55,9 +55,9 @@ var _ = Describe("Testing internal git CNAO Repo", func() {
 
 		DescribeTable("and checking isPrAlreadyOpened function",
 			func(r isPrAlreadyOpenedParams) {
-				defer func(path string) {
-					Expect(os.RemoveAll(path)).To(Succeed())
-				}(gitCnaoRepo.gitRepo.localDir)
+				DeferCleanup(func() {
+					Expect(os.RemoveAll(gitCnaoRepo.gitRepo.localDir)).To(Succeed())
+				})
 
 				gitCnaoRepo.configParams.Url = repoDir
 				gitCnaoRepo.configParams.Branch = r.branch
@@ -114,9 +114,9 @@ var _ = Describe("Testing internal git CNAO Repo", func() {
 	}
 	DescribeTable("canonicalizeVersion function",
 		func(v canonicalizeVersionParams) {
-			defer func(path string) {
-				Expect(os.RemoveAll(path)).To(Succeed())
-			}(gitCnaoRepo.gitRepo.localDir)
+			DeferCleanup(func() {
+				Expect(os.RemoveAll(gitCnaoRepo.gitRepo.localDir)).To(Succeed())
+			})
 
 			By("Parsing the version string")
 			formattedVersion, err := canonicalizeVersion(v.version)
@@ -164,7 +164,9 @@ var _ = Describe("Testing internal git CNAO Repo", func() {
 	}
 	DescribeTable("isVtagFormat function",
 		func(p isVtagFormatParams) {
-			defer os.RemoveAll(gitCnaoRepo.gitRepo.localDir)
+			DeferCleanup(func() {
+				Expect(os.RemoveAll(gitCnaoRepo.gitRepo.localDir)).To(Succeed())
+			})
 
 			By("Checking if the version string of vtag format")
 			isVtag := isVtagFormat(p.version)
@@ -217,9 +219,9 @@ var _ = Describe("Testing internal git CNAO Repo", func() {
 	dummyPRTitle := "dummy new PR title"
 	DescribeTable("isComponentBumpNeeded function",
 		func(b isComponentBumpNeededParams) {
-			defer func(path string) {
-				Expect(os.RemoveAll(path)).To(Succeed())
-			}(gitCnaoRepo.gitRepo.localDir)
+			DeferCleanup(func() {
+				Expect(os.RemoveAll(gitCnaoRepo.gitRepo.localDir)).To(Succeed())
+			})
 			gitCnaoRepo.configParams.Url = repoDir
 
 			By("Checking if bump is needed")
@@ -324,9 +326,9 @@ var _ = Describe("Testing internal git CNAO Repo", func() {
 
 	DescribeTable("resetInAllowedList function",
 		func(r resetInAllowedListParams) {
-			defer func(path string) {
-				Expect(os.RemoveAll(path)).To(Succeed())
-			}(gitCnaoRepo.gitRepo.localDir)
+			DeferCleanup(func() {
+				Expect(os.RemoveAll(gitCnaoRepo.gitRepo.localDir)).To(Succeed())
+			})
 			worktree, err := gitCnaoRepo.gitRepo.repo.Worktree()
 
 			By("Modifying files in the Repo")
@@ -389,9 +391,9 @@ var _ = Describe("Testing internal git CNAO Repo", func() {
 
 	DescribeTable("fileInGlobList function",
 		func(r fileInGlobListParams) {
-			defer func(path string) {
-				Expect(os.RemoveAll(path)).To(Succeed())
-			}(gitCnaoRepo.gitRepo.localDir)
+			DeferCleanup(func() {
+				Expect(os.RemoveAll(gitCnaoRepo.gitRepo.localDir)).To(Succeed())
+			})
 
 			By("Running fileInGlobList on given input")
 			result := fileInGlobList(r.fileName, r.globList)
@@ -431,9 +433,9 @@ var _ = Describe("Testing internal git CNAO Repo", func() {
 
 	DescribeTable("collectModifiedToTreeList function",
 		func(r collectModifiedToTreeListParams) {
-			defer func(path string) {
-				Expect(os.RemoveAll(path)).To(Succeed())
-			}(gitCnaoRepo.gitRepo.localDir)
+			DeferCleanup(func() {
+				Expect(os.RemoveAll(gitCnaoRepo.gitRepo.localDir)).To(Succeed())
+			})
 
 			if len(r.files) != 0 {
 				By("Modifying files in the Repo")

--- a/tools/bumper/component_commands_test.go
+++ b/tools/bumper/component_commands_test.go
@@ -28,6 +28,7 @@ var _ = Describe("Testing internal git component", func() {
 
 		DeferCleanup(func() {
 			Expect(os.RemoveAll(gitComponent.gitRepo.localDir)).To(Succeed())
+			Expect(os.RemoveAll(tempDir)).To(Succeed())
 		})
 	})
 

--- a/tools/bumper/component_commands_test.go
+++ b/tools/bumper/component_commands_test.go
@@ -25,6 +25,10 @@ var _ = Describe("Testing internal git component", func() {
 		githubApi = newFakeGithubApi(repoDir)
 
 		gitComponent = newFakeGitComponent(githubApi, repoDir, &component{}, expectedTagCommitMap)
+
+		DeferCleanup(func() {
+			Expect(os.RemoveAll(gitComponent.gitRepo.localDir)).To(Succeed())
+		})
 	})
 
 	type getVirtualTagParams struct {
@@ -32,9 +36,6 @@ var _ = Describe("Testing internal git component", func() {
 	}
 	DescribeTable("getVirtualTag function",
 		func(r getVirtualTagParams) {
-			DeferCleanup(func() {
-				Expect(os.RemoveAll(gitComponent.gitRepo.localDir)).To(Succeed())
-			})
 			By("Running api to get the current virtual tag")
 			commitTested := expectedTagCommitMap[r.TagKey]
 			currentReleaseTag, err := gitComponent.getVirtualTag(commitTested)
@@ -71,10 +72,6 @@ var _ = Describe("Testing internal git component", func() {
 	}
 	DescribeTable("getCurrentReleaseTag function",
 		func(r currentReleaseParams) {
-			DeferCleanup(func() {
-				Expect(os.RemoveAll(gitComponent.gitRepo.localDir)).To(Succeed())
-			})
-
 			// update test params since you cant do it in the Entry context
 			gitComponent.configParams.Url = repoDir
 			gitComponent.configParams.Commit = expectedTagCommitMap[r.TagKey]
@@ -131,9 +128,6 @@ var _ = Describe("Testing internal git component", func() {
 	}
 	DescribeTable("getUpdatedReleaseInfo function",
 		func(r updatedReleaseParams) {
-			DeferCleanup(func() {
-				Expect(os.RemoveAll(gitComponent.gitRepo.localDir)).To(Succeed())
-			})
 			// update test params since you cant do it in the Entry context
 			gitComponent.configParams = r.comp
 			gitComponent.configParams.Url = repoDir

--- a/tools/bumper/component_commands_test.go
+++ b/tools/bumper/component_commands_test.go
@@ -32,10 +32,9 @@ var _ = Describe("Testing internal git component", func() {
 	}
 	DescribeTable("getVirtualTag function",
 		func(r getVirtualTagParams) {
-			defer func(path string) {
-				Expect(os.RemoveAll(path)).To(Succeed())
-			}(gitComponent.gitRepo.localDir)
-
+			DeferCleanup(func() {
+				Expect(os.RemoveAll(gitComponent.gitRepo.localDir)).To(Succeed())
+			})
 			By("Running api to get the current virtual tag")
 			commitTested := expectedTagCommitMap[r.TagKey]
 			currentReleaseTag, err := gitComponent.getVirtualTag(commitTested)
@@ -72,9 +71,9 @@ var _ = Describe("Testing internal git component", func() {
 	}
 	DescribeTable("getCurrentReleaseTag function",
 		func(r currentReleaseParams) {
-			defer func(path string) {
-				Expect(os.RemoveAll(path)).To(Succeed())
-			}(gitComponent.gitRepo.localDir)
+			DeferCleanup(func() {
+				Expect(os.RemoveAll(gitComponent.gitRepo.localDir)).To(Succeed())
+			})
 
 			// update test params since you cant do it in the Entry context
 			gitComponent.configParams.Url = repoDir
@@ -132,10 +131,9 @@ var _ = Describe("Testing internal git component", func() {
 	}
 	DescribeTable("getUpdatedReleaseInfo function",
 		func(r updatedReleaseParams) {
-			defer func(path string) {
-				Expect(os.RemoveAll(path)).To(Succeed())
-			}(gitComponent.gitRepo.localDir)
-
+			DeferCleanup(func() {
+				Expect(os.RemoveAll(gitComponent.gitRepo.localDir)).To(Succeed())
+			})
 			// update test params since you cant do it in the Entry context
 			gitComponent.configParams = r.comp
 			gitComponent.configParams.Url = repoDir


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR is refactoring the bumper unit tests to use DeferCleanup, following a [discussion](https://github.com/kubevirt/cluster-network-addons-operator/pull/1971#discussion_r1905430675) in anotherPR

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
