### PR TITLE
components,rbac: Grant permissions for r/w network-policies

### DIFF
--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -538,6 +538,23 @@ func GetRole(namespace string) *rbacv1.Role {
 					"delete",
 				},
 			},
+			{
+				APIGroups: []string{
+					"networking.k8s.io",
+				},
+				Resources: []string{
+					"networkpolicies",
+				},
+				Verbs: []string{
+					"get",
+					"list",
+					"watch",
+					"create",
+					"update",
+					"patch",
+					"delete",
+				},
+			},
 		},
 	}
 	return role


### PR DESCRIPTION
Enable CNAO create read/write NetwrokPolicy objects.

This permissions is require for CNAO to deploy the components network-policy objects.

<!-- Thanks for sending a pull request!

Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the main branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it

If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**What this PR does / why we need it**:
Enable CNAO create read/write NetwrokPolicy objects.

This permissions is require for CNAO to deploy the components
network-policy objects.

This PR changes should fix https://github.com/kubevirt/cluster-network-addons-operator/pull/2295 failures on CI, for example https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_cluster-network-addons-operator/2295/pull-e2e-cluster-network-addons-operator-br-marker-functests/1924377354927345664#1:build-log.txt%3A952

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
rbac: Allow read/write network-policy objects
```
