### PR TITLE
hack/install-go: Pin go installed on the CI to go.mod

### DIFF
--- a/automation/check-patch.e2e-multus-dynamic-networks-controller-functests.sh
+++ b/automation/check-patch.e2e-multus-dynamic-networks-controller-functests.sh
@@ -31,6 +31,7 @@ main() {
 
     echo "Install golang ..."
     cp hack/install-go.sh ${TMP_COMPONENT_PATH}/hack/install-go.sh
+    cp hack/go-version.sh ${TMP_COMPONENT_PATH}/hack/go-version.sh
     cd ${TMP_COMPONENT_PATH}
     BIN_DIR="${TMP_COMPONENT_PATH}/build/_output/go1.18/bin/"
     mkdir -p "$BIN_DIR"

--- a/hack/install-go.sh
+++ b/hack/install-go.sh
@@ -1,7 +1,11 @@
 #!/bin/bash -xe
 
 destination=$1
-version=$(curl -s https://go.dev/dl/?mode=json | jq -r ".[0].version")
+
+script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+go_mod_version=$("$script_dir/go-version.sh")
+version="go${go_mod_version}"
+
 arch=$(uname -m | sed 's/x86_64/amd64/')
 tarball=$version.linux-$arch.tar.gz
 url=https://dl.google.com/go/


### PR DESCRIPTION
**What this PR does / why we need it**:
This Pr pins the go installed on the CI to go.mod, due to a backwards compatibility https://github.com/golang/go/issues/74462

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
