### PR TITLE
Bump kubevirtci and enable flannel

### DIFF
--- a/cluster/cluster.sh
+++ b/cluster/cluster.sh
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 export KUBEVIRT_PROVIDER=${KUBEVIRT_PROVIDER:-'k8s-1.33'}
-export KUBEVIRTCI_TAG=${KUBEVIRTCI_TAG:-2509250927-f5abd488}
+export KUBEVIRTCI_TAG=${KUBEVIRTCI_TAG:-2510291918-9bf8091a}
 
 KUBEVIRTCI_REPO='https://github.com/kubevirt/kubevirtci.git'
 # The CLUSTER_PATH var is used in cluster folder and points to the _kubevirtci where the cluster is deployed from.


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the main branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it

If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**What this PR does / why we need it**:
Bump kubevirtci in order to consume bigger flannel pods per node subnet,
to overcome the lifecycle lane problem.

For more info see https://github.com/kubevirt/kubevirtci/pull/1557#issuecomment-3448479120

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
None
```
