### PR TITLE
tools/bumper: Initiate bump after branch following latest is tagged

### DIFF
--- a/tools/bumper/bumper.go
+++ b/tools/bumper/bumper.go
@@ -74,7 +74,8 @@ func main() {
 		}
 
 		proposedPrTitle := fmt.Sprintf("bump %s to %s", componentName, updatedReleaseTag)
-		componentBumpNeeded, err := cnaoRepo.isComponentBumpNeeded(currentReleaseTag, updatedReleaseTag, component.Updatepolicy, proposedPrTitle)
+		componentBumpNeeded, err := cnaoRepo.isComponentBumpNeeded(currentReleaseTag, updatedReleaseTag,
+			component.Updatepolicy, component.Metadata, proposedPrTitle)
 		if err != nil {
 			exitWithError(errors.Wrapf(err, "Failed to discover if Bump need for %s", componentName))
 		}

--- a/tools/bumper/cnao_repo_commands_test.go
+++ b/tools/bumper/cnao_repo_commands_test.go
@@ -204,6 +204,7 @@ var _ = Describe("Testing internal git CNAO Repo", func() {
 		currentReleaseVersion string
 		latestReleaseVersion  string
 		updatePolicy          string
+		metadata              string
 		prTitle               string
 		isBumpExpected        bool
 		isValid               bool
@@ -214,7 +215,7 @@ var _ = Describe("Testing internal git CNAO Repo", func() {
 			gitCnaoRepo.configParams.Url = repoDir
 
 			By("Checking if bump is needed")
-			isComponentBumpNeeded, err := gitCnaoRepo.isComponentBumpNeeded(b.currentReleaseVersion, b.latestReleaseVersion, b.updatePolicy, b.prTitle)
+			isComponentBumpNeeded, err := gitCnaoRepo.isComponentBumpNeeded(b.currentReleaseVersion, b.latestReleaseVersion, b.updatePolicy, b.metadata, b.prTitle)
 			By("Checking expected error received")
 			if b.isValid {
 				Expect(err).ToNot(HaveOccurred(), "Expect function to not return an Error")
@@ -301,6 +302,24 @@ var _ = Describe("Testing internal git CNAO Repo", func() {
 			currentReleaseVersion: "v3.6.2",
 			latestReleaseVersion:  "v3.6.2",
 			updatePolicy:          "tagged",
+			prTitle:               dummyPRTitle,
+			isBumpExpected:        false,
+			isValid:               true,
+		}),
+		Entry("Should bump if updatePolicy latest and the component issued a release on that branch head", isComponentBumpNeededParams{
+			currentReleaseVersion: "v3.6.2",
+			latestReleaseVersion:  "v3.6.2",
+			updatePolicy:          "latest",
+			metadata:              "v3.6.1-5-g4d4511",
+			prTitle:               dummyPRTitle,
+			isBumpExpected:        true,
+			isValid:               true,
+		}),
+		Entry("Should not bump if updatePolicy latest and the component issued a release on that branch head, but metadata is already aligned", isComponentBumpNeededParams{
+			currentReleaseVersion: "v3.6.2",
+			latestReleaseVersion:  "v3.6.2",
+			updatePolicy:          "latest",
+			metadata:              "v3.6.2",
 			prTitle:               dummyPRTitle,
 			isBumpExpected:        false,
 			isValid:               true,


### PR DESCRIPTION
**What this PR does / why we need it**:
In the case where component follows **latest** of branch, and that branch issues a release (=tag), then the auto bumper needs to prefer the new tag over the virtual tag and initiate a bump. It is needed in order to refresh the component's image sha256 using the new tag.

This PR change bumper code to prefer real tags.

**Special notes for your reviewer**:
Fixes https://github.com/kubevirt/cluster-network-addons-operator/issues/2278

**Release note**:
```release-note
NONE
```
