### PR TITLE
fix the test-nightly-build.sh script

### DIFF
--- a/automation/test-nightly-build.sh
+++ b/automation/test-nightly-build.sh
@@ -45,7 +45,7 @@ main() {
     gsutil cp "${SRC_DIR}/operator.yaml" "${DEST}/operator.yaml"
     gsutil cp "${SRC_DIR}/network-addons-config-example.cr.yaml" "${DEST}/network-addons-config-example.cr.yaml"
 
-    git show -s --format=%H > .${SRC_DIR}/commit
+    git show -s --format=%H > ${SRC_DIR}/commit
     gsutil cp ${SRC_DIR}/commit "${DEST}/commit"
 
     echo "${build_date}" > build-date


### PR DESCRIPTION
**What this PR does / why we need it**:
The script failed because of a redundent characture '.' (a leftover).

This PR removes the redundent characture.

**Release note**:

```release-note
None
```
