### PR TITLE
network-policies: Update opt-in label provided by HCO

### DIFF
--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -182,9 +182,9 @@ func GetDeployment(version string, operatorVersion string, namespace string, rep
 						"name":                   Name,
 						names.PrometheusLabelKey: names.PrometheusLabelValue,
 						// opt-in to hco-bundle network-policy allowing egress to cluster services
-						"hco.kubevirt.io/allow-access-cluster-services": "",
+						"np.kubevirt.io/allow-access-cluster-services": "",
 						// opt-in to hco-bundle network-policy allowing ingress to the metrics endpoint
-						"hco.kubevirt.io/allow-prometheus-access": "",
+						"np.kubevirt.io/allow-prometheus-access": "",
 					},
 					Annotations: map[string]string{
 						"description": "cluster-network-addons-operator manages the lifecycle of different Kubernetes network components on top of Kubernetes cluster",


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the main branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it

If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**What this PR does / why we need it**:
HCO labels for network-policy opt-in has been changed,

Use the new labels for opting in for network-policies provided by HCO.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
