### PR TITLE
Set container's TerminationMessagePolicy to FallbackToLogsOnError

### DIFF
--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -308,6 +308,7 @@ func GetDeployment(version string, operatorVersion string, namespace string, rep
 									Drop: []corev1.Capability{corev1.Capability("ALL")},
 								},
 							},
+							TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
 						},
 						{
 							Name:            "kube-rbac-proxy",


### PR DESCRIPTION
**What this PR does / why we need it**:
To comply with best practices, all the containers in all the pods, must set the TerminationMessagePolicy field to FallbackToLogsOnError [0]

[0]
https://github.com/redhat-best-practices-for-k8s/certsuite/blob/main/CATALOG.md#observability-termination-policy

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
