### PR TITLE
tools/Bumper: Remove clone prints

### DIFF
--- a/tools/bumper/component_commands.go
+++ b/tools/bumper/component_commands.go
@@ -130,7 +130,6 @@ func newGitRepo(componentName string, componentParams *component) (*gitRepo, err
 	repo, err := git.PlainClone(repoDir, false, &git.CloneOptions{
 		URL:           componentParams.Url,
 		ReferenceName: plumbing.NewBranchReferenceName(componentParams.Branch),
-		Progress:      os.Stdout,
 	})
 	if err != nil {
 		return nil, errors.Wrapf(err, "Failed to clone %s repo", componentName)

--- a/tools/bumper/component_commands.go
+++ b/tools/bumper/component_commands.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 
@@ -122,7 +121,7 @@ func newGithubApi(token string) (*githubApi, error) {
 
 // newGitRepo clones the repository on a local temp directory.
 func newGitRepo(componentName string, componentParams *component) (*gitRepo, error) {
-	repoDir, err := ioutil.TempDir("/tmp", componentName)
+	repoDir, err := os.MkdirTemp("/tmp", componentName)
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to create temp dir for component")
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR is removing excessive cloning [prints](https://github.com/kubevirt/cluster-network-addons-operator/actions/runs/15153983883/job/42605183704#step:5:1750) during the bumper process.
It also removes a small deprecated function.

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
