### PR TITLE
Align placement with HCO components

### DIFF
--- a/data/kubevirt-ipam-controller/003-passtbindingcni.yaml
+++ b/data/kubevirt-ipam-controller/003-passtbindingcni.yaml
@@ -55,6 +55,6 @@ spec:
         - name: cnibin
           hostPath:
             path: {{ .CNIBinDir }}
-      nodeSelector: {{ toYaml .Placement.NodeSelector | nindent 8 }}
-      affinity: {{ toYaml .Placement.Affinity | nindent 8 }}
-      tolerations: {{ toYaml .Placement.Tolerations | nindent 8 }}
+      nodeSelector: {{ toYaml .PlacementPasst.NodeSelector | nindent 8 }}
+      affinity: {{ toYaml .PlacementPasst.Affinity | nindent 8 }}
+      tolerations: {{ toYaml .PlacementPasst.Tolerations | nindent 8 }}

--- a/hack/components/bump-kubevirt-ipam-controller.sh
+++ b/hack/components/bump-kubevirt-ipam-controller.sh
@@ -75,9 +75,9 @@ function __parametize_passt_binding_cni() {
   f=003-passtbindingcni.yaml
 
   yaml-utils::update_param ${f} metadata.namespace '{{ .Namespace }}'
-  yaml-utils::set_param ${f} spec.template.spec.nodeSelector '{{ toYaml .Placement.NodeSelector | nindent 8 }}'
-  yaml-utils::set_param ${f} spec.template.spec.affinity '{{ toYaml .Placement.Affinity | nindent 8 }}'
-  yaml-utils::set_param ${f} spec.template.spec.tolerations '{{ toYaml .Placement.Tolerations | nindent 8 }}'
+  yaml-utils::set_param ${f} spec.template.spec.nodeSelector '{{ toYaml .PlacementPasst.NodeSelector | nindent 8 }}'
+  yaml-utils::set_param ${f} spec.template.spec.affinity '{{ toYaml .PlacementPasst.Affinity | nindent 8 }}'
+  yaml-utils::set_param ${f} spec.template.spec.tolerations '{{ toYaml .PlacementPasst.Tolerations | nindent 8 }}'
   yaml-utils::update_param ${f} spec.template.spec.containers[0].image '{{ .PasstBindingCNIImage }}'
   yaml-utils::set_param ${f} spec.template.spec.containers[0].imagePullPolicy '{{ .ImagePullPolicy }}'
   yaml-utils::update_param ${f} spec.template.spec.volumes[0].hostPath.path '{{ .CNIBinDir }}'

--- a/pkg/network/kube_secondary_dns_controller.go
+++ b/pkg/network/kube_secondary_dns_controller.go
@@ -21,7 +21,7 @@ func renderKubeSecondaryDNS(conf *cnao.NetworkAddonsConfigSpec, manifestDir stri
 	data := render.MakeRenderData()
 	data.Data["Namespace"] = os.Getenv("OPERAND_NAMESPACE")
 	data.Data["ImagePullPolicy"] = conf.ImagePullPolicy
-	data.Data["Placement"] = conf.PlacementConfiguration.Workloads
+	data.Data["Placement"] = conf.PlacementConfiguration.Infra
 	data.Data["Domain"] = conf.KubeSecondaryDNS.Domain
 	data.Data["NameServerIp"] = conf.KubeSecondaryDNS.NameServerIP
 	data.Data["KubeSecondaryDNSImage"] = os.Getenv("KUBE_SECONDARY_DNS_IMAGE")

--- a/pkg/network/kubevirt_ipam_controller.go
+++ b/pkg/network/kubevirt_ipam_controller.go
@@ -29,7 +29,8 @@ func renderKubevirtIPAMController(conf *cnao.NetworkAddonsConfigSpec, manifestDi
 	data := render.MakeRenderData()
 	data.Data["Namespace"] = os.Getenv("OPERAND_NAMESPACE")
 	data.Data["ImagePullPolicy"] = conf.ImagePullPolicy
-	data.Data["Placement"] = conf.PlacementConfiguration.Workloads
+	data.Data["Placement"] = conf.PlacementConfiguration.Infra
+	data.Data["PlacementPasst"] = conf.PlacementConfiguration.Workloads
 	data.Data["KubevirtIpamControllerImage"] = os.Getenv("KUBEVIRT_IPAM_CONTROLLER_IMAGE")
 	data.Data["PasstBindingCNIImage"] = os.Getenv("PASST_BINDING_CNI_IMAGE")
 

--- a/pkg/network/kubevirt_ipam_controller_test.go
+++ b/pkg/network/kubevirt_ipam_controller_test.go
@@ -14,7 +14,10 @@ import (
 
 var _ = Describe("Testing kubevirt ipam controller", func() {
 	Context("Render KubevirtIpamController", func() {
-		conf := &cnao.NetworkAddonsConfigSpec{ImagePullPolicy: v1.PullAlways, Multus: &cnao.Multus{}, KubevirtIpamController: &cnao.KubevirtIpamController{}, PlacementConfiguration: &cnao.PlacementConfiguration{Workloads: &cnao.Placement{}}}
+		conf := &cnao.NetworkAddonsConfigSpec{ImagePullPolicy: v1.PullAlways, Multus: &cnao.Multus{}, KubevirtIpamController: &cnao.KubevirtIpamController{}, PlacementConfiguration: &cnao.PlacementConfiguration{
+			Infra:     &cnao.Placement{},
+			Workloads: &cnao.Placement{},
+		}}
 		manifestDir := "../../data"
 		openshiftNetworkConf := &osv1.Network{}
 		clusterInfo := &ClusterInfo{}

--- a/pkg/network/placement_configuration.go
+++ b/pkg/network/placement_configuration.go
@@ -9,7 +9,6 @@ import (
 func GetDefaultPlacementConfiguration() cnao.PlacementConfiguration {
 	return cnao.PlacementConfiguration{
 		Infra: &cnao.Placement{
-			Tolerations: []corev1.Toleration{},
 			Affinity: corev1.Affinity{
 				NodeAffinity: &corev1.NodeAffinity{
 					PreferredDuringSchedulingIgnoredDuringExecution: []corev1.PreferredSchedulingTerm{

--- a/pkg/network/placement_configuration.go
+++ b/pkg/network/placement_configuration.go
@@ -7,33 +7,9 @@ import (
 )
 
 func GetDefaultPlacementConfiguration() cnao.PlacementConfiguration {
-	var nodeNotNReadyTolerationInSeconds int64 = 60
 	return cnao.PlacementConfiguration{
 		Infra: &cnao.Placement{
-			Tolerations: []corev1.Toleration{
-				corev1.Toleration{
-					Key:      "node-role.kubernetes.io/control-plane",
-					Operator: corev1.TolerationOpExists,
-					Effect:   corev1.TaintEffectNoSchedule,
-				},
-				corev1.Toleration{
-					Key:      "node-role.kubernetes.io/master",
-					Operator: corev1.TolerationOpExists,
-					Effect:   corev1.TaintEffectNoSchedule,
-				},
-				corev1.Toleration{
-					Key:               "node.kubernetes.io/unreachable",
-					Operator:          corev1.TolerationOpExists,
-					Effect:            corev1.TaintEffectNoExecute,
-					TolerationSeconds: &nodeNotNReadyTolerationInSeconds,
-				},
-				corev1.Toleration{
-					Key:               "node.kubernetes.io/not-ready",
-					Operator:          corev1.TolerationOpExists,
-					Effect:            corev1.TaintEffectNoExecute,
-					TolerationSeconds: &nodeNotNReadyTolerationInSeconds,
-				},
-			},
+			Tolerations: []corev1.Toleration{},
 			Affinity: corev1.Affinity{
 				NodeAffinity: &corev1.NodeAffinity{
 					PreferredDuringSchedulingIgnoredDuringExecution: []corev1.PreferredSchedulingTerm{

--- a/pkg/network/placement_configuration.go
+++ b/pkg/network/placement_configuration.go
@@ -41,10 +41,11 @@ func GetDefaultPlacementConfiguration() cnao.PlacementConfiguration {
 		},
 		Workloads: &cnao.Placement{
 			NodeSelector: map[string]string{
-				"kubernetes.io/os": "linux",
+				corev1.LabelOSStable: "linux",
 			},
 			Tolerations: []corev1.Toleration{
 				corev1.Toleration{
+					Key:      corev1.TaintNodeUnschedulable,
 					Operator: corev1.TolerationOpExists,
 					Effect:   corev1.TaintEffectNoSchedule,
 				},


### PR DESCRIPTION
**What this PR does / why we need it**:
The components installed by CNAO should follow the kind of placement configuration done by HCO components by default so features like node drain work similar.

In this case CNAO was configuring deployments that are part of the controlplane as part of the Workload this means that they will run at workers and that they will not evict after drain (they should not since they are not daemonsets), this PR move those to Infra placemnt and also remove invalid tolerationsn from Infra.

**Special notes for your reviewer**:
Closes https://issues.redhat.com/browse/CNV-56947

**Release note**:
```release-note
Move control plane deployments to infra placement
```
