### PR TITLE
e2e, reporter: Enhance debugging logs

### DIFF
--- a/test/reporter/reporter.go
+++ b/test/reporter/reporter.go
@@ -22,6 +22,9 @@ func (r *KubernetesCNAOReporter) DumpLogs() int {
 	r.logCommand([]string{"get", "daemonset", "-n", r.namespace, "-o", "yaml"}, "daemonsets")
 	r.logCommand([]string{"get", "deployment", "-n", r.namespace, "-o", "yaml"}, "deployments")
 	r.logCommand([]string{"get", "pod", "-n", r.namespace, "-o", "yaml"}, "pods")
+	r.logCommand([]string{"get", "clusterrole", "-n", r.namespace, "-o", "yaml"}, "clusterroles")
+	r.logCommand([]string{"get", "role", "-n", r.namespace, "-o", "yaml"}, "roles")
+	r.logCommand([]string{"get", "clusterrolebinding", "-n", r.namespace, "-o", "yaml"}, "clusterrolebindings")
 	r.logNamespacePods()
 
 	return r.failureCount

--- a/test/reporter/writers.go
+++ b/test/reporter/writers.go
@@ -69,6 +69,9 @@ func (r *KubernetesCNAOReporter) logNamespacePods() {
 			if _, _, err := kubectl.Kubectl(argsPrev...); err != nil {
 				r.logCommand(argsPrev, "prev_"+podName+"_"+containerName)
 			}
+
+			args = []string{"get", "events", "-n", r.namespace, "--field-selector", "involvedObject.kind=Pod,involvedObject.name=" + podName}
+			r.logCommand(args, podName+"_events")
 		}
 	}
 }

--- a/test/reporter/writers.go
+++ b/test/reporter/writers.go
@@ -62,7 +62,13 @@ func (r *KubernetesCNAOReporter) logNamespacePods() {
 		}
 		podContainers = strings.Trim(podContainers, "'")
 		for _, containerName := range strings.Split(podContainers, " ") {
-			r.logCommand([]string{"logs", "-n", r.namespace, podName, "-c", containerName}, podName+"_"+containerName)
+			args = []string{"logs", "-n", r.namespace, podName, "-c", containerName}
+			r.logCommand(args, podName+"_"+containerName)
+
+			argsPrev := append(args, "-p")
+			if _, _, err := kubectl.Kubectl(argsPrev...); err != nil {
+				r.logCommand(argsPrev, "prev_"+podName+"_"+containerName)
+			}
 		}
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds more logs when an e2e test fails. These will assist in future debugging.

Example [artifacts](https://gcsweb.ci.kubevirt.io/gcs/kubevirt-prow/pr-logs/pull/kubevirt_cluster-network-addons-operator/2230/pull-e2e-cluster-network-addons-operator-workflow-k8s/1909193081664573440/artifacts/)

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
