### PR TITLE
e2e/monitoring: Fix test not waiting for monitoring component

### DIFF
--- a/test/e2e/monitoring/rules_test.go
+++ b/test/e2e/monitoring/rules_test.go
@@ -30,7 +30,7 @@ var _ = Context("Prometheus Rules", func() {
 				MacvtapCni: &cnao.MacvtapCni{},
 			}
 			CreateConfig(gvk, configSpec)
-			components := []Component{MacvtapComponent}
+			components := []Component{MacvtapComponent, MonitoringComponent}
 			CheckConfigComponents(gvk, components)
 			CheckConfigCondition(gvk, ConditionAvailable, ConditionTrue, 15*time.Minute, CheckDoNotRepeat)
 			CheckConfigCondition(gvk, ConditionProgressing, ConditionFalse, CheckImmediately, CheckDoNotRepeat)


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR is fixing a flake where the prom-rule is not existing after CNAO CR is ready. 

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
