### PR TITLE
components, multus-dynamic-networks: update_policy to tagged

### DIFF
--- a/components.yaml
+++ b/components.yaml
@@ -45,7 +45,7 @@ components:
     url: https://github.com/k8snetworkplumbingwg/multus-dynamic-networks-controller
     commit: e328aeb727e70165a8c7275aafa7035c963a8e22
     branch: main
-    update-policy: static
+    update-policy: tagged
     metadata: v0.3.4
   ovs-cni:
     url: https://github.com/k8snetworkplumbingwg/ovs-cni


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR changes the update-policy of multus-dynamic-networks to tagged.

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
