### PR TITLE
test/kubectl: Fix port-forwarding setup flake

### DIFF
--- a/test/kubectl/kubectl.go
+++ b/test/kubectl/kubectl.go
@@ -41,8 +41,9 @@ func waitForPortForwardCmd(stdout io.ReadCloser, src, dst int) {
 	Eventually(func() string {
 		tmp := make([]byte, 1024)
 		_, err := stdout.Read(tmp)
-		Expect(err).NotTo(HaveOccurred())
-
+		if err != nil {
+			return ""
+		}
 		return string(tmp)
 	}, 30*time.Second, 1*time.Second).Should(ContainSubstring(fmt.Sprintf("Forwarding from 127.0.0.1:%d -> %d", src, dst)))
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently the port-forward to Prometheus setup is flaking, sometimes giving off an EOF error and failing the eventually. This PR is fixing it by returning an empty string on read errors instead of asserting, allowing Gomega's Eventually to naturally retry.

**Special notes for your reviewer**:
fix #2436 

**Release note**:
```release-note
NONE
```
