### PR TITLE
Fix nightly build

### DIFF
--- a/automation/test-nightly-build.sh
+++ b/automation/test-nightly-build.sh
@@ -42,11 +42,11 @@ main() {
     CNAO_VERSION=$(hack/version.sh)
     SRC_DIR="./_out/cluster-network-addons/${CNAO_VERSION}"
     DEST="gs://${cnao_bucket}/${build_date}"
-    gsutil cp "${SRC_DIR}/namespace.yaml" "${DEST}"
-    gsutil cp "${SRC_DIR}/cluster-network-addons-operator.${CNAO_VERSION}.clusterserviceversion.yaml" "${DEST}"
-    gsutil cp "${SRC_DIR}/network-addons-config.crd.yaml" "${DEST}"
-    gsutil cp "${SRC_DIR}/operator.yaml" "${DEST}"
-    gsutil cp "${SRC_DIR}/network-addons-config-example.cr.yaml" "${DEST}"
+    gsutil cp "${SRC_DIR}/namespace.yaml" "${DEST}/namespace.yaml"
+    gsutil cp "${SRC_DIR}/cluster-network-addons-operator.${CNAO_VERSION}.clusterserviceversion.yaml" "${DEST}/cluster-network-addons-operator.${CNAO_VERSION}.clusterserviceversion.yaml"
+    gsutil cp "${SRC_DIR}/network-addons-config.crd.yaml" "${DEST}/network-addons-config.crd.yaml"
+    gsutil cp "${SRC_DIR}/operator.yaml" "${DEST}/operator.yaml"
+    gsutil cp "${SRC_DIR}/network-addons-config-example.cr.yaml" "${DEST}/network-addons-config-example.cr.yaml"
 }
 
 main

--- a/automation/test-nightly-build.sh
+++ b/automation/test-nightly-build.sh
@@ -35,9 +35,6 @@ main() {
     # functional test passed: publish latest nightly build
     cnao_bucket="kubevirt-prow/devel/nightly/release/kubevirt/cluster-network-addons-operator"
 
-    echo "${build_date}" > build-date
-    gsutil cp ./build-date gs://${cnao_bucket}/latest
-
     # publish the nightly build manifests
     CNAO_VERSION=$(hack/version.sh)
     SRC_DIR="./_out/cluster-network-addons/${CNAO_VERSION}"
@@ -47,6 +44,9 @@ main() {
     gsutil cp "${SRC_DIR}/network-addons-config.crd.yaml" "${DEST}/network-addons-config.crd.yaml"
     gsutil cp "${SRC_DIR}/operator.yaml" "${DEST}/operator.yaml"
     gsutil cp "${SRC_DIR}/network-addons-config-example.cr.yaml" "${DEST}/network-addons-config-example.cr.yaml"
+
+    echo "${build_date}" > build-date
+    gsutil cp ./build-date gs://${cnao_bucket}/latest
 }
 
 main


### PR DESCRIPTION
**What this PR does / why we need it**:
At the end of the nightly build, the automation/test-nightly-build.sh script copies the artifact files to a gcp bucket using the gsutil. The script, as currently implemented, copies the files to the a file named the build date, overriding the last copied file, instaed of to a directory with the name of the build date.

e.g.
```shell
curl https://storage.googleapis.com/kubevirt-prow/devel/nightly/release/kubevirt/cluster-network-addons-operator/20250502
```
returns the network-addons-config-example.cr.yaml file, while
```shell
curl https://storage.googleapis.com/kubevirt-prow/devel/nightly/release/kubevirt/cluster-network-addons-operator/20250502/network-addons-config-example.cr.yaml
```
returns 404.

And all the other files are not there, because they were overrode by the last copied file.

This PR fixes the `gsutil cp` command to work as expected.

In addition, the PR overrides the ["latest" file](https://storage.googleapis.com/kubevirt-prow/devel/nightly/release/kubevirt/cluster-network-addons-operator/latest), only if all the artifacts were copied to the new bucket, successfully.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
None
```
