### PR TITLE
e2e: log failed tests to artifacts

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -17,7 +17,6 @@ docs
 
 # Test and infra
 test
-test_logs
 automation
 
 

--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,6 @@ _out
 build/operator/_output
 build/operator/_test
 build/_output
-test_logs
 
 # Temporary local cluster files
 _kubevirtci/

--- a/automation/check-patch.setup.sh
+++ b/automation/check-patch.setup.sh
@@ -22,7 +22,7 @@ rm -rf $tmp_dir
 mkdir -p $tmp_dir
 
 export TMP_PROJECT_PATH=$tmp_dir/cluster-network-addons-operator
-export E2E_LOGS=${TMP_PROJECT_PATH}/test_logs/e2e
+export E2E_LOGS=${TMP_PROJECT_PATH}/_out/e2e
 export ARTIFACTS=${ARTIFACTS-$tmp_dir/artifacts}
 mkdir -p $ARTIFACTS
 

--- a/test/e2e/lifecycle/main_test.go
+++ b/test/e2e/lifecycle/main_test.go
@@ -1,19 +1,27 @@
 package test
 
 import (
+	"fmt"
 	"os"
 	"testing"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	"github.com/kubevirt/cluster-network-addons-operator/pkg/components"
 	. "github.com/kubevirt/cluster-network-addons-operator/test/check"
 	testenv "github.com/kubevirt/cluster-network-addons-operator/test/env"
 	. "github.com/kubevirt/cluster-network-addons-operator/test/operations"
 	. "github.com/kubevirt/cluster-network-addons-operator/test/releases"
+	"github.com/kubevirt/cluster-network-addons-operator/test/reporter"
 )
 
+var cnaoReporter *reporter.KubernetesCNAOReporter
+
 func TestE2E(t *testing.T) {
+	cnaoReporter = reporter.New("_out/e2e/lifecycle/", components.Namespace)
+	cnaoReporter.Cleanup()
+
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "lifecycle Test Suite")
 }
