### PR TITLE
CI: Add test coverage for network-policies by simulate network restrictions

### DIFF
--- a/automation/check-patch.e2e-kube-secondary-dns-functests.sh
+++ b/automation/check-patch.e2e-kube-secondary-dns-functests.sh
@@ -29,6 +29,9 @@ main() {
 
     trap teardown EXIT
 
+    echo "Simulate network restrictions on CNAO namespace"
+    ./hack/install-network-policy.sh
+
     ./hack/deploy-kubevirt.sh
     cd ${TMP_COMPONENT_PATH}
     make create-nodeport

--- a/automation/check-patch.e2e-kubemacpool-functests.sh
+++ b/automation/check-patch.e2e-kubemacpool-functests.sh
@@ -44,6 +44,9 @@ main() {
 
     trap teardown EXIT
 
+    echo "Simulate network restrictions on CNAO namespace"
+    ./hack/install-network-policy.sh
+
     echo "Deploy KubeVirt latest stable release"
     ./hack/deploy-kubevirt.sh
 

--- a/automation/check-patch.e2e-kubevirt-ipam-controller-functests.sh
+++ b/automation/check-patch.e2e-kubevirt-ipam-controller-functests.sh
@@ -68,6 +68,8 @@ main() {
     ./cluster/cert-manager-install.sh
     deploy_cnao
     deploy_cnao_cr
+    echo "Simulate network restrictions on CNAO namespace"
+    ./hack/install-network-policy.sh
     ./hack/deploy-kubevirt.sh
     ./cluster/kubectl.sh -n kubevirt patch kubevirt kubevirt --type=json --patch '[{"op":"add","path":"/spec/configuration/developerConfiguration","value":{"featureGates":[]}},{"op":"add","path":"/spec/configuration/developerConfiguration/featureGates/-","value":"NetworkBindingPlugins"},{"op":"add","path":"/spec/configuration/developerConfiguration/featureGates/-","value":"DynamicPodInterfaceNaming"}]'
     ./cluster/kubectl.sh -n kubevirt patch kubevirt kubevirt --type=json --patch '[{"op":"add","path":"/spec/configuration/network","value":{"binding":{"l2bridge":{"domainAttachmentType":"managedTap","migration":{}}}}}]'

--- a/automation/check-patch.e2e-monitoring-k8s.sh
+++ b/automation/check-patch.e2e-monitoring-k8s.sh
@@ -28,6 +28,9 @@ main() {
     make cluster-operator-push
     make cluster-operator-install
 
+     echo "Simulate network restriction on CNAO namespace"
+     ./hack/install-network-policy.sh
+
     make E2E_TEST_EXTRA_ARGS="-ginkgo.noColor --ginkgo.junit-report=$ARTIFACTS/junit.functest.xml" test/e2e/monitoring
 }
 

--- a/automation/check-patch.e2e-workflow-k8s.sh
+++ b/automation/check-patch.e2e-workflow-k8s.sh
@@ -24,6 +24,10 @@ main() {
     ./hack/deploy-kubevirt.sh
     make cluster-operator-push
     make cluster-operator-install
+
+    echo "Simulate network restriction on CNAO namespace"
+    ./hack/install-network-policy.sh
+
     make E2E_TEST_EXTRA_ARGS="-ginkgo.noColor --ginkgo.junit-report=$ARTIFACTS/junit.functest.xml" test/e2e/workflow
 }
 

--- a/hack/install-network-policy.sh
+++ b/hack/install-network-policy.sh
@@ -1,0 +1,97 @@
+#!/bin/bash -ex
+#
+# Copyright 2025 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# This script install NetworkPolicy that affects CNAO namespace.
+# The network-policy blocks egress/ingress traffic in CNAO namespace with the following exceptions:
+# 1. Allow egress to cluster API and DNS for pods who labeled with
+#    "hco.kubevirt.io/allow-access-cluster-services"
+# 2. Allow ingress to metrics endpoint to pods who labeled with
+#    "hco.kubevirt.io/allow-prometheus-access"
+
+readonly ns="$(./cluster/kubectl.sh get pod -l name=cluster-network-addons-operator -A -o=custom-columns=NS:.metadata.namespace --no-headers | head -1)"
+[[ -z "${ns}" ]] && echo "FATAL: CNAO pods not found. Make sure its installed" && exit 1
+
+cat <<EOF | ./cluster/kubectl.sh -n "${ns}" apply -f -
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny-all
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  - Egress
+  ingress: []
+  egress: []
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-egress-to-cluster-dns
+spec:
+  podSelector:
+    matchExpressions:
+    - key: hco.kubevirt.io/allow-access-cluster-services
+      operator: Exists
+  policyTypes:
+  - Egress
+  egress:
+    - to:
+      - namespaceSelector:
+          matchLabels:
+            kubernetes.io/metadata.name: kube-system
+        podSelector:
+          matchLabels:
+            k8s-app: kube-dns
+      ports:
+        - protocol: TCP
+          port: dns-tcp
+        - protocol: UDP
+          port: dns
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-egress-to-cluster-api
+spec:
+  podSelector:
+    matchExpressions:
+    - key: hco.kubevirt.io/allow-access-cluster-services
+      operator: Exists
+  policyTypes:
+  - Egress
+  egress:
+  - ports:
+    - protocol: TCP
+      port: 6443
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-ingress-to-metrics-endpoint
+spec:
+  podSelector:
+    matchExpressions:
+    - key: hco.kubevirt.io/allow-prometheus-access
+      operator: Exists
+  policyTypes:
+  - Ingress
+  ingress:
+  - ports:
+    - protocol: TCP
+      port: metrics
+EOF


### PR DESCRIPTION

<!-- Thanks for sending a pull request!

Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the main branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it

If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**What this PR does / why we need it**:
Following recent work for allowing CNAO pods operate in network restricted environment 
this PR add test coverage by simulating network restrictions on the project namespace.

The automation install default deny-all network-policy with the following exceptions:
1. Allow egress to cluster API and DNS for pods who labeled with `hco.kubevirt.io/allow-access-cluster-services`
2. Allow ingress to metrics endpoint to pods who labeled with `hco.kubevirt.io/allow-prometheus-access`

The additional network-policies allowing the above exceptions provider verify 
opt-in for network-policy provided by hco using labels works and CNAO pods can operate.

The affected CI jobs are as follows:
- `pull-e2e-cluster-network-addons-operator-workflow-k8s`
- `pull-e2e-cluster-network-addons-operator-monitoring`
- `pull-e2e-cluster-network-addons-operator-kubemacpool-functests`
- `pull-e2e-cnao-kube-secondary-dns-functests`
- `Kubevirt IPAM controller Tests / e2e`

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
