### PR TITLE
[Release 0.97] bump multus-dynamic-networks v0.3.6

### DIFF
--- a/components.yaml
+++ b/components.yaml
@@ -43,10 +43,10 @@ components:
     metadata: v4.1.4
   multus-dynamic-networks:
     url: https://github.com/k8snetworkplumbingwg/multus-dynamic-networks-controller
-    commit: e328aeb727e70165a8c7275aafa7035c963a8e22
+    commit: dbbb88bfa4ccde4dbd462b18859a6a74f03fefcc
     branch: main
     update-policy: static
-    metadata: v0.3.4
+    metadata: v0.3.6
   ovs-cni:
     url: https://github.com/k8snetworkplumbingwg/ovs-cni
     commit: 641e6348f9a6ea234e216a84784f0e1d90c80ade

--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -31,7 +31,7 @@ var (
 
 const (
 	MultusImageDefault                 = "ghcr.io/k8snetworkplumbingwg/multus-cni@sha256:16030e8320088cf74dc5fbc7dccfea40169f09722dfad15765fa28bceb8de439"
-	MultusDynamicNetworksImageDefault  = "ghcr.io/k8snetworkplumbingwg/multus-dynamic-networks-controller@sha256:0bdf7dc9c15bdf7e5760955f05077c23868f3421141e8e623d75cf6b8cf36247"
+	MultusDynamicNetworksImageDefault  = "ghcr.io/k8snetworkplumbingwg/multus-dynamic-networks-controller@sha256:8061bd1276ff022fe52a0b07bc6fa8d27e5f6f20cf3bf764e76d347d2e3c929b"
 	LinuxBridgeCniImageDefault         = "quay.io/kubevirt/cni-default-plugins@sha256:0c354fa9d695b8cab97b459e8afea2f7662407a987e83f6f6f1a8af4b45726be"
 	LinuxBridgeMarkerImageDefault      = "quay.io/kubevirt/bridge-marker@sha256:e492ca4a6d1234781928aedefb096941d95babee4116baaba4d2a3834813826a"
 	KubeMacPoolImageDefault            = "quay.io/kubevirt/kubemacpool@sha256:6cc8ca860960c003b36754c6dde249f26f78d32eb22159a25b5647e197dbc9f9"

--- a/test/releases/99.0.0.go
+++ b/test/releases/99.0.0.go
@@ -18,7 +18,7 @@ func init() {
 				ParentName: "dynamic-networks-controller-ds",
 				ParentKind: "DaemonSet",
 				Name:       "dynamic-networks-controller",
-				Image:      "ghcr.io/k8snetworkplumbingwg/multus-dynamic-networks-controller@sha256:0bdf7dc9c15bdf7e5760955f05077c23868f3421141e8e623d75cf6b8cf36247",
+				Image:      "ghcr.io/k8snetworkplumbingwg/multus-dynamic-networks-controller@sha256:8061bd1276ff022fe52a0b07bc6fa8d27e5f6f20cf3bf764e76d347d2e3c929b",
 			},
 			{
 				ParentName: "multus",


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR is a manual bump of multus-dynamic-networks to v0.3.6

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
