### PR TITLE
Linux-bridge: Set container's TerminationMessagePolicy to FallbackToLogsOnError

### DIFF
--- a/data/linux-bridge/002-linux-bridge.yaml
+++ b/data/linux-bridge/002-linux-bridge.yaml
@@ -72,6 +72,7 @@ spec:
           volumeMounts:
             - name: cnibin
               mountPath: /opt/cni/bin
+          terminationMessagePolicy: FallbackToLogsOnError
       volumes:
         - name: cnibin
           hostPath:


### PR DESCRIPTION
**What this PR does / why we need it**:
To comply with best practices, all the containers in all the linux-bridge pods, must set the TerminationMessagePolicy field to FallbackToLogsOnError [0]

[0]
https://github.com/redhat-best-practices-for-k8s/certsuite/blob/main/CATALOG.md#observability-termination-policy

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
