### PR TITLE
Fix goimports-check to validate test/ and tools/ directories

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -106,7 +106,7 @@ vet: $(GO) $(cmd_sources) $(pkg_sources)
 	touch $@
 
 goimports-check: $(GO) $(cmd_sources) $(pkg_sources)
-	$(GO) tool goimports -d ./pkg ./cmd
+	$(GO) tool goimports -d ./pkg ./cmd ./test/ ./tools/
 	touch $@
 
 test/unit: $(GO)


### PR DESCRIPTION
## Summary
- Align `goimports-check` target with `goimports` by adding `./test/` and `./tools/` to the checked directories

## Root cause
The `goimports-check` Makefile target only validated `./pkg` and `./cmd`, while the `goimports` formatting target operated on `./pkg`, `./cmd`, `./test/`, and `./tools/`. This gap meant `make check` could pass even when files under `test/` or `tools/` had import formatting drift.

## Change
One-line diff in `Makefile`: added `./test/` and `./tools/` to the `goimports-check` command, matching the `goimports` target.

## Validation
- `make -n goimports-check` dry-run confirms the updated command includes all four directories
- No other targets or behaviors are affected

Fixes #2680

🤖 Generated with [Claude Code](https://claude.com/claude-code)