### PR TITLE
components: Bump kubemacpool to v0.47.0

### DIFF
--- a/components.yaml
+++ b/components.yaml
@@ -16,7 +16,7 @@ components:
     commit: c22fe1e9b2ef6dce61f82a2148519a51673c937c
     branch: main
     update-policy: latest
-    metadata: v0.46.0-16-gc22fe1e
+    metadata: v0.47.0
   kubevirt-ipam-controller:
     url: https://github.com/kubevirt/ipam-extensions
     commit: 60d7be853bd9b003dd4ad608735f6dbc9662d98e

--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -34,7 +34,7 @@ const (
 	MultusDynamicNetworksImageDefault  = "ghcr.io/k8snetworkplumbingwg/multus-dynamic-networks-controller@sha256:8061bd1276ff022fe52a0b07bc6fa8d27e5f6f20cf3bf764e76d347d2e3c929b"
 	LinuxBridgeCniImageDefault         = "quay.io/kubevirt/cni-default-plugins@sha256:976a24392c2a096c38c2663d234b2d3131f5c24558889196d30b9ac1b6716788"
 	LinuxBridgeMarkerImageDefault      = "quay.io/kubevirt/bridge-marker@sha256:bf269af61e618857e7b14439cfc003aac2d65db9ee633147a73f5d9648dab377"
-	KubeMacPoolImageDefault            = "quay.io/kubevirt/kubemacpool@sha256:2c602a112411b639f01535f05df4dd977969065f7dbd71821694e81fa617a537"
+	KubeMacPoolImageDefault            = "quay.io/kubevirt/kubemacpool@sha256:1cccec2d349be74a6c089f8331c46eb0a6adcf53437ae709f142f07fb3617515"
 	OvsCniImageDefault                 = "ghcr.io/k8snetworkplumbingwg/ovs-cni-plugin@sha256:daffd23fd96806298ea1dbe642418d02147b361fb5648303cd9e0c9568975800"
 	MacvtapCniImageDefault             = "quay.io/kubevirt/macvtap-cni@sha256:10e631dea111c070e67b03ab1fdd5563eb95fb3f14959ffc66386cdf215133c9"
 	KubeRbacProxyImageDefault          = "quay.io/brancz/kube-rbac-proxy@sha256:e6a323504999b2a4d2a6bf94f8580a050378eba0900fd31335cf9df5787d9a9b"

--- a/test/releases/99.0.0.go
+++ b/test/releases/99.0.0.go
@@ -42,7 +42,7 @@ func init() {
 				ParentName: "kubemacpool-mac-controller-manager",
 				ParentKind: "Deployment",
 				Name:       "manager",
-				Image:      "quay.io/kubevirt/kubemacpool@sha256:2c602a112411b639f01535f05df4dd977969065f7dbd71821694e81fa617a537",
+				Image:      "quay.io/kubevirt/kubemacpool@sha256:1cccec2d349be74a6c089f8331c46eb0a6adcf53437ae709f142f07fb3617515",
 			},
 			{
 				ParentName: "kubemacpool-mac-controller-manager",
@@ -54,7 +54,7 @@ func init() {
 				ParentName: "kubemacpool-cert-manager",
 				ParentKind: "Deployment",
 				Name:       "manager",
-				Image:      "quay.io/kubevirt/kubemacpool@sha256:2c602a112411b639f01535f05df4dd977969065f7dbd71821694e81fa617a537",
+				Image:      "quay.io/kubevirt/kubemacpool@sha256:1cccec2d349be74a6c089f8331c46eb0a6adcf53437ae709f142f07fb3617515",
 			},
 			{
 				ParentName: "ovs-cni-amd64",


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR is a manual bump of KMP to [v0.47.0](https://github.com/k8snetworkplumbingwg/kubemacpool/releases/tag/v0.47.0)

**Special notes for your reviewer**:
PR is issued manually because auto bumper cannot  bump due to an open issue #2278 .


**Release note**:

```release-note
NONE
```
