### PR TITLE
Fix prepare-minor/patch/major to handle RC versions correctly

### DIFF
--- a/hack/bump-version.sh
+++ b/hack/bump-version.sh
@@ -7,6 +7,20 @@ bump() {
     local version="$1"
     local bump_type="$2"
 
+    # If version is a pre-release (RC), strip it and decide what to do
+    if [[ $version =~ -rc-[0-9]+$ ]]; then
+        local base_version=$(echo $version | sed 's/-rc-[0-9]\+$//')
+
+        # Patch bump always removes the RC
+        if [[ $bump_type == "patch" ]]; then
+            echo $base_version
+            return
+        fi
+
+        # Minor/Major bumps: strip RC, then apply the bump
+        version=$base_version
+    fi
+
     case $bump_type in
         major)
             local major=$(echo $version | sed 's/^\([0-9]\+\)\..*$/\1/')


### PR DESCRIPTION
**What this PR does / why we need it**:
When the current version is an RC (e.g., v0.101.0-rc-0), running `make prepare-minor` should strip the RC suffix to create the final release (v0.101.0), not bump to the next minor version (v0.102.0).

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
