### PR TITLE
tests: Check for configMap deploy and removal

### DIFF
--- a/test/check/check.go
+++ b/test/check/check.go
@@ -478,6 +478,10 @@ func checkForComponent(component *Component) error {
 		errsAppend(checkForNetworkAttachmentDefinition(component.NetworkAttachmentDefinition))
 	}
 
+	if component.ConfigMap != "" {
+		errsAppend(checkForConfigMap(component.ConfigMap))
+	}
+
 	return errsToErr(errs)
 }
 
@@ -531,6 +535,10 @@ func checkForComponentRemoval(component *Component) error {
 
 	if component.NetworkAttachmentDefinition != "" {
 		errsAppend(checkForNetworkAttachmentDefinitionRemoval(component.NetworkAttachmentDefinition))
+	}
+
+	if component.ConfigMap != "" {
+		errsAppend(checkForConfigMapRemoval(component.ConfigMap))
 	}
 
 	return errsToErr(errs)
@@ -801,6 +809,21 @@ func checkForNetworkAttachmentDefinition(name string) error {
 	}
 
 	err = checkRelationshipLabels(networkAttachmentDefinition.GetLabels(), "NetworkAttachmentDefinition", name)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func checkForConfigMap(name string) error {
+	configMap := corev1.ConfigMap{}
+	err := testenv.Client.Get(context.Background(), types.NamespacedName{Name: name, Namespace: components.Namespace}, &configMap)
+	if err != nil {
+		return err
+	}
+
+	err = checkRelationshipLabels(configMap.GetLabels(), "ConfigMap", name)
 	if err != nil {
 		return err
 	}

--- a/test/check/check.go
+++ b/test/check/check.go
@@ -73,6 +73,11 @@ func CheckComponentsRemoval(components []Component) {
 			return checkForComponentRemoval(&component)
 		}, 5*time.Minute, time.Second).ShouldNot(HaveOccurred(), fmt.Sprintf("%s component has not been fully removed within the given timeout", component.ComponentName))
 	}
+
+	By(fmt.Sprintf("Checking the %s configmap has been removed", names.AppliedPrefix+names.OperatorConfig))
+	Eventually(func() error {
+		return checkForConfigMapRemoval(names.AppliedPrefix + names.OperatorConfig)
+	}, 5*time.Minute, time.Second).Should(Succeed())
 }
 
 func getConfigComponentsMap(gvk schema.GroupVersionKind) (map[string]struct{}, error) {
@@ -878,6 +883,11 @@ func checkForNetworkAttachmentDefinitionRemoval(name string) error {
 		return nil
 	}
 	return isNotFound("NetworkAttachmentDefinition", name, err)
+}
+
+func checkForConfigMapRemoval(name string) error {
+	err := testenv.Client.Get(context.Background(), types.NamespacedName{Name: name, Namespace: components.Namespace}, &corev1.ConfigMap{})
+	return isNotFound("ConfigMap", name, err)
 }
 
 func getMonitoringEndpoint() (*corev1.Endpoints, error) {

--- a/test/check/components.go
+++ b/test/check/components.go
@@ -21,6 +21,7 @@ type Component struct {
 	ServiceMonitor               string
 	PrometheusRule               string
 	NetworkAttachmentDefinition  string
+	ConfigMap                    string
 }
 
 var (
@@ -30,6 +31,7 @@ var (
 		ClusterRoleBinding:           "kubemacpool-manager-rolebinding",
 		Deployments:                  []string{"kubemacpool-mac-controller-manager", "kubemacpool-cert-manager"},
 		MutatingWebhookConfiguration: "kubemacpool-mutator",
+		ConfigMap:                    "kubemacpool-mac-range-config",
 	}
 	LinuxBridgeComponent = Component{
 		ComponentName:              "Linux Bridge",


### PR DESCRIPTION
**What this PR does / why we need it**:
When running a CNAO CR, CNAO creates a prev config of the last applied configuration, in order to ensure persistent reconfiguration in case a re-install took place on an existing CR. For example, if kubemacpool was redeployed, it will remember the ranges.

This however creates a test race when checking that removing the CNAO CR recreates the kubemacpool ranges when redeployed after CR deletion. 

This PR is adding a check to ensure the configmap was removed after CR deletion, in order to fix this race.

**Special notes for your reviewer**:
Fix #2202 

**Release note**:

```release-note
NONE
```
