### PR TITLE
e2e/workflow: Fix race waiting for components

### DIFF
--- a/test/e2e/workflow/deployment_test.go
+++ b/test/e2e/workflow/deployment_test.go
@@ -468,6 +468,7 @@ func testConfigUpdate(gvk schema.GroupVersionKind, configSpec cnao.NetworkAddons
 // available on operator-sdk test framework:
 // https://github.com/operator-framework/operator-sdk/issues/2655
 func checkConfigChange(gvk schema.GroupVersionKind, components []Component, while func()) {
+	conditionTimestampsBeforeChange := CaptureConditionTimestamps(gvk)
 
 	// Start the function with a little delay to give the Progressing check a better chance
 	// of catching the event
@@ -479,13 +480,13 @@ func checkConfigChange(gvk schema.GroupVersionKind, components []Component, whil
 	if len(components) == 0 {
 		// Wait until Available condition is reported. Should be fast when no components are
 		// being deployed
-		CheckConfigCondition(gvk, ConditionAvailable, ConditionTrue, 5*time.Minute, CheckDoNotRepeat)
+		CheckConfigConditionChangedAfter(gvk, ConditionAvailable, ConditionTrue, conditionTimestampsBeforeChange, 5*time.Minute, CheckDoNotRepeat)
 	} else {
 		CheckConfigComponents(gvk, components)
 		// Wait until Available condition is reported. It may take a few minutes the first time
 		// we are pulling component images to the Node
-		CheckConfigCondition(gvk, ConditionAvailable, ConditionTrue, 15*time.Minute, CheckDoNotRepeat)
-		CheckConfigCondition(gvk, ConditionProgressing, ConditionFalse, CheckImmediately, CheckDoNotRepeat)
+		CheckConfigConditionChangedAfter(gvk, ConditionAvailable, ConditionTrue, conditionTimestampsBeforeChange, 15*time.Minute, CheckDoNotRepeat)
+		CheckConfigConditionChangedAfter(gvk, ConditionProgressing, ConditionFalse, conditionTimestampsBeforeChange, CheckImmediately, CheckDoNotRepeat)
 
 		// Check that all requested components have been deployed
 		CheckComponentsDeployment(components)

--- a/test/e2e/workflow/deployment_test.go
+++ b/test/e2e/workflow/deployment_test.go
@@ -129,48 +129,48 @@ var _ = Describe("NetworkAddonsConfig", func() {
 			configSpec := cnao.NetworkAddonsConfigSpec{}
 			components := []Component{}
 
-			// Deploy initial empty config
+			By("Deploy initial empty config")
 			testConfigCreate(gvk, configSpec, components)
 
-			// Deploy Multus component
+			By("Add Multus component")
 			configSpec.Multus = &cnao.Multus{}
 			components = append(components, MultusComponent)
 			testConfigUpdate(gvk, configSpec, components)
 			CheckModifiedEvent(gvk)
 			CheckProgressingEvent(gvk)
 
-			// Add Linux bridge component
+			By("Add Linux-bridge component")
 			configSpec.LinuxBridge = &cnao.LinuxBridge{}
 			components = append(components, LinuxBridgeComponent)
 			testConfigUpdate(gvk, configSpec, components)
 
-			// Add KubeMacPool component
+			By("Add KubeMacPool component")
 			configSpec.KubeMacPool = &cnao.KubeMacPool{}
 			components = append(components, KubeMacPoolComponent)
 			testConfigUpdate(gvk, configSpec, components)
 
-			// Add Ovs component
+			By("Add OVS-CNI component")
 			configSpec.Ovs = &cnao.Ovs{}
 			components = append(components, OvsComponent)
 			testConfigUpdate(gvk, configSpec, components)
 
-			// Add Macvtap component
+			By("Add Macvtap component")
 			configSpec.MacvtapCni = &cnao.MacvtapCni{}
 			components = append(components, MacvtapComponent)
 			testConfigUpdate(gvk, configSpec, components)
 
-			// Add Multus Dynamic Networks component (requires multus ...)
+			By("Add Multus Dynamic Networks component (requires multus ...)")
 			configSpec.Multus = &cnao.Multus{}
 			configSpec.MultusDynamicNetworks = &cnao.MultusDynamicNetworks{}
 			components = append(components, MultusComponent, MultusDynamicNetworks)
 			testConfigUpdate(gvk, configSpec, components)
 
-			// Add KubeSecondaryDNS component
+			By("Add KubeSecondaryDNS component")
 			configSpec.KubeSecondaryDNS = &cnao.KubeSecondaryDNS{}
 			components = append(components, KubeSecondaryDNSComponent)
 			testConfigUpdate(gvk, configSpec, components)
 
-			// Add KubevirtIpamController component
+			By("Add KubevirtIpamController component")
 			configSpec.KubevirtIpamController = &cnao.KubevirtIpamController{}
 			components = append(components, KubevirtIpamController)
 			testConfigUpdate(gvk, configSpec, components)

--- a/test/e2e/workflow/deployment_test.go
+++ b/test/e2e/workflow/deployment_test.go
@@ -481,8 +481,7 @@ func checkConfigChange(gvk schema.GroupVersionKind, components []Component, whil
 		// being deployed
 		CheckConfigCondition(gvk, ConditionAvailable, ConditionTrue, 5*time.Minute, CheckDoNotRepeat)
 	} else {
-		// If there are any components to deploy wait until Progressing condition is reported
-		CheckConfigCondition(gvk, ConditionProgressing, ConditionTrue, 5*time.Minute, CheckDoNotRepeat)
+		CheckConfigComponents(gvk, components)
 		// Wait until Available condition is reported. It may take a few minutes the first time
 		// we are pulling component images to the Node
 		CheckConfigCondition(gvk, ConditionAvailable, ConditionTrue, 15*time.Minute, CheckDoNotRepeat)


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently checkConfigChange waiting on the transient status condition of
the CNAO CR, in order to make sure that the component is properly
deployed.
This is raceful by design, as if the component deployment moved "too
fast" to ConditionProgressing=TRUE then the test will fail.
Also, there is another race where the Available condition might change before the operator changed the status to in progress. 

This PR is changing the test to fix these two races.

**Special notes for your reviewer**:
Fix #626

**Release note**:

```release-note
NONE
```
