### PR TITLE
bump kubemacpool to v0.47.0-3-g5276a1c

### DIFF
--- a/components.yaml
+++ b/components.yaml
@@ -13,10 +13,10 @@ components:
     metadata: v0.0.18
   kubemacpool:
     url: https://github.com/k8snetworkplumbingwg/kubemacpool
-    commit: 64d4c3ba1efa2f01944e40043318ae89553d0366
+    commit: 5276a1c03e048bba842d576df4a29535373a0f75
     branch: main
     update-policy: latest
-    metadata: v0.47.0-2-g64d4c3b
+    metadata: v0.47.0-3-g5276a1c
   kubevirt-ipam-controller:
     url: https://github.com/kubevirt/ipam-extensions
     commit: 60d7be853bd9b003dd4ad608735f6dbc9662d98e

--- a/data/kubemacpool/kubemacpool.yaml
+++ b/data/kubemacpool/kubemacpool.yaml
@@ -374,6 +374,63 @@ spec:
         secret:
           secretName: kubemacpool-service
 ---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: kubemacpool-allow-egress-to-api-server
+  namespace: '{{ .Namespace }}'
+spec:
+  egress:
+  - ports:
+    - port: 6443
+      protocol: TCP
+  podSelector:
+    matchLabels:
+      app: kubemacpool
+  policyTypes:
+  - Egress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: kubemacpool-allow-egress-to-dns
+  namespace: '{{ .Namespace }}'
+spec:
+  egress:
+  - ports:
+    - port: dns-tcp
+      protocol: TCP
+    - port: dns
+      protocol: UDP
+    to:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: kube-system
+      podSelector:
+        matchLabels:
+          k8s-app: kube-dns
+  podSelector:
+    matchLabels:
+      app: kubemacpool
+  policyTypes:
+  - Egress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: kubemacpool-allow-ingress-to-kubemacpool-service
+  namespace: '{{ .Namespace }}'
+spec:
+  ingress:
+  - ports:
+    - port: 8000
+      protocol: TCP
+  podSelector:
+    matchLabels:
+      control-plane: mac-controller-manager
+  policyTypes:
+  - Ingress
+---
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:

--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -36,7 +36,7 @@ const (
 	MultusDynamicNetworksImageDefault  = "ghcr.io/k8snetworkplumbingwg/multus-dynamic-networks-controller@sha256:8061bd1276ff022fe52a0b07bc6fa8d27e5f6f20cf3bf764e76d347d2e3c929b"
 	LinuxBridgeCniImageDefault         = "quay.io/kubevirt/cni-default-plugins@sha256:976a24392c2a096c38c2663d234b2d3131f5c24558889196d30b9ac1b6716788"
 	LinuxBridgeMarkerImageDefault      = "quay.io/kubevirt/bridge-marker@sha256:bf269af61e618857e7b14439cfc003aac2d65db9ee633147a73f5d9648dab377"
-	KubeMacPoolImageDefault            = "quay.io/kubevirt/kubemacpool@sha256:775942c3e72ee0893711c5f5801bcc6384b931a72a0cdd75e25547d0e4433021"
+	KubeMacPoolImageDefault            = "quay.io/kubevirt/kubemacpool@sha256:fbb88294aec0a6d23495e059e5d59c09aba17c09dd29b7985b9e2739c6b88a53"
 	OvsCniImageDefault                 = "ghcr.io/k8snetworkplumbingwg/ovs-cni-plugin@sha256:435f374b434b3bc70a5cfaba0011fdcf5f433d96b98b06d29306cbd8db3a8c21"
 	MacvtapCniImageDefault             = "quay.io/kubevirt/macvtap-cni@sha256:10e631dea111c070e67b03ab1fdd5563eb95fb3f14959ffc66386cdf215133c9"
 	KubeRbacProxyImageDefault          = "quay.io/brancz/kube-rbac-proxy@sha256:e6a323504999b2a4d2a6bf94f8580a050378eba0900fd31335cf9df5787d9a9b"

--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -538,6 +538,23 @@ func GetRole(namespace string) *rbacv1.Role {
 					"delete",
 				},
 			},
+			{
+				APIGroups: []string{
+					"networking.k8s.io",
+				},
+				Resources: []string{
+					"networkpolicies",
+				},
+				Verbs: []string{
+					"get",
+					"list",
+					"watch",
+					"create",
+					"update",
+					"patch",
+					"delete",
+				},
+			},
 		},
 	}
 	return role

--- a/test/releases/99.0.0.go
+++ b/test/releases/99.0.0.go
@@ -42,7 +42,7 @@ func init() {
 				ParentName: "kubemacpool-mac-controller-manager",
 				ParentKind: "Deployment",
 				Name:       "manager",
-				Image:      "quay.io/kubevirt/kubemacpool@sha256:775942c3e72ee0893711c5f5801bcc6384b931a72a0cdd75e25547d0e4433021",
+				Image:      "quay.io/kubevirt/kubemacpool@sha256:fbb88294aec0a6d23495e059e5d59c09aba17c09dd29b7985b9e2739c6b88a53",
 			},
 			{
 				ParentName: "kubemacpool-mac-controller-manager",
@@ -54,7 +54,7 @@ func init() {
 				ParentName: "kubemacpool-cert-manager",
 				ParentKind: "Deployment",
 				Name:       "manager",
-				Image:      "quay.io/kubevirt/kubemacpool@sha256:775942c3e72ee0893711c5f5801bcc6384b931a72a0cdd75e25547d0e4433021",
+				Image:      "quay.io/kubevirt/kubemacpool@sha256:fbb88294aec0a6d23495e059e5d59c09aba17c09dd29b7985b9e2739c6b88a53",
 			},
 			{
 				ParentName: "ovs-cni-amd64",


### PR DESCRIPTION
**What this PR does / why we need it**:
bump kubemacpool to v0.47.0-3-g5276a1c
Executed by Bumper script

Also added a commit to update network-policy RBACs

**Special notes for your reviewer**:

**Release note**:

```release-note
bump kubemacpool to v0.47.0-3-g5276a1c
```
