### PR TITLE
Refactor unit test lane to output clear message to contributor

### DIFF
--- a/automation/check-patch.unit-test.sh
+++ b/automation/check-patch.unit-test.sh
@@ -12,9 +12,20 @@ verify_metrics_docs_updated() {
 main() {
     source automation/check-patch.setup.sh
     cd ${TMP_PROJECT_PATH}
+
     make bump-all
+    if ! make check; then
+        echo "error: Uncommitted changes found after bump check. \
+        If you are performing a component bump, recheck all created manifests and image URL are valid. \
+        If you are not attempting a component bump, please contact the repo's maintainer for further analysis"
+    fi
+
     make vendor
-    make check
+    if ! make check; then
+        echo "error: Uncommitted changes found after vendor check. \
+        Make sure go.mod is up to date and all 'make vendor' output is commited"
+    fi
+
     verify_metrics_docs_updated
     make lint-metrics
     make lint-monitoring


### PR DESCRIPTION
**What this PR does / why we need it**:
In order to allow the contributor to better navigate the change they're inserting, and fix potential issues that may occur, this PR is adding a proper message in case unit test lane is failing at key points.

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
