### PR TITLE
Fix monitoring flake

### DIFF
--- a/test/e2e/monitoring/rules_test.go
+++ b/test/e2e/monitoring/rules_test.go
@@ -30,7 +30,12 @@ var _ = Context("Prometheus Rules", func() {
 				MacvtapCni: &cnao.MacvtapCni{},
 			}
 			CreateConfig(gvk, configSpec)
+			components := []Component{MacvtapComponent}
+			CheckConfigComponents(gvk, components)
 			CheckConfigCondition(gvk, ConditionAvailable, ConditionTrue, 15*time.Minute, CheckDoNotRepeat)
+			CheckConfigCondition(gvk, ConditionProgressing, ConditionFalse, CheckImmediately, CheckDoNotRepeat)
+
+			CheckComponentsDeployment(components)
 		})
 
 		Context("CNAO alert rules", func() {


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR is fixing a [flake](https://prow.ci.kubevirt.io/view/gcs/kubevirt-prow/pr-logs/pull/kubevirt_cluster-network-addons-operator/2238/pull-e2e-cluster-network-addons-operator-monitoring-k8s/1914942140790607872), where the
prometheus-rules-cluster-network-addons-operator promRule was not yet
deployed, causing test flakes - adding the standard checks to make sure
the components are correctly deployed before moving to the test.

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
