### PR TITLE
Upgrade monitoring linter to latest

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -240,7 +240,7 @@ lint-metrics:
 	./hack/prom_metric_linter.sh --operator-name="kubevirt" --sub-operator-name="cnao"
 
 lint-monitoring:
-	GOBIN=$$(pwd)/build/_output/bin/ $(GO) install -mod=mod github.com/kubevirt/monitoring/monitoringlinter/cmd/monitoringlinter@e2be790
+	GOBIN=$$(pwd)/build/_output/bin/ $(GO) install -mod=mod github.com/kubevirt/monitoring/monitoringlinter/cmd/monitoringlinter@v0.0.8
 	$(MONITORING_LINTER) ./...
 
 clean:


### PR DESCRIPTION
This pr is upgrading the metrics linter to latest version which [bumps go to 1.23](https://github.com/kubevirt/monitoring/pull/283) and fix the type issue, see https://github.com/kubevirt/cluster-network-addons-operator/issues/2005#issuecomment-2662343204

Fixes #2005

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
none
```
