### PR TITLE
Opt-in for network-policies provided by hco-bundle for CNAO and its components pods

### DIFF
--- a/data/kube-secondary-dns/secondarydns.yaml
+++ b/data/kube-secondary-dns/secondarydns.yaml
@@ -73,6 +73,7 @@ spec:
     metadata:
       labels:
         k8s-app: secondary-dns
+        hco.kubevirt.io/allow-access-cluster-services: ""
       annotations:
         kubectl.kubernetes.io/default-container: status-monitor
         openshift.io/required-scc: "restricted-v2"

--- a/data/kubemacpool/kubemacpool.yaml
+++ b/data/kubemacpool/kubemacpool.yaml
@@ -153,6 +153,7 @@ spec:
         app: kubemacpool
         control-plane: cert-manager
         controller-tools.k8s.io: "1.0"
+        hco.kubevirt.io/allow-access-cluster-services: ""
     spec:
       affinity: {{ toYaml .Placement.Affinity | nindent 8 }}
       containers:
@@ -245,6 +246,8 @@ spec:
         app: kubemacpool
         control-plane: mac-controller-manager
         controller-tools.k8s.io: "1.0"
+        hco.kubevirt.io/allow-access-cluster-services: ""
+        hco.kubevirt.io/allow-prometheus-access: ""
     spec:
       affinity: {{ toYaml .Placement.Affinity | nindent 8 }}
       containers:

--- a/data/kubevirt-ipam-controller/001-kubevirtipamcontroller.yaml
+++ b/data/kubevirt-ipam-controller/001-kubevirtipamcontroller.yaml
@@ -178,6 +178,7 @@ spec:
       labels:
         app: ipam-virt-workloads
         control-plane: manager
+        hco.kubevirt.io/allow-access-cluster-services: ""
     spec:
       containers:
         - args:

--- a/hack/components/bump-kube-secondary-dns.sh
+++ b/hack/components/bump-kube-secondary-dns.sh
@@ -35,6 +35,7 @@ function __parametize_by_object() {
         yaml-utils::set_param ${f} spec.template.spec.affinity '{{ toYaml .Placement.Affinity | nindent 8 }}'
         yaml-utils::set_param ${f} spec.template.spec.tolerations '{{ toYaml .Placement.Tolerations | nindent 8 }}'
         yaml-utils::set_param ${f} 'spec.template.metadata.annotations."openshift.io/required-scc"' '"restricted-v2"'
+        yaml-utils::set_param ${f} 'spec.template.metadata.labels."hco.kubevirt.io/allow-access-cluster-services"' '""'
         yaml-utils::remove_single_quotes_from_yaml ${f}
         ;;
       ./ServiceAccount_secondary.yaml)

--- a/hack/components/bump-kubemacpool.sh
+++ b/hack/components/bump-kubemacpool.sh
@@ -59,6 +59,15 @@ patches:
   target:
     version: v1
     kind: Namespace
+- path: add-pod-template-label-allow-access-cluster-services_patch.yaml
+  target:
+    version: v1
+    kind: Deployment
+- path: add-pod-template-label-allow-prometheus-access_patch.yaml
+  target:
+    version: v1
+    kind: Deployment
+    name: mac-controller-manager
 EOF
 
     cat <<EOF > config/cnao/cnao_kubemacpool_manager_patch.yaml
@@ -145,6 +154,16 @@ EOF
   path: /metadata/labels
 EOF
 
+    cat <<EOF > config/cnao/add-pod-template-label-allow-access-cluster-services_patch.yaml
+- op: add
+  path: /spec/template/metadata/labels/hco.kubevirt.io~1allow-access-cluster-services
+  value: ""
+EOF
+    cat <<EOF > config/cnao/add-pod-template-label-allow-prometheus-access_patch.yaml
+- op: add
+  path: /spec/template/metadata/labels/hco.kubevirt.io~1allow-prometheus-access
+  value: ""
+EOF
 
     (
         cd config/cnao

--- a/hack/components/bump-kubevirt-ipam-controller.sh
+++ b/hack/components/bump-kubevirt-ipam-controller.sh
@@ -29,6 +29,7 @@ function __parametize_by_object() {
         yaml-utils::set_param ${f} spec.template.spec.nodeSelector '{{ toYaml .Placement.NodeSelector | nindent 8 }}'
         yaml-utils::set_param ${f} spec.template.spec.affinity '{{ toYaml .Placement.Affinity | nindent 8 }}'
         yaml-utils::set_param ${f} spec.template.spec.tolerations '{{ toYaml .Placement.Tolerations | nindent 8 }}'
+        yaml-utils::set_param ${f} 'spec.template.metadata.labels."hco.kubevirt.io/allow-access-cluster-services"' '""'
         yaml-utils::remove_single_quotes_from_yaml ${f}
         ;;
       ./Service_kubevirt-ipam-controller-webhook-service.yaml)

--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -181,6 +181,10 @@ func GetDeployment(version string, operatorVersion string, namespace string, rep
 					Labels: map[string]string{
 						"name":                   Name,
 						names.PrometheusLabelKey: names.PrometheusLabelValue,
+						// opt-in to hco-bundle network-policy allowing egress to cluster services
+						"hco.kubevirt.io/allow-access-cluster-services": "",
+						// opt-in to hco-bundle network-policy allowing ingress to the metrics endpoint
+						"hco.kubevirt.io/allow-prometheus-access": "",
 					},
 					Annotations: map[string]string{
 						"description": "cluster-network-addons-operator manages the lifecycle of different Kubernetes network components on top of Kubernetes cluster",


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the main branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it

If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**What this PR does / why we need it**:
Enable CNAO operator and its operands pors operate when network restrictions in form of defaultl deny-all network-policy is in place, when managed by HCO.

The hco-bundle should provide network-policies allowing its operands work when network restrictions are in place.
In order to opt-in pods for the provided network-policies pods should be labeled with the following labels:
1. `hco.kubevirt.io/allow-access-cluster-services`
    Allow access the cluster API and DNS.
    This is a fundamental requirement for a k8s controller to oprate, it is requiremd for the following compoents:
    - kubemacpool
    -  ipam-extentions
    - kube-secondary-dns
2. `hco.kubevirt.io/allow-prometheus-access` 
    Allow Prometheus pods ingress the metrics endpoint
    Required by CNAO opreator pods, allowing promethues scrape CNAO metrics.

With this change the project `manifest-templator` and `csv-gen` tool should produce the project Deployment and CSV with the above labels. 
Allowing CNAO to operate under network restrictions when managed by HCO.

In addition CNAO should generate and install kubemacpool, kubevirt-ipam-contoller and kube-secondary-dns with the above labels.
Allowing them to operate under network restrictions when managed by CNAO and HCO.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
5. If no release note is required, just write "NONE".
-->

```release-note
CNAO operator and its components opt-in for network-policies provided by hco-bundle
```
