### PR TITLE
Linux bridge:  Harden SCC by restricting SELinux context and allowed volume types

### DIFF
--- a/data/linux-bridge/001-rbac.yaml
+++ b/data/linux-bridge/001-rbac.yaml
@@ -16,7 +16,7 @@ allowHostIPC: false
 allowHostNetwork: false
 allowHostPID: false
 allowHostPorts: false
-readOnlyRootFilesystem: false
+readOnlyRootFilesystem: true
 runAsUser:
   type: RunAsAny
 seLinuxContext:
@@ -29,4 +29,5 @@ volumes:
   - hostPath
   - configMap
   - secret
+  - emptyDir
 {{ end }}

--- a/data/linux-bridge/001-rbac.yaml
+++ b/data/linux-bridge/001-rbac.yaml
@@ -20,7 +20,9 @@ readOnlyRootFilesystem: false
 runAsUser:
   type: RunAsAny
 seLinuxContext:
-  type: RunAsAny
+  type: MustRunAs
+  seLinuxOptions:
+    type: spc_t
 users:
 - system:serviceaccount:{{ .Namespace }}:linux-bridge
 volumes:

--- a/data/linux-bridge/001-rbac.yaml
+++ b/data/linux-bridge/001-rbac.yaml
@@ -26,5 +26,7 @@ seLinuxContext:
 users:
 - system:serviceaccount:{{ .Namespace }}:linux-bridge
 volumes:
-- "*"
+  - hostPath
+  - configMap
+  - secret
 {{ end }}

--- a/data/linux-bridge/002-linux-bridge.yaml
+++ b/data/linux-bridge/002-linux-bridge.yaml
@@ -69,11 +69,16 @@ spec:
               memory: "15Mi"
           securityContext:
             privileged: true
+            readOnlyRootFilesystem: true
           volumeMounts:
             - name: cnibin
               mountPath: /opt/cni/bin
+            - name: tmp
+              mountPath: /tmp
           terminationMessagePolicy: FallbackToLogsOnError
       volumes:
         - name: cnibin
           hostPath:
             path: {{ .CNIBinDir }}
+        - name: tmp
+          emptyDir: { }


### PR DESCRIPTION
**What this PR does / why we need it**:
This pull request improves the security posture of the linux-bridge SecurityContextConstraints (SCC) by introducing two changes:

1. **Restrict SELinux context** to `MustRunAs` with `spc_t` type.
2. **Restrict allowed volume types** to only `hostPath`, `configMap`, and `secret`.

**Special notes for your reviewer**:
To anticipate reviewers request, [commented](https://github.com/kubevirt/cluster-network-addons-operator/pull/2331#issuecomment-2943335474) on the PR why I did NOT remove other SCCs.

**Release note**:

```release-note
reduce linux bridge SCC
```
