### PR TITLE
[release-0.97] components/kmp: Follow tagged releases

### DIFF
--- a/components.yaml
+++ b/components.yaml
@@ -15,7 +15,7 @@ components:
     url: https://github.com/k8snetworkplumbingwg/kubemacpool
     commit: 65a48a99deb5b8b1452927709de3efb2d32d8dbd
     branch: release-0.45
-    update-policy: latest
+    update-policy: tagged
     metadata: v0.45.1
   kubevirt-ipam-controller:
     url: https://github.com/kubevirt/ipam-extensions


### PR DESCRIPTION
**What this PR does / why we need it**:
Following the increase in traffic, limiting kubmacpool bumps to only tagged versions on the stable branch

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
