### PR TITLE
 scc, ovs-cni: Harden SCC restirctions

### DIFF
--- a/data/ovs/001-ovs-cni.yaml
+++ b/data/ovs/001-ovs-cni.yaml
@@ -137,9 +137,9 @@ allowHostNetwork: true
 allowPrivilegedContainer: true
 allowHostDirVolumePlugin: true
 runAsUser:
-  type: RunAsAny
+  type: MustRunAsNonRoot
 seLinuxContext:
-  type: RunAsAny
+  type: MustRunAs
 users:
   - system:serviceaccount:{{ .Namespace }}:ovs-cni-marker
 {{ end }}

--- a/hack/components/bump-ovs-cni.sh
+++ b/hack/components/bump-ovs-cni.sh
@@ -81,9 +81,9 @@ allowHostNetwork: true
 allowPrivilegedContainer: true
 allowHostDirVolumePlugin: true
 runAsUser:
-  type: RunAsAny
+  type: MustRunAsNonRoot
 seLinuxContext:
-  type: RunAsAny
+  type: MustRunAs
 users:
   - system:serviceaccount:{{ .Namespace }}:ovs-cni-marker
 {{ end }}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR improves the security posture of the ovs-cni DaemonSet deployment by tightening its associated OpenShift SecurityContextConstraints (SCC). It ensures containers run with minimal privileges while preserving required functionality for Open vSwitch integration.

**Special notes for your reviewer**:
script used in order to check it works on kcli (inspired by original e2e [test](https://github.com/k8snetworkplumbingwg/ovs-cni/blob/6ef93aa45fdf95de667e43b73225f16f81f171c7/tests/ovs_test.go)):
```
#!/usr/bin/env bash
set -euo pipefail

NODE="multi-homing-worker-0.yourname.corp"
BRIDGE="br-test"
RESOURCE="ovs-cni.network.kubevirt.io/$BRIDGE"
VERSION="1.0.0"
NAMESPACE="test"
NAD_NAME="ovs-net"
POD1="pod-test-1"
POD2="pod-test-2"
CIDR1="10.0.0.1/24"
CIDR2="10.0.0.2/24"
TIMEOUT=180
INTERVAL=5

cleanup() {
  echo "🧹 Cleaning up..."
  oc delete pod "$POD1" "$POD2" -n "$NAMESPACE" --ignore-not-found
  oc delete net-attach-def "$NAD_NAME" -n "$NAMESPACE" --ignore-not-found
  oc delete namespace "$NAMESPACE" --ignore-not-found
  oc debug node/"$NODE" -- chroot /host ovs-vsctl --if-exists del-br "$BRIDGE" || true
}
trap cleanup EXIT

oc create namespace "$NAMESPACE" || true
echo "⏳ Waiting for namespace $NAMESPACE to be ready..."
until oc get namespace "$NAMESPACE" &> /dev/null; do
  sleep 1
done

echo "🔍 1. Checking ovs-cni pods"
pods=$(oc get pods --all-namespaces -l app=ovs-cni -o json)
count=$(echo "$pods" | jq '.items | length')
if (( count > 0 )); then
  echo "✔ Found $count ovs-cni pod(s)"
else
  echo "❌ No ovs-cni pods found"
  exit 1
fi

echo "🌉 2. Adding OVS bridge on node"
oc debug node/"$NODE" -- chroot /host ovs-vsctl add-br "$BRIDGE"

echo "⏳ Waiting for bridge resource to be reported"
start=0
while :; do
  if oc get node "$NODE" -o json | jq -e '.status.capacity["'"$RESOURCE"'"] == "1k"' > /dev/null; then
    reported=yes
  else
    reported=no
  fi

  [[ "$reported" == "yes" ]] && break

  (( start += INTERVAL ))
  if (( start >= TIMEOUT )); then
    echo "❌ Timeout waiting for resource $RESOURCE"
    exit 1
  fi
  sleep "$INTERVAL"
done
echo "✔ Bridge resource reported"

echo "📦 3. Setting up test namespace and NAD"
cat <<EOF | oc apply -f -
apiVersion: k8s.cni.cncf.io/v1
kind: NetworkAttachmentDefinition
metadata:
  name: $NAD_NAME
  namespace: $NAMESPACE
  annotations:
    k8s.v1.cni.cncf.io/resourceName: ovs-cni.network.kubevirt.io/$BRIDGE
spec:
  config: |
    {
      "cniVersion": "$VERSION",
      "type": "ovs",
      "bridge": "$BRIDGE",
      "vlan": 100
    }
EOF

echo "🐳 4. Launching privileged pods with static IPs"
pod_yaml() {
  local name=$1
  local ip=$2
  cat <<EOF
apiVersion: v1
kind: Pod
metadata:
  name: $name
  namespace: $NAMESPACE
  annotations:
    k8s.v1.cni.cncf.io/networks: $NAD_NAME
spec:
  nodeName: $NODE
  hostNetwork: false
  containers:
  - name: test
    image: quay.io/jitesoft/alpine
    command: ["sh", "-c", "ip addr add $ip dev net1 && sleep 3600"]
    securityContext:
      privileged: true
  restartPolicy: Never
EOF
}

pod_yaml "$POD1" "$CIDR1" | oc apply -f -
pod_yaml "$POD2" "$CIDR2" | oc apply -f -

echo "⏳ Waiting for pods to be Running"
oc wait pod/"$POD1" pod/"$POD2" -n "$NAMESPACE" --for=condition=Ready --timeout=120s

IP1=${CIDR1%/*}
IP2=${CIDR2%/*}

echo "📶 5. Checking connectivity: $POD1 -> $IP2"
oc exec -n "$NAMESPACE" "$POD1" -- ping -c 3 -W 2 "$IP2"

echo "🎉 Test succeeded – pods can communicate!"
```
**Release note**:

```release-note
ovs-cni, harden SCC
```
