### PR TITLE
automation/unit-test: Add vendor check

### DIFF
--- a/automation/check-patch.unit-test.sh
+++ b/automation/check-patch.unit-test.sh
@@ -13,6 +13,7 @@ main() {
     source automation/check-patch.setup.sh
     cd ${TMP_PROJECT_PATH}
     make bump-all
+    make vendor
     make check
     verify_metrics_docs_updated
     make lint-metrics


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds a vendor check before `make check`, so that we can make sure that the go files are aligned.

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
