### PR TITLE
automation, kmp: Preserve failure logs in artifacts

### DIFF
--- a/automation/check-patch.e2e-kubemacpool-functests.sh
+++ b/automation/check-patch.e2e-kubemacpool-functests.sh
@@ -28,6 +28,8 @@ function __get_skipped_tests() {
 }
 
 teardown() {
+    # Copy kubemacpool failure logs to CNAO artifacts before cleanup
+    cp ${TMP_COMPONENT_PATH}/tests/_out/*.log $ARTIFACTS || true
     rm -rf "${TMP_COMPONENT_PATH}"
     cd ${TMP_PROJECT_PATH}
     make cluster-down


### PR DESCRIPTION
**What this PR does / why we need it**:
When kubemacpool functional tests fail in CNAO's test lane, the detailed failure logs (pod logs, services, endpoints, network policies) were being lost because they are written to the cloned kubemacpool repository's _out/ directory, which gets deleted during teardown [0].

This change copies the kubemacpool failure logs from the temporary component directory to CNAO's artifacts directory before cleanup, ensuring they are preserved for debugging failed tests.

[0]
https://github.com/k8snetworkplumbingwg/kubemacpool/blob/main/tests/tests_suite_test.go#L24

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
