### PR TITLE
nightly: login to quay.io

### DIFF
--- a/automation/test-nightly-build.sh
+++ b/automation/test-nightly-build.sh
@@ -13,6 +13,10 @@ teardown() {
 }
 
 main() {
+    source hack/components/docker-utils.sh
+    export OCI_BIN=${OCI_BIN:-$(docker-utils::determine_cri_bin)}
+    cat "${QUAY_PASSWORD}" | ${OCI_BIN} login --username $(cat "${QUAY_USER}") --password-stdin=true quay.io
+
     source automation/check-patch.setup.sh
     cd ${TMP_PROJECT_PATH}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
The nightly build fails to push images to quay.io

login to quay.io before trying to push the image.

**Release note**:
```release-note
None
```
