### PR TITLE
gitActions, bumper: Remove unsupported branches

### DIFF
--- a/.github/workflows/component-bumper.yaml
+++ b/.github/workflows/component-bumper.yaml
@@ -14,10 +14,7 @@ jobs:
       matrix:
         branch:
           - main
-          - release-0.65
-          - release-0.76
           - release-0.79
-          - release-0.85
           - release-0.89
           - release-0.91
           - release-0.93


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR removes unsupported branches from the auto bumper gitActions.

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
