### PR TITLE
hack, install network-policy: Use digit ports

### DIFF
--- a/hack/install-network-policy.sh
+++ b/hack/install-network-policy.sh
@@ -59,9 +59,9 @@ spec:
             k8s-app: kube-dns
       ports:
         - protocol: TCP
-          port: dns-tcp
+          port: 53
         - protocol: UDP
-          port: dns
+          port: 53
 ---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
@@ -93,5 +93,5 @@ spec:
   ingress:
   - ports:
     - protocol: TCP
-      port: metrics
+      port: 8443
 EOF


### PR DESCRIPTION


<!-- Thanks for sending a pull request!

Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the main branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it

If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**What this PR does / why we need it**:
Some CNIs does not support named ports (e.g.: ovn-kubernetes), hence use digit ports

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
