### PR TITLE
network/kubemacpool: Allow day2 changes

### DIFF
--- a/pkg/network/kubemacpool.go
+++ b/pkg/network/kubemacpool.go
@@ -6,7 +6,6 @@ import (
 	"net"
 	"os"
 	"path/filepath"
-	"reflect"
 	"strings"
 
 	"github.com/kubevirt/cluster-network-addons-operator/pkg/render"
@@ -88,10 +87,6 @@ func fillDefaultsKubeMacPool(conf, previous *cnao.NetworkAddonsConfigSpec) []err
 }
 
 func changeSafeKubeMacPool(prev, next *cnao.NetworkAddonsConfigSpec) []error {
-	if prev.KubeMacPool != nil && next.KubeMacPool != nil && !reflect.DeepEqual(prev.KubeMacPool, next.KubeMacPool) {
-		return []error{errors.Errorf("cannot modify KubeMacPool configuration once it is deployed")}
-	}
-
 	return []error{}
 }
 

--- a/pkg/network/kubemacpool_test.go
+++ b/pkg/network/kubemacpool_test.go
@@ -207,16 +207,27 @@ var _ = Describe("Testing kubeMacPool", func() {
 			})
 		})
 
-		Context("When they are not equal", func() {
-			It("should return an error", func() {
+		Context("When only MAC ranges are different", func() {
+			It("should NOT return an error (MAC range changes are allowed)", func() {
 				previousClusterConfig := &cnao.NetworkAddonsConfigSpec{
 					KubeMacPool: &cnao.KubeMacPool{RangeStart: "02:00:00:00:00:00", RangeEnd: "0A:FF:FF:FF:FF:FF"}}
 				currentClusterConfig := &cnao.NetworkAddonsConfigSpec{
 					KubeMacPool: &cnao.KubeMacPool{RangeStart: "02:00:00:00:00:00", RangeEnd: "0A:FF:FF:FF:FF:F1"}}
 
 				errorList := changeSafeKubeMacPool(previousClusterConfig, currentClusterConfig)
-				Expect(len(errorList)).To(Equal(1), "validation failed due to an unexpected error: %v", errorList)
-				Expect(errorList[0].Error()).To(Equal("cannot modify KubeMacPool configuration once it is deployed"))
+				Expect(errorList).To(BeEmpty(), "MAC range changes should be allowed")
+			})
+		})
+
+		Context("When both MAC ranges are different", func() {
+			It("should NOT return an error (MAC range changes are allowed)", func() {
+				previousClusterConfig := &cnao.NetworkAddonsConfigSpec{
+					KubeMacPool: &cnao.KubeMacPool{RangeStart: "02:00:00:00:00:00", RangeEnd: "0A:FF:FF:FF:FF:FF"}}
+				currentClusterConfig := &cnao.NetworkAddonsConfigSpec{
+					KubeMacPool: &cnao.KubeMacPool{RangeStart: "02:00:01:00:00:00", RangeEnd: "0A:FF:FF:FF:FF:F1"}}
+
+				errorList := changeSafeKubeMacPool(previousClusterConfig, currentClusterConfig)
+				Expect(errorList).To(BeEmpty(), "MAC range changes should be allowed")
 			})
 		})
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently CNAO CR API for kubemacpool, that holds the rangeStart,rangeEnd params, is only configurable on day1.

Following change [0] in kubemacpool that now allows for day2 range changes - this PR is removing operator validation that prevents day2 changes.

[0] https://github.com/k8snetworkplumbingwg/kubemacpool/pull/566

**Special notes for your reviewer**:

**Release note**:

```release-note
Allow kubemacpool API day2 changes.
```
