### PR TITLE
makefile: Fix release target for Go 1.24 tool directive

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -220,11 +220,11 @@ release-notes:
 	hack/render-release-notes.sh $(WHAT)
 
 release: $(GO)
-	GITHUB_RELEASE=$(GITHUB_RELEASE) \
-	TAG=v$(shell hack/version.sh) \
-	  hack/release.sh \
-	    manifests/cluster-network-addons/cluster-network-addons.package.yaml \
-	    $(shell find manifests/cluster-network-addons/$(shell hack/version.sh) -type f)
+	export GITHUB_RELEASE="$(GITHUB_RELEASE)"; \
+	export TAG=v$(shell hack/version.sh); \
+	hack/release.sh \
+	  manifests/cluster-network-addons/cluster-network-addons.package.yaml \
+	  $(shell find manifests/cluster-network-addons/$(shell hack/version.sh) -type f)
 
 vendor: $(GO)
 	$(GO) mod tidy -compat=$(GO_VERSION)


### PR DESCRIPTION
**What this PR does / why we need it**:
The Go 1.24 tool directive migration was intoroduced on former [change](https://github.com/kubevirt/cluster-network-addons-operator/pull/2493), but the release target had a shell parsing issue.

When GITHUB_RELEASE expands to "/path/to/go tool github-release" (containing spaces) and is used as an inline environment variable:
  GITHUB_RELEASE=$(GITHUB_RELEASE) TAG=... hack/release.sh
The shell parses it as:
  GITHUB_RELEASE=/path/to/go (env var)
  tool (command to execute - not found!)

Fixed by using export statements with quoted values instead of inline environment variable assignments.

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
