### PR TITLE
Align goimports-check directories with goimports target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -106,7 +106,7 @@ vet: $(GO) $(cmd_sources) $(pkg_sources)
 	touch $@
 
 goimports-check: $(GO) $(cmd_sources) $(pkg_sources)
-	$(GO) tool goimports -d ./pkg ./cmd
+	$(GO) tool goimports -d ./pkg ./cmd ./test/ ./tools/
 	touch $@
 
 test/unit: $(GO)


### PR DESCRIPTION
## Summary
- Align `goimports-check` Makefile target to validate the same directories as `goimports`

## Root cause
The `goimports-check` target only checked `./pkg` and `./cmd`, while the `goimports` formatting target operated on `./pkg`, `./cmd`, `./test/`, and `./tools/`. This gap meant `make check` could pass even when files under `test/` or `tools/` had import formatting drift.

## Change
One-line diff in `Makefile`: added `./test/` and `./tools/` to the `goimports-check` command, matching the `goimports` target.

## Validation
```bash
# Dry-run to confirm updated command includes all four directories:
make -n goimports-check

# Full validation:
make goimports-check
make check
```

Fixes: https://github.com/kubevirt/cluster-network-addons-operator/issues/2680

```release-note
Fix goimports-check to validate test/ and tools/ directories
```