### PR TITLE
Consume and install kube-seconday-dns network-policy

### DIFF
--- a/data/kube-secondary-dns/secondarydns.yaml
+++ b/data/kube-secondary-dns/secondarydns.yaml
@@ -186,3 +186,19 @@ spec:
       nodeSelector: {{ toYaml .Placement.NodeSelector | nindent 8 }}
       affinity: {{ toYaml .Placement.Affinity | nindent 8 }}
       tolerations: {{ toYaml .Placement.Tolerations | nindent 8 }}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-ingress-to-secondary-dns
+  namespace: '{{ .Namespace }}'
+spec:
+  podSelector:
+    matchLabels:
+      k8s-app: secondary-dns
+  policyTypes:
+    - Ingress
+  ingress:
+    - ports:
+        - protocol: UDP
+          port: dns

--- a/hack/components/bump-kube-secondary-dns.sh
+++ b/hack/components/bump-kube-secondary-dns.sh
@@ -41,6 +41,9 @@ function __parametize_by_object() {
         yaml-utils::update_param ${f} metadata.namespace '{{ .Namespace }}'
         yaml-utils::remove_single_quotes_from_yaml ${f}
         ;;
+      ./NetworkPolicy_allow-ingress-to-secondary-dns.yaml)
+        yaml-utils::update_param ${f} metadata.namespace '{{ .Namespace }}'
+        ;;
     esac
   done
 }
@@ -79,7 +82,9 @@ echo 'Adjust kube-secondary-dns to CNAO'
       ClusterRole_secondary.yaml \
       ClusterRoleBinding_secondary.yaml \
       ServiceAccount_secondary.yaml \
-      Deployment_secondary-dns.yaml > secondarydns.yaml
+      Deployment_secondary-dns.yaml \
+      NetworkPolicy_allow-ingress-to-secondary-dns.yaml \
+        > secondarydns.yaml
 )
 
 echo 'copy manifests'


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the main branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it

If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**What this PR does / why we need it**:
kube-secondary-dns introduce network-policy since v0.0.22.

Installing KSD network-policy allow it to operate when network restrictions in form of default deny-all network-policy is in place.

This PR extend the bump-kube-secondary-dns automation to consume the project network-policy manifests.
And make CNAO install KSD network-policy, when KSD is installed.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
CNAO install kube-secondary-dns network-policy
```
