### PR TITLE
e2e/check: Verify Deamonset, Deployment removal

### DIFF
--- a/test/check/check.go
+++ b/test/check/check.go
@@ -374,6 +374,14 @@ func checkForComponentRemoval(component *Component) error {
 		errsAppend(checkForSecurityContextConstraintsRemoval(component.SecurityContextConstraints))
 	}
 
+	for _, daemonSet := range component.DaemonSets {
+		errsAppend(checkForDaemonSetRemoval(daemonSet))
+	}
+
+	for _, deployment := range component.Deployments {
+		errsAppend(checkForDeploymentRemoval(deployment))
+	}
+
 	if component.Secret != "" {
 		errsAppend(checkForSecretRemoval(component.Secret))
 	}
@@ -705,6 +713,16 @@ func checkForSecurityContextConstraintsRemoval(name string) error {
 		return nil
 	}
 	return isNotFound("SecurityContextConstraints", name, err)
+}
+
+func checkForDaemonSetRemoval(name string) error {
+	err := testenv.Client.Get(context.Background(), types.NamespacedName{Name: name, Namespace: components.Namespace}, &appsv1.DaemonSet{})
+	return isNotFound("DaemonSets", name, err)
+}
+
+func checkForDeploymentRemoval(name string) error {
+	err := testenv.Client.Get(context.Background(), types.NamespacedName{Name: name, Namespace: components.Namespace}, &appsv1.Deployment{})
+	return isNotFound("Deployments", name, err)
 }
 
 func checkForSecretRemoval(name string) error {


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently e2e checkForComponentRemoval does not check removal of deployments and Daemonsets. This can cause cross-talk noise between tests, especially in workflow and lifecycle lanes.

This PR is adding checks that Daemonset and Deployments are removed.

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
