### PR TITLE
[release-0.99] Set ipam ext update-policy to static

### DIFF
--- a/components.yaml
+++ b/components.yaml
@@ -21,7 +21,7 @@ components:
     url: https://github.com/kubevirt/ipam-extensions
     commit: 7a580e38fd8b0f1531edfbc66a52b2885c7b0ced
     branch: release-0.2.4
-    update-policy: tagged
+    update-policy: static
     metadata: v0.2.4-1
   linux-bridge:
     url: https://github.com/containernetworking/plugins


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR sets ipam ext update-policy to static

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
