### PR TITLE
bumper: Verify new release image exist

### DIFF
--- a/components.yaml
+++ b/components.yaml
@@ -17,12 +17,14 @@ components:
     branch: main
     update-policy: latest
     metadata: v0.50.0-25-g5727cd1
+    image: quay.io/kubevirt/kubemacpool
   kubevirt-ipam-controller:
     url: https://github.com/kubevirt/ipam-extensions
     commit: e1c5d84f5604e4bf833d45d8e98b743fe6f31be3
     branch: main
     update-policy: tagged
     metadata: v0.6.0-rc1
+    image: quay.io/kubevirt/ipam-controller
   linux-bridge:
     url: https://github.com/containernetworking/plugins
     commit: c29dc79f96cd50452a247a4591443d2aac033429

--- a/tools/bumper/bumper.go
+++ b/tools/bumper/bumper.go
@@ -73,6 +73,11 @@ func main() {
 			exitWithError(errors.Wrapf(err, "Failed to get latest release version tag from %s", componentName))
 		}
 
+		if err := verifyNewReleaseTagImageExist(component.Image, updatedReleaseTag); err != nil {
+			exitWithError(errors.Wrapf(err, "Failed to verify image exist for component %q image %q updated release tag %q",
+				componentName, component.Image, updatedReleaseTag))
+		}
+
 		proposedPrTitle := fmt.Sprintf("bump %s to %s", componentName, updatedReleaseTag)
 		componentBumpNeeded, err := cnaoRepo.isComponentBumpNeeded(currentReleaseTag, updatedReleaseTag,
 			component.Updatepolicy, component.Metadata, proposedPrTitle)

--- a/tools/bumper/component_commands.go
+++ b/tools/bumper/component_commands.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"os/exec"
 	"sort"
 	"strings"
 
@@ -141,6 +142,15 @@ func newGitRepo(componentName string, componentParams *component) (*gitRepo, err
 		repo:     repo,
 		localDir: repoDir,
 	}, nil
+}
+
+func verifyNewReleaseTagImageExist(componentImage, newReleaseTag string) error {
+	if componentImage == "" {
+		return nil
+	}
+	logger.Printf("Checking container image tag exist %q %q", componentImage, newReleaseTag)
+	return exec.Command("skopeo", "inspect", fmt.Sprintf("docker://%s:%s", componentImage, newReleaseTag)).Run()
+
 }
 
 // getCurrentReleaseTag gets the tag name of currently configured commit sha in this component.

--- a/tools/bumper/parser.go
+++ b/tools/bumper/parser.go
@@ -15,6 +15,7 @@ type component struct {
 	Branch       string `yaml:"branch"`
 	Updatepolicy string `yaml:"update-policy"`
 	Metadata     string `yaml:"metadata"`
+	Image        string `yaml:"image"`
 }
 
 type componentsConfig struct {


### PR DESCRIPTION


<!-- Thanks for sending a pull request!

Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the main branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it

If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**What this PR does / why we need it**:
Currently when a components release is issued, it take time for the image to upload to the registry.
The result is the auto-bumper posting bump PR but the image is not available yet.

To workaround this check that the component new release image exist before posting a PR.

Extent components.yaml to contain the container image base tag.

The check assume the new image tag match the 'metadata' field.

**Special notes for your reviewer**:
The new check relay on the fact the new release image tag is the same as the release tag.
For example, ipam-ext release is `v0.6.0-rc1`, the release container image tag will be `ghcr.io/kubevirt/ipam-controller:v0.6.0-rc1`.

This PR may not work for Kubemacpool as expected:
Kubemacpool release tags doesnt equal to the release image tag, for example:
release tag - `v0.50.0-25-g5727cd1` -
https://github.com/kubevirt/cluster-network-addons-operator/blob/main/components.yaml#L19
container image tag - `v0.50.0-25-g5727cd18`
https://quay.io/repository/kubevirt/kubemacpool?tab=tags&tag=%20v0.50.0-25-g5727cd18
It seems that the container tag missing containing one extra character (from the commit SHA).

Possible workaround would to address this on kubemacpool release process side.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note

```
