### PR TITLE
Fix goimports-check to validate test/ and tools/ directories

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -106,7 +106,7 @@ vet: $(GO) $(cmd_sources) $(pkg_sources)
 	touch $@
 
 goimports-check: $(GO) $(cmd_sources) $(pkg_sources)
-	$(GO) tool goimports -d ./pkg ./cmd
+	$(GO) tool goimports -d ./pkg ./cmd ./test/ ./tools/
 	touch $@
 
 test/unit: $(GO)


### PR DESCRIPTION
## Summary

The `goimports-check` Makefile target only validated `./pkg` and `./cmd`, while the `goimports` formatting target also covered `./test/` and `./tools/`. This allowed import formatting drift in those directories to pass `make check` undetected.

## Changes

- Added `./test/` and `./tools/` to the `goimports-check` command in the Makefile (one-line change)

## Root cause

The directory lists in `goimports` (line 90) and `goimports-check` (line 109) were out of sync. `goimports` used `-w ./pkg ./cmd ./test/ ./tools/` but `goimports-check` only used `-d ./pkg ./cmd`.

## Validation

- `make -n goimports-check` confirms the updated command now includes all four directories
- `make -n goimports` confirms both targets now operate on the same directory set
- The only difference between the two commands is the flag: `-w` (write) vs `-d` (diff), which is correct

## Why this PR

Prior PRs #2681, #2684, and #2689 contained the same correct fix but were blocked by missing DCO signoff or release-note formatting. This PR includes both.

Fixes: #2680

```release-note
Fix goimports-check Makefile target to validate test/ and tools/ directories
```