### PR TITLE
[release-0.99] Follow kubemacpool stable branch

### DIFF
--- a/components.yaml
+++ b/components.yaml
@@ -14,8 +14,8 @@ components:
   kubemacpool:
     url: https://github.com/k8snetworkplumbingwg/kubemacpool
     commit: c22fe1e9b2ef6dce61f82a2148519a51673c937c
-    branch: main
-    update-policy: static
+    branch: release-0.47
+    update-policy: tagged
     metadata: v0.47.0
   kubevirt-ipam-controller:
     url: https://github.com/kubevirt/ipam-extensions


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR sets CNAO to follow KMP's stable branch [release-0.47](https://github.com/k8snetworkplumbingwg/kubemacpool/tree/release-0.47)

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
