### PR TITLE
[release-0.102] components/kubemacpool: Convert TLS cipher names to Go format

### DIFF
--- a/pkg/network/kubemacpool.go
+++ b/pkg/network/kubemacpool.go
@@ -121,7 +121,7 @@ func renderKubeMacPool(conf *cnao.NetworkAddonsConfigSpec, manifestDir string, c
 	}
 
 	ciphers, tlsMinVersion := SelectCipherSuitesAndMinTLSVersion(conf.TLSSecurityProfile)
-	data.Data["TLSSecurityProfileCiphers"] = strings.Join(ciphers, ",")
+	data.Data["TLSSecurityProfileCiphers"] = strings.Join(OCPTLSProfileCiphersToGoCipherNames(ciphers), ",")
 	data.Data["TLSMinVersion"] = string(tlsMinVersion)
 
 	objs, err := render.RenderDir(filepath.Join(manifestDir, "kubemacpool"), &data)


### PR DESCRIPTION
**What this PR does / why we need it**:
This is a manual commit cherry pick of https://github.com/kubevirt/cluster-network-addons-operator/pull/2688/changes/109438d5e80b9e6909cae4c3a2e92474404aab78

**Special notes for your reviewer**:

**Release note**:

```release-note
components/kubemacpool: Convert TLS cipher names to Go format
```
