### PR TITLE
[release-0.95] pin go ci to gomod

### DIFF
--- a/automation/check-patch.e2e-multus-dynamic-networks-controller-functests.sh
+++ b/automation/check-patch.e2e-multus-dynamic-networks-controller-functests.sh
@@ -31,6 +31,7 @@ main() {
 
     echo "Install golang ..."
     cp hack/install-go.sh ${TMP_COMPONENT_PATH}/hack/install-go.sh
+    cp hack/go-version.sh ${TMP_COMPONENT_PATH}/hack/go-version.sh
     cd ${TMP_COMPONENT_PATH}
     BIN_DIR="${TMP_COMPONENT_PATH}/build/_output/go1.18/bin/"
     mkdir -p "$BIN_DIR"

--- a/hack/install-go.sh
+++ b/hack/install-go.sh
@@ -1,7 +1,11 @@
 #!/bin/bash -xe
 
 destination=$1
-version=$(curl -s https://go.dev/dl/?mode=json | jq -r ".[0].version")
+
+script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+go_mod_version=$("$script_dir/go-version.sh")
+version="go${go_mod_version}"
+
 tarball=$version.linux-amd64.tar.gz
 url=https://dl.google.com/go/
 


### PR DESCRIPTION
**What this PR does / why we need it**:
manual backport to https://github.com/kubevirt/cluster-network-addons-operator/pull/2445

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
