### PR TITLE
[release-0.100] Bump kubemacpool to v0.49.3

### DIFF
--- a/components.yaml
+++ b/components.yaml
@@ -13,10 +13,10 @@ components:
     metadata: v0.0.23
   kubemacpool:
     url: https://github.com/k8snetworkplumbingwg/kubemacpool
-    commit: 5fde90513d3f27edc61aa1816e36cdba026e3ed1
+    commit: b88da8b2eb5a3a9d47d08d4697feb355efe5b634
     branch: release-0.49
     update-policy: tagged
-    metadata: v0.49.2
+    metadata: v0.49.3
   kubevirt-ipam-controller:
     url: https://github.com/kubevirt/ipam-extensions
     commit: e2c93f35c8e7d31513c3bb59620812873d45d72b

--- a/data/kubemacpool/kubemacpool.yaml
+++ b/data/kubemacpool/kubemacpool.yaml
@@ -125,7 +125,6 @@ spec:
   ports:
   - port: 443
     targetPort: 8000
-  publishNotReadyAddresses: true
   selector:
     control-plane: mac-controller-manager
 ---

--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -36,7 +36,7 @@ const (
 	MultusDynamicNetworksImageDefault  = "ghcr.io/k8snetworkplumbingwg/multus-dynamic-networks-controller@sha256:2a2bb32c0ea8b232b3dbe81c0323a107e8b05f8cad06704fca2efd0d993a87be"
 	LinuxBridgeCniImageDefault         = "quay.io/kubevirt/cni-default-plugins@sha256:976a24392c2a096c38c2663d234b2d3131f5c24558889196d30b9ac1b6716788"
 	LinuxBridgeMarkerImageDefault      = "quay.io/kubevirt/bridge-marker@sha256:bf269af61e618857e7b14439cfc003aac2d65db9ee633147a73f5d9648dab377"
-	KubeMacPoolImageDefault            = "quay.io/kubevirt/kubemacpool@sha256:f9e5151798acc03798a007eacf51bc7a579c5e5a57851836eae601cc1eaa1c30"
+	KubeMacPoolImageDefault            = "quay.io/kubevirt/kubemacpool@sha256:7097c4e1686020a387b73000c9f78a85e064f78b64222647ef806aa4f3bb8410"
 	OvsCniImageDefault                 = "ghcr.io/k8snetworkplumbingwg/ovs-cni-plugin@sha256:435f374b434b3bc70a5cfaba0011fdcf5f433d96b98b06d29306cbd8db3a8c21"
 	MacvtapCniImageDefault             = "quay.io/kubevirt/macvtap-cni@sha256:af31faae20c0128a469dd4c1aa866d6bf78d1d2f5972127adf4c9438dcde10f4"
 	KubeRbacProxyImageDefault          = "quay.io/brancz/kube-rbac-proxy@sha256:e6a323504999b2a4d2a6bf94f8580a050378eba0900fd31335cf9df5787d9a9b"

--- a/test/releases/99.0.0.go
+++ b/test/releases/99.0.0.go
@@ -42,7 +42,7 @@ func init() {
 				ParentName: "kubemacpool-mac-controller-manager",
 				ParentKind: "Deployment",
 				Name:       "manager",
-				Image:      "quay.io/kubevirt/kubemacpool@sha256:f9e5151798acc03798a007eacf51bc7a579c5e5a57851836eae601cc1eaa1c30",
+				Image:      "quay.io/kubevirt/kubemacpool@sha256:7097c4e1686020a387b73000c9f78a85e064f78b64222647ef806aa4f3bb8410",
 			},
 			{
 				ParentName: "kubemacpool-mac-controller-manager",
@@ -54,7 +54,7 @@ func init() {
 				ParentName: "kubemacpool-cert-manager",
 				ParentKind: "Deployment",
 				Name:       "manager",
-				Image:      "quay.io/kubevirt/kubemacpool@sha256:f9e5151798acc03798a007eacf51bc7a579c5e5a57851836eae601cc1eaa1c30",
+				Image:      "quay.io/kubevirt/kubemacpool@sha256:7097c4e1686020a387b73000c9f78a85e064f78b64222647ef806aa4f3bb8410",
 			},
 			{
 				ParentName: "ovs-cni-amd64",


### PR DESCRIPTION
**What this PR does / why we need it**:
bump kubemacpool to v0.49.3

**Special notes for your reviewer**:

**Release note**:

```release-note
bump kubemacpool to v0.49.3
```
