### PR TITLE
hack: Prefer go toolchain version in go-version.sh

### DIFF
--- a/hack/go-version.sh
+++ b/hack/go-version.sh
@@ -1,2 +1,7 @@
 #!/bin/bash -e
-grep ^go go.mod | awk '{print $2}'
+toolchain=$(grep '^toolchain' go.mod | awk '{print $2}' | sed 's/^go//')
+if [ -n "$toolchain" ]; then
+    echo "$toolchain"
+else
+    grep '^go' go.mod | awk '{print $2}'
+fi


### PR DESCRIPTION
**What this PR does / why we need it**:
When a `toolchain` directive is present in go.mod, use its version instead of the `go` directive. This ensures that install-go.sh downloads the correct patch-level Go binary and that Makefile's GO_VERSION reflects the intended toolchain.

This PR makes the repo toolchain aware.

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
