### PR TITLE
automation/workflow: Pre-install kubevirt

### DIFF
--- a/automation/check-patch.e2e-workflow-k8s.sh
+++ b/automation/check-patch.e2e-workflow-k8s.sh
@@ -20,6 +20,8 @@ main() {
     make cluster-down
     make cluster-up
     trap teardown EXIT SIGINT SIGTERM SIGSTOP
+
+    ./hack/deploy-kubevirt.sh
     make cluster-operator-push
     make cluster-operator-install
     make E2E_TEST_EXTRA_ARGS="-ginkgo.noColor --ginkgo.junit-report=$ARTIFACTS/junit.functest.xml" test/e2e/workflow


### PR DESCRIPTION
**What this PR does / why we need it**:
Some of the components deployed in the deployments e2e test require kubevirt (ipam-ext, ksd, kubemacpool). Without it, they may restart, causing instability in the networkAddonsConfig CR status.
This PR is deploying kubevirt as a pre-step to the workflow automation in order to provide stability in the e2e runs.

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
