### PR TITLE
Move the nightly build images to quay.io/kubevirt

### DIFF
--- a/automation/test-nightly-build.sh
+++ b/automation/test-nightly-build.sh
@@ -26,8 +26,8 @@ main() {
 
     # create and push bundle image and index image
     build_date="$(date +%Y%m%d)"
-    export IMAGE_REGISTRY=quay.io/kubevirtci
-    export IMAGE_TAG="nb_${build_date}_$(git show -s --format=%h)"
+    export IMAGE_REGISTRY=quay.io/kubevirt
+    export IMAGE_TAG="${build_date}_$(git show -s --format=%h)"
     export VERSION=${IMAGE_TAG}
     export DEPLOY_DIR=_out
 


### PR DESCRIPTION
**What this PR does / why we need it**:

To align with KubeVirt and CDI nightly builds, move the CNAO image from quay.io/kubevirtci registry, to quay.io/kubevirt, and remove the `"nb_"` prefix from the image tag.

**Release note**:
```release-note
Move the nightly build images to the quay.io/kubevirt registry
```
