### PR TITLE
Fix goimports-check to validate test/ and tools/ dirs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -106,7 +106,7 @@ vet: $(GO) $(cmd_sources) $(pkg_sources)
 	touch $@
 
 goimports-check: $(GO) $(cmd_sources) $(pkg_sources)
-	$(GO) tool goimports -d ./pkg ./cmd
+	$(GO) tool goimports -d ./pkg ./cmd ./test/ ./tools/
 	touch $@
 
 test/unit: $(GO)


### PR DESCRIPTION
## Summary
- Adds `./test/` and `./tools/` to the `goimports-check` Makefile target so it validates the same directories as `goimports`

## Root cause
The `goimports` formatting target (line 90) runs on `./pkg ./cmd ./test/ ./tools/`, but `goimports-check` (line 109) only checked `./pkg ./cmd`. This gap meant `make check` could pass even when import formatting in `test/` or `tools/` was out of sync.

## What changed
One line in `Makefile`: added `./test/ ./tools/` to the `goimports-check` command.

## Validation
```bash
# Verify both targets now cover the same directories:
grep -n 'goimports' Makefile
# Line 90: $(GO) tool goimports -w ./pkg ./cmd ./test/ ./tools/
# Line 109: $(GO) tool goimports -d ./pkg ./cmd ./test/ ./tools/
```

Fixes: #2680

🤖 Generated with [Claude Code](https://claude.com/claude-code)