### PR TITLE
data,components: Consume kubevirt-ipam-controller network-policy

### DIFF
--- a/data/kubevirt-ipam-controller/001-kubevirtipamcontroller.yaml
+++ b/data/kubevirt-ipam-controller/001-kubevirtipamcontroller.yaml
@@ -296,3 +296,21 @@ webhooks:
         resources:
           - pods
     sideEffects: None
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  labels:
+    app: ipam-virt-workloads
+  name: kubevirt-ipam-controller-allow-ingress-to-ipam-ext-webhook
+  namespace: '{{ .Namespace }}'
+spec:
+  ingress:
+    - ports:
+        - port: webhook-server
+          protocol: TCP
+  podSelector:
+    matchLabels:
+      app: ipam-virt-workloads
+  policyTypes:
+    - Ingress

--- a/hack/components/bump-kubevirt-ipam-controller.sh
+++ b/hack/components/bump-kubevirt-ipam-controller.sh
@@ -67,6 +67,9 @@ function __parametize_by_object() {
         yaml-utils::update_param ${f} metadata.namespace '{{ .Namespace }}'
         yaml-utils::remove_single_quotes_from_yaml ${f}
         ;;
+      ./NetworkPolicy_kubevirt-ipam-controller-allow-ingress-to-ipam-ext-webhook.yaml)
+        yaml-utils::update_param ${f} metadata.namespace '{{ .Namespace }}'
+        ;;
     esac
   done
 }
@@ -126,7 +129,9 @@ echo 'Adjust kubevirt-ipam-controller to CNAO'
       Deployment_kubevirt-ipam-controller-manager.yaml \
       Certificate_kubevirt-ipam-controller-serving-cert.yaml \
       Issuer_kubevirt-ipam-controller-selfsigned-issuer.yaml \
-      MutatingWebhookConfiguration_kubevirt-ipam-controller-mutating-webhook-configuration.yaml > 001-kubevirtipamcontroller.yaml
+      MutatingWebhookConfiguration_kubevirt-ipam-controller-mutating-webhook-configuration.yaml \
+      NetworkPolicy_kubevirt-ipam-controller-allow-ingress-to-ipam-ext-webhook.yaml \
+        > 001-kubevirtipamcontroller.yaml
 
 )
 


### PR DESCRIPTION
Extend the bump-kubevirt-ipam-controller to consume the project network-policy manifests.

This change include 'make gen-manifest bump-kubevirt-ipam-controller' changes.

With this change ipam-ext network-policy is added to ipam-ext template, and CNAO install ipam-ext network-policy on ipam-ext installation.

<!-- Thanks for sending a pull request!

Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the main branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it

If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**What this PR does / why we need it**:
kubevirt-ipam-controller introduce network-policy since v0.0.26.

This PR extend the kubevirt-ipam-controller automation to consume the project network-policy manifests.
And make CNAO install kubevirt-ipam-controller network-policy when kubevirt-ipam-controller is installed.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
CNAO install kubevirt-ipam-controller network-policy
```
