### PR TITLE
[release-0.95] components/kmp: Follow tagged releases

### DIFF
--- a/components.yaml
+++ b/components.yaml
@@ -15,7 +15,7 @@ components:
     url: https://github.com/k8snetworkplumbingwg/kubemacpool
     commit: afd99eefbaf9955d3c1d8b29dfd655405b3d07cf
     branch: release-0.44
-    update-policy: latest
+    update-policy: tagged
     metadata: v0.44.2
   kubevirt-ipam-controller:
     url: https://github.com/kubevirt/ipam-extensions


### PR DESCRIPTION
**What this PR does / why we need it**:
Following the increase in traffic, limiting kubmacpool bumps to only tagged versions on the stable branch

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
