### PR TITLE
Makefile: Enforce max allowed version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,10 @@ VERSION_REPLACES ?= 0.95.0
 
 DEPLOY_DIR ?= manifests
 
+MAX_GO_VERSION=1.22
+CURRENT_GO_VERSION=$(shell awk '/^go [0-9]+\./ {print $$2}' go.mod | awk -F. '{print $$1"."$$2}')
+TOOLCHAIN_VERSION=$(shell grep '^toolchain' go.mod | awk '{print $$2}' | sed 's/go//' | awk -F. '{print $$1"."$$2}' || echo "")
+
 IMAGE_REGISTRY ?= quay.io/kubevirt
 IMAGE_TAG ?= latest
 OPERATOR_IMAGE ?= cluster-network-addons-operator
@@ -201,7 +205,15 @@ release: $(GITHUB_RELEASE)
 	    manifests/cluster-network-addons/cluster-network-addons.package.yaml \
 	    $(shell find manifests/cluster-network-addons/$(shell hack/version.sh) -type f)
 
-vendor: $(GO)
+check-go-version:
+	@if [ "$(CURRENT_GO_VERSION)" != "$(MAX_GO_VERSION)" ]; then \
+		echo "Error: go.mod version $(CURRENT_GO_VERSION) exceeds max allowed version $(MAX_GO_VERSION)"; exit 1; \
+	fi
+	@if [ -n "$(TOOLCHAIN_VERSION)" ] && [ "$(TOOLCHAIN_VERSION)" != "$(MAX_GO_VERSION)" ]; then \
+		echo "Error: Go toolchain version $(TOOLCHAIN_VERSION) exceeds max allowed version $(MAX_GO_VERSION)"; exit 1; \
+	fi
+
+vendor: $(GO) check-go-version
 	$(GO) mod tidy -compat=$(GO_VERSION)
 	$(GO) mod vendor
 


### PR DESCRIPTION
In order to protect us from bumping either manually or by Renovate bot, 
go toolchain / lang higher than allowed for stable branches, guard was added to Makefile.

Notes:
1. The guard doesn't protect from bumping higher than allowed Z stream, only X.Y.
2. The guard should be added once the go.mod file has the highest allowed, or at least to know that if you add it as is, you need to update both in case you update go.mod.
3. The guard will disregard toolchain line if such doesn't exists.
4. For simplicity the guard protects the that max normalized (without Z) allowed version match both language level and toolchain, but it is allowed basically that the toolchain will be higher than the lang level on go.mod, so this is extra safty that we might want to remove.

Tried to keep it simple for start, we can later improve upon need.
For example to create a generic snippet that covers all cases, but it is bit more complex,
and keeping stuff simple also has advantage.

<!-- Thanks for sending a pull request!

Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the main branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it

If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
None
```
