### PR TITLE
components/kmp: Follow latest main branch

### DIFF
--- a/components.yaml
+++ b/components.yaml
@@ -15,7 +15,7 @@ components:
     url: https://github.com/k8snetworkplumbingwg/kubemacpool
     commit: 9be6f3e0b82b8b9796fe039d501668daa22d261f
     branch: main
-    update-policy: tagged
+    update-policy: latest
     metadata: v0.46.0
   kubevirt-ipam-controller:
     url: https://github.com/kubevirt/ipam-extensions


### PR DESCRIPTION
**What this PR does / why we need it**:
CNAO main branch should follow the latest changes on kubemacpool, and if necessary - fail fast in order to fix fast.

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
