### PR TITLE
Update lifecycle release selector for s390x

### DIFF
--- a/automation/check-patch.e2e-lifecycle-k8s.sh
+++ b/automation/check-patch.e2e-lifecycle-k8s.sh
@@ -28,7 +28,14 @@ main() {
         export E2E_TEST_TIMEOUT=4h
     else
         # Don't run all upgrade tests in regular PRs, stick to those released under HCO
-        export RELEASES_SELECTOR="{0.89.3,0.91.1,0.93.0,0.95.0,99.0.0}"
+        case "$(go env GOARCH)" in
+            s390x)
+                export RELEASES_SELECTOR="{0.98.2,99.0.0}"
+                ;;
+            *)
+                export RELEASES_SELECTOR="{0.89.3,0.91.1,0.93.0,0.95.0,99.0.0}"
+                ;;
+        esac
     fi
 
     make cluster-down

--- a/automation/check-patch.e2e-lifecycle-k8s.sh
+++ b/automation/check-patch.e2e-lifecycle-k8s.sh
@@ -30,7 +30,7 @@ main() {
         # Don't run all upgrade tests in regular PRs, stick to those released under HCO
         case "$(go env GOARCH)" in
             s390x)
-                export RELEASES_SELECTOR="{0.98.2,99.0.0}"
+                export RELEASES_SELECTOR="{0.99.0,99.0.0}"
                 ;;
             *)
                 export RELEASES_SELECTOR="{0.89.3,0.91.1,0.93.0,0.95.0,99.0.0}"

--- a/test/e2e/lifecycle/upgrade_test.go
+++ b/test/e2e/lifecycle/upgrade_test.go
@@ -15,7 +15,7 @@ import (
 const podsDeploymentTimeout = 20 * time.Minute
 
 // CNAO supports multiarch from this release
-const multiArchStartRelease = "0.98.2"
+const multiArchRelease = "0.99.0"
 
 var _ = Context("Cluster Network Addons Operator", func() {
 	testUpgrade := func(oldRelease, newRelease Release) {
@@ -92,7 +92,7 @@ var _ = Context("Cluster Network Addons Operator", func() {
 	start := 0
 	if runtime.GOARCH == "s390x" {
 		for index, release := range releases {
-			if release.Version == multiArchStartRelease {
+			if release.Version == multiArchRelease {
 				start = index
 				break
 			}

--- a/test/e2e/lifecycle/upgrade_test.go
+++ b/test/e2e/lifecycle/upgrade_test.go
@@ -2,6 +2,7 @@ package test
 
 import (
 	"fmt"
+	"runtime"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -12,6 +13,9 @@ import (
 )
 
 const podsDeploymentTimeout = 20 * time.Minute
+
+// CNAO supports multiarch from this release
+const multiArchStartRelease = "0.98.2"
 
 var _ = Context("Cluster Network Addons Operator", func() {
 	testUpgrade := func(oldRelease, newRelease Release) {
@@ -84,7 +88,18 @@ var _ = Context("Cluster Network Addons Operator", func() {
 
 	// Run tests upgrading from each released version to the latest/main
 	releases := Releases()
-	for _, oldRelease := range releases[:len(releases)-1] {
+
+	start := 0
+	if runtime.GOARCH == "s390x" {
+		for index, release := range releases {
+			if release.Version == multiArchStartRelease {
+				start = index
+				break
+			}
+		}
+	}
+
+	for _, oldRelease := range releases[start : len(releases)-1] {
 		testUpgrade(oldRelease, LatestRelease())
 	}
 })


### PR DESCRIPTION
**What this PR does / why we need it**:

Full support for the s390x architecture is available starting from CNAO v0.98.2. 

This pull request updates the lifecycle CI pipeline and end-to-end test configurations to use v0.98.2 as the starting version for s390x, so that tests can run successfully. These changes help improve compatibility for the s390x architecture.


**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