@@ -24,6 +32,13 @@ var _ = BeforeSuite(func() {
 	os.Chdir("../../../")
 
 	testenv.Start()
+})
+
+var _ = JustAfterEach(func() {
+	if CurrentSpecReport().Failed() {
+		failureCount := cnaoReporter.DumpLogs()
+		By(fmt.Sprintf("Test failed, collected logs and artifacts, failure count %d", failureCount))
+	}
 })
 
 var _ = AfterEach(func() {

--- a/test/reporter/reporter.go
+++ b/test/reporter/reporter.go
@@ -1,142 +1,28 @@
 package reporter
 
-import (
-	"fmt"
-	"io"
-	"io/ioutil"
-	"os"
-	"path"
-	"strings"
-	"sync"
-	"time"
-
-	"github.com/onsi/ginkgo/v2/config"
-	"github.com/onsi/ginkgo/v2/types"
-)
-
 type KubernetesCNAOReporter struct {
-	artifactsDir         string
-	namespace            string
-	previousDeviceStatus string
+	artifactsDir string
+	namespace    string
+	failureCount int
 }
 
-func New(artifactsDir string, namespace string) *KubernetesCNAOReporter {
+func New(artifactsDir, namespace string) *KubernetesCNAOReporter {
 	return &KubernetesCNAOReporter{
 		artifactsDir: artifactsDir,
 		namespace:    namespace,
+		failureCount: 0,
 	}
 }
 
-func (r *KubernetesCNAOReporter) SpecSuiteWillBegin(config config.GinkgoConfigType, summary *types.SuiteSummary) {
-}
+// DumpLogs saves the desired logs to files
+func (r *KubernetesCNAOReporter) DumpLogs() int {
+	r.failureCount++
+	r.logCommand([]string{"get", "all", "-A"}, "overview")
+	r.logCommand([]string{"get", "networkaddonsconfig", "cluster", "-n", r.namespace, "-o", "yaml"}, "networkaddonsconfig")
+	r.logCommand([]string{"get", "daemonset", "-n", r.namespace, "-o", "yaml"}, "daemonsets")
+	r.logCommand([]string{"get", "deployment", "-n", r.namespace, "-o", "yaml"}, "deployments")
+	r.logCommand([]string{"get", "pod", "-n", r.namespace, "-o", "yaml"}, "pods")
+	r.logNamespacePods()
 
-func (r *KubernetesCNAOReporter) BeforeSuiteDidRun(setupSummary *types.SetupSummary) {
-	r.Cleanup()
-}
-
-func (r *KubernetesCNAOReporter) SpecWillRun(specSummary *types.SpecSummary) {
-	if specSummary.Skipped() || specSummary.Pending() {
-		return
-	}
-
-	r.storeStateBeforeEach()
-}
-func (r *KubernetesCNAOReporter) SpecDidComplete(specSummary *types.SpecSummary) {
-	if specSummary.Skipped() || specSummary.Pending() {
-		return
-	}
-
-	since := time.Now().Add(-specSummary.RunTime).Add(-5 * time.Second)
-	name := strings.Join(specSummary.ComponentTexts[1:], " ")
-	passed := specSummary.Passed()
-
-	r.dumpStateAfterEach(name, since, passed)
-}
-
-func (r *KubernetesCNAOReporter) AfterSuiteDidRun(setupSummary *types.SetupSummary) {
-}
-
-func (r *KubernetesCNAOReporter) SpecSuiteDidEnd(summary *types.SuiteSummary) {
-}
-
-func (r *KubernetesCNAOReporter) storeStateBeforeEach() {
-}
-
-func runAndWait(funcs ...func()) {
-	var wg sync.WaitGroup
-	wg.Add(len(funcs))
-	for _, f := range funcs {
-		// You have to pass f to the goroutine, it's going to change
-		// at the next loop iteration.
-		go func(rf func()) {
-			rf()
-			wg.Done()
-		}(f)
-	}
-	wg.Wait()
-}
-
-func (r *KubernetesCNAOReporter) dumpStateAfterEach(testName string, testStartTime time.Time, passed bool) {
-	if passed {
-		return
-	}
-	runAndWait(
-		func() { r.logPods(testName, testStartTime) },
-	)
-}
-
-// Cleanup cleans up the current content of the artifactsDir
-func (r *KubernetesCNAOReporter) Cleanup() {
-	// clean up artifacts from previous run
-	if r.artifactsDir != "" {
-		_, err := os.Stat(r.artifactsDir)
-		if err != nil {
-			if os.IsNotExist(err) {
-				return
-			} else {
-				panic(err)
-			}
-		}
-		names, err := ioutil.ReadDir(r.artifactsDir)
-		if err != nil {
-			panic(err)
-		}
-		for _, entery := range names {
-			os.RemoveAll(path.Join([]string{r.artifactsDir, entery.Name()}...))
-		}
-	}
-}
-
-func (r *KubernetesCNAOReporter) logPods(testName string, sinceTime time.Time) error {
-
-	// Let's print the pods logs to the GinkgoWriter so
-	// we see the failure directly at prow junit output without opening files
-	r.OpenTestLogFile("pods", testName, podLogsWriter(r.namespace, sinceTime))
-
-	return nil
-}
-
-func (r *KubernetesCNAOReporter) OpenTestLogFile(logType string, testName string, cb func(f io.Writer), extraWriters ...io.Writer) {
-	err := os.MkdirAll(r.artifactsDir, 0755)
-	if err != nil {
-		fmt.Println(err)
-		return
-	}
-
-	name := fmt.Sprintf("%s/%s_%s.log", r.artifactsDir, testName, logType)
-	fi, err := os.OpenFile(name, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0644)
-	if err != nil {
-		fmt.Println(err)
-		return
-	}
-	defer func() {
-		if err := fi.Close(); err != nil {
-			fmt.Println(err)
-		}
-	}()
-	writers := []io.Writer{fi}
-	if len(extraWriters) > 0 {
-		writers = append(writers, extraWriters...)
-	}
-	cb(io.MultiWriter(writers...))
+	return r.failureCount
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently when a test fails on CNAO main lanes, the logs are printed to the screen, which makes it hard to debug. Moreover, there is no guarantee that the cleanup hasn't already commenced - giving a false picture of the cluster when the test failed.
Refactor the reporter to write the logs to files.
Refactor to use ginkgo's JustAfterEach to ensure that the cleanup is not yet started.

**Special notes for your reviewer**:
Examples of artifacts collected using this change:
- [lifecycle lane](https://gcsweb.ci.kubevirt.io/gcs/kubevirt-prow/pr-logs/pull/kubevirt_cluster-network-addons-operator/2168/pull-e2e-cluster-network-addons-operator-lifecycle-k8s/1904825531044466688/artifacts/)
- [workflow lane](https://gcsweb.ci.kubevirt.io/gcs/kubevirt-prow/pr-logs/pull/kubevirt_cluster-network-addons-operator/2168/pull-e2e-cluster-network-addons-operator-workflow-k8s/1904825531161907200/artifacts/)

**Release note**:
```release-note
NONE
```
