### PR TITLE
bumper: Fix tag sorting to use semantic versioning

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.24.3
 toolchain go1.24.10
 
 require (
+	github.com/Masterminds/semver/v3 v3.3.1
 	github.com/Masterminds/sprig v2.22.0+incompatible
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/coreos/go-semver v0.3.1
@@ -55,7 +56,6 @@ require (
 	github.com/MakeNowJust/heredoc v1.0.0 // indirect
 	github.com/Masterminds/goutils v1.1.1 // indirect
 	github.com/Masterminds/semver v1.5.0 // indirect
-	github.com/Masterminds/semver/v3 v3.3.1 // indirect
 	github.com/Masterminds/sprig/v3 v3.3.0 // indirect
 	github.com/Masterminds/squirrel v1.5.4 // indirect
 	github.com/Microsoft/go-winio v0.6.2 // indirect


### PR DESCRIPTION
**What this PR does / why we need it**:
GetLatestTaggedFromBranch incorrectly assumes tags are semantically ordered, but GitHub API has no such constraint. This causes, for example, that v0.9.0 to be selected over v0.49.3 (since '9' > '4' in strings).

example from gitActions run:
https://github.com/kubevirt/cluster-network-addons-operator/actions/runs/19545022389/job/55961491110#step:5:139

This PR fixes the function logic to parse tags as semantic versions, sort descending, and return the first tag found on target branch. Tags that don't parse as semver are skipped with a log message.

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
