### PR TITLE
Network policies

### DIFF
--- a/cluster/operator-install.sh
+++ b/cluster/operator-install.sh
@@ -24,3 +24,6 @@ if [[ ! $(./cluster/kubectl.sh -n cluster-network-addons wait deployment cluster
 	exit 1
 fi
 
+# Ensure the project network-polices are valid by installing an additional deny-all network policy affecting CNAO operator pods
+./hack/install-deny-all-net-pol.sh
+

--- a/hack/install-deny-all-net-pol.sh
+++ b/hack/install-deny-all-net-pol.sh
@@ -1,0 +1,38 @@
+#!/bin/bash -ex
+#
+# Copyright 2025 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# This script install deny-all NetworkPolicy that affects kubemacpool namespace.
+
+readonly ns="$(./cluster/kubectl.sh get pod -l name=cluster-network-addons-operator -A -o=custom-columns=NS:.metadata.namespace --no-headers | head -1)"
+[[ -z "${ns}" ]] && echo "FATAL: CNAO pods not found. Make sure CNAO is installed" && exit 1
+
+cat <<EOF | ./cluster/kubectl.sh -n "${ns}" apply -f -
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: deny-all
+spec:
+  podSelector:
+    # once all components provider network-policies this selection rule can be removed.
+    matchLabels:
+      name: cluster-network-addons-operator
+  policyTypes:
+  - Ingress
+  - Egress
+  ingress: []
+  egress: []
+EOF

--- a/pkg/components/clusterdns.go
+++ b/pkg/components/clusterdns.go
@@ -1,0 +1,11 @@
+package components
+
+// ClusterDNSPlacement describe the cluster DNS information, such as namespace and common label
+type ClusterDNSPlacement struct {
+	// Namespace is the Namespace name where cluster DNS endpoints reside.
+	Namespace string
+	// LabelKey is the cluster DNS pods label key that can be used by a label selector.
+	LabelKey string
+	// LabelValue is the cluster DNS pods label value that can be used by a label selector.
+	LabelValue string
+}

--- a/templates/cluster-network-addons/VERSION/operator.yaml.in
+++ b/templates/cluster-network-addons/VERSION/operator.yaml.in
@@ -36,3 +36,61 @@ subjects:
     name: cluster-network-addons-operator
 
 {{.CNA.Deployment}}
+
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: cnao-allow-egress-to-dns
+  namespace: {{.Namespace}}
+spec:
+  podSelector:
+    matchLabels:
+      name: cluster-network-addons-operator
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+      - namespaceSelector:
+          matchLabels:
+            kubernetes.io/metadata.name: {{ .ClusterDNSPlacement.Namespace }}
+        podSelector:
+          matchLabels:
+            {{ .ClusterDNSPlacement.LabelKey }}: {{ .ClusterDNSPlacement.LabelValue }}
+      ports:
+        - protocol: TCP
+          port: dns-tcp
+        - protocol: UDP
+          port: dns
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: cnao-allow-egress-to-api-server
+  namespace: {{.Namespace}}
+spec:
+  podSelector:
+    matchLabels:
+      name: cluster-network-addons-operator
+  policyTypes:
+    - Egress
+  egress:
+    - ports:
+        - protocol: TCP
+          port: 6443
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: cnao-allow-ingress-to-metrics-endpoint
+  namespace: {{.Namespace}}
+spec:
+  podSelector:
+    matchLabels:
+      name: cluster-network-addons-operator
+  policyTypes:
+    - Ingress
+  ingress:
+    - ports:
+        - protocol: TCP
+          port: metrics

--- a/tools/manifest-templator/manifest-templator.go
+++ b/tools/manifest-templator/manifest-templator.go
@@ -52,16 +52,17 @@ type operatorData struct {
 }
 
 type templateData struct {
-	Version         string
-	VersionReplaces string
-	OperatorVersion string
-	Namespace       string
-	ContainerPrefix string
-	ImageName       string
-	ContainerTag    string
-	ImagePullPolicy string
-	CNA             *operatorData
-	AddonsImages    *components.AddonsImages
+	Version             string
+	VersionReplaces     string
+	OperatorVersion     string
+	Namespace           string
+	ContainerPrefix     string
+	ImageName           string
+	ContainerTag        string
+	ImagePullPolicy     string
+	CNA                 *operatorData
+	AddonsImages        *components.AddonsImages
+	ClusterDNSPlacement components.ClusterDNSPlacement
 }
 
 func check(err error) {
@@ -254,6 +255,9 @@ func main() {
 	kubevirtIpamControllerImage := flag.String("kubevirt-ipam-controller-image", components.KubevirtIpamControllerImageDefault, "The kubevirtipamcontroller-image managed by CNA")
 	dumpOperatorCRD := flag.Bool("dump-crds", false, "Append operator CRD to bottom of template. Used for csv-generator")
 	inputFile := flag.String("input-file", "", "Not used for csv-generator")
+	clusterDNSNamespace := flag.String("cluster-dns-namespace", "kube-system", "The namespace name where the cluster DNS endpoint reside")
+	clusterDNSLabelKey := flag.String("cluster-dns-label-key", "k8s-app", "The cluster DNS pods labels key, which can be used by a label selector")
+	clusterDNSLabelValue := flag.String("cluster-dns-label-value", "kube-dns", "The cluster DNS pods labels value, which can be used by a label selector")
 	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
 	pflag.CommandLine.ParseErrorsWhitelist.UnknownFlags = true
 	pflag.Parse()
@@ -267,6 +271,11 @@ func main() {
 		ImageName:       *imageName,
 		ContainerTag:    *containerTag,
 		ImagePullPolicy: *imagePullPolicy,
+		ClusterDNSPlacement: components.ClusterDNSPlacement{
+			Namespace:  *clusterDNSNamespace,
+			LabelKey:   *clusterDNSLabelKey,
+			LabelValue: *clusterDNSLabelValue,
+		},
 		AddonsImages: (&components.AddonsImages{
 			Multus:                 *multusImage,
 			LinuxBridgeCni:         *linuxBridgeCniImage,


### PR DESCRIPTION
**What this PR does / why we need it**:
In a scenario where a cluster networking has been hardened and futures a default deny-all network policy that affects CNAO operator pods, it will not be able to operate properly.

This PR introduce network-policies for CNAO operator allowing it to operate, complying with restrictions in form of deny all network-policy.

**Special notes for your reviewer**:
In order to have coverage for the introduced network-policies, and additional deny-all network-policies is installed as part of the cluster-sync flow.
Having a deny-all network-policy installed, allow the introduced network-policies to be tested in a development and test environments, locally and CI.

Since not all CNAO component provide network-policy, the deny-all network policy is configured to affect CNAO operator pods only.
Once all relevant components provide network-policies, we can change the deny-all network-policy to affect all pods in CNAO namespace.
 
The following work will be done in follow-up PRs:
- Network-policies for CNAO components will be done in follow-up PRs, including kubemacpool, ~~kubesecondarydns~~ and kubvirt-ipam-controller.
- Adjust CNAO (operator) network-policies to support OCP.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
Introduce network-policies allowing CNAO to operate in restricted env
```