### PR TITLE
Bump kubevirtci to use a tag with multi-architecture support

### DIFF
--- a/cluster/cluster.sh
+++ b/cluster/cluster.sh
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 export KUBEVIRT_PROVIDER=${KUBEVIRT_PROVIDER:-'k8s-1.30'}
-export KUBEVIRTCI_TAG=${KUBEVIRTCI_TAG:-2503111657-1a9278ce}
+export KUBEVIRTCI_TAG=${KUBEVIRTCI_TAG:-2503281142-a291de27}
 
 KUBEVIRTCI_REPO='https://github.com/kubevirt/kubevirtci.git'
 # The CLUSTER_PATH var is used in cluster folder and points to the _kubevirtci where the cluster is deployed from.


### PR DESCRIPTION
**What this PR does / why we need it**:

 updating the KubeVirt CI tags to the latest version: [KubeVirt CI Tags](https://github.com/kubevirt/kubevirtci/tags).

The latest tag, 2503281142-a291de27, is now multi-architecture supported(We can't create kubevirtci cluster other than amd64 platform with existing tag(https://github.com/ashokpariya0/cluster-network-addons-operator/blob/2edc8b58f002438464e33576454b229d7bd6d5ea/cluster/cluster.sh#L16)), and you can find more details here: [KubeVirt CI Multi-Arch Tag](https://quay.io/repository/kubevirtci/gocli?tab=tags&tag=latest).


**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
None
```
