### PR TITLE
Nightly build: publish the commit file

### DIFF
--- a/automation/test-nightly-build.sh
+++ b/automation/test-nightly-build.sh
@@ -45,6 +45,9 @@ main() {
     gsutil cp "${SRC_DIR}/operator.yaml" "${DEST}/operator.yaml"
     gsutil cp "${SRC_DIR}/network-addons-config-example.cr.yaml" "${DEST}/network-addons-config-example.cr.yaml"
 
+    git show -s --format=%H > .${SRC_DIR}/commit
+    gsutil cp ${SRC_DIR}/commit "${DEST}/commit"
+
     echo "${build_date}" > build-date
     gsutil cp ./build-date gs://${cnao_bucket}/latest
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
On nightly build, create and publish the `commit` file, with the current git commit.

This will allow linking the specific build with the corresponding commit.

**Release note**:
```release-note
None
```
