### PR TITLE
bridge marker: Fix readOnlyRootFilesystem

### DIFF
--- a/data/linux-bridge/003-bridge-marker.yaml
+++ b/data/linux-bridge/003-bridge-marker.yaml
@@ -50,6 +50,8 @@ spec:
           volumeMounts:
             - name: tmp
               mountPath: /tmp
+          securityContext:
+            readOnlyRootFilesystem: true
       affinity: {{ toYaml .Placement.Affinity | nindent 8 }}
       volumes:
         - name: tmp
@@ -57,7 +59,6 @@ spec:
       securityContext:
         runAsNonRoot: true
         runAsUser: 1001
-        readOnlyRootFilesystem: true
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1

--- a/hack/components/bump-bridge-marker.sh
+++ b/hack/components/bump-bridge-marker.sh
@@ -32,7 +32,7 @@ function __parametize_by_object() {
 				yaml-utils::set_param ${f} spec.template.spec.containers[0].volumeMounts[0].mountPath '/tmp'
 				yaml-utils::set_param ${f} spec.template.spec.securityContext.runAsNonRoot 'true'
 				yaml-utils::set_param ${f} spec.template.spec.securityContext.runAsUser '1001'
-				yaml-utils::set_param ${f} spec.template.spec.securityContext.readOnlyRootFilesystem 'true'
+				yaml-utils::set_param ${f} spec.template.spec.containers[0].securityContext.readOnlyRootFilesystem 'true'
 				yaml-utils::remove_single_quotes_from_yaml ${f}
 				;;
 		esac


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the main branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it

If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**What this PR does / why we need it**:
Fixes the following error (the object was still created despite it).

`{"level":"info","ts":"2025-11-19T14:37:42Z","msg":"unknown field \"spec.template.spec.securityContext.readOnlyRootFilesystem\""}`

It should be under container level.

Field purpose is to block writing to all `/`, beside the mounted folders.

**Special notes for your reviewer**:
Interesting that on KCLI (based on k8s 1.32), it doesn't print the error, and the fields is created under the container.
It is possible that SCC admission controller mutates it.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
None
```
