### PR TITLE
Harden bridge-marker SCC: restrict privileges, enforce non-root, allow projected volumes

### DIFF
--- a/data/linux-bridge/003-bridge-marker.yaml
+++ b/data/linux-bridge/003-bridge-marker.yaml
@@ -89,7 +89,7 @@ kind: SecurityContextConstraints
 metadata:
   name: bridge-marker
 allowHostNetwork: true
-allowHostDirVolumePlugin: true
+allowHostDirVolumePlugin: false
 allowPrivilegedContainer: false
 readOnlyRootFilesystem: false
 allowHostIPC: false
@@ -102,6 +102,8 @@ seLinuxContext:
 users:
 - system:serviceaccount:{{ .Namespace }}:bridge-marker
 volumes:
-- "*"
+- configMap
+- emptyDir
+- projected
 {{ end }}
 ---

--- a/data/linux-bridge/003-bridge-marker.yaml
+++ b/data/linux-bridge/003-bridge-marker.yaml
@@ -48,6 +48,10 @@ spec:
                   fieldPath: spec.nodeName
           terminationMessagePolicy: FallbackToLogsOnError
       affinity: {{ toYaml .Placement.Affinity | nindent 8 }}
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1001
+        readOnlyRootFilesystem: true
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1

--- a/data/linux-bridge/003-bridge-marker.yaml
+++ b/data/linux-bridge/003-bridge-marker.yaml
@@ -91,14 +91,14 @@ metadata:
 allowHostNetwork: true
 allowHostDirVolumePlugin: false
 allowPrivilegedContainer: false
-readOnlyRootFilesystem: false
+readOnlyRootFilesystem: true
 allowHostIPC: false
 allowHostPID: false
 allowHostPorts: false
 runAsUser:
-  type: RunAsAny
+  type: MustRunAsNonRoot
 seLinuxContext:
-  type: RunAsAny
+  type: MustRunAs
 users:
 - system:serviceaccount:{{ .Namespace }}:bridge-marker
 volumes:

--- a/hack/components/bump-bridge-marker.sh
+++ b/hack/components/bump-bridge-marker.sh
@@ -68,7 +68,7 @@ kind: SecurityContextConstraints
 metadata:
   name: bridge-marker
 allowHostNetwork: true
-allowHostDirVolumePlugin: true
+allowHostDirVolumePlugin: false
 allowPrivilegedContainer: false
 readOnlyRootFilesystem: false
 allowHostIPC: false
@@ -81,7 +81,9 @@ seLinuxContext:
 users:
 - system:serviceaccount:{{ .Namespace }}:bridge-marker
 volumes:
-- "*"
+- configMap
+- emptyDir
+- projected
 {{ end }}
 ---
 EOF

--- a/hack/components/bump-bridge-marker.sh
+++ b/hack/components/bump-bridge-marker.sh
@@ -26,6 +26,9 @@ function __parametize_by_object() {
 				yaml-utils::set_param ${f} spec.template.spec.affinity '{{ toYaml .Placement.Affinity | nindent 8 }}'
 				yaml-utils::set_param ${f} 'spec.template.metadata.annotations."openshift.io/required-scc"' '"bridge-marker"'
 				yaml-utils::update_param ${f} spec.template.spec.tolerations '{{ toYaml .Placement.Tolerations | nindent 8 }}'
+				yaml-utils::set_param ${f} spec.template.spec.securityContext.runAsNonRoot 'true'
+				yaml-utils::set_param ${f} spec.template.spec.securityContext.runAsUser '1001'
+				yaml-utils::set_param ${f} spec.template.spec.securityContext.readOnlyRootFilesystem 'true'
 				yaml-utils::remove_single_quotes_from_yaml ${f}
 				;;
 		esac

--- a/hack/components/bump-bridge-marker.sh
+++ b/hack/components/bump-bridge-marker.sh
@@ -70,14 +70,14 @@ metadata:
 allowHostNetwork: true
 allowHostDirVolumePlugin: false
 allowPrivilegedContainer: false
-readOnlyRootFilesystem: false
+readOnlyRootFilesystem: true
 allowHostIPC: false
 allowHostPID: false
 allowHostPorts: false
 runAsUser:
-  type: RunAsAny
+  type: MustRunAsNonRoot
 seLinuxContext:
-  type: RunAsAny
+  type: MustRunAs
 users:
 - system:serviceaccount:{{ .Namespace }}:bridge-marker
 volumes:


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR improves the security posture of the bridge-marker DaemonSet in OpenShift by hardening its SecurityContextConstraints (SCC) and enforcing best practices.

**Special notes for your reviewer**:
To anticipate reviewers request, commented on the PR why I did NOT remove other SCCs.

**Release note**:

```release-note
reduce bridge-marker SCC
```
