### PR TITLE
kubemacpool: use RUNBOOK_URL_TEMPLATE for MAC collision alert

### DIFF
--- a/data/kubemacpool/kubemacpool-monitoring.yaml
+++ b/data/kubemacpool/kubemacpool-monitoring.yaml
@@ -63,7 +63,7 @@ spec:
         - alert: KubemacpoolMACCollisionDetected
           annotations:
             description: '{{ "{{" }} $value {{ "}}" }} MAC address(es) have collisions. Multiple running objects are using the same MAC address.'
-            runbook_url: https://kubevirt.io/monitoring/runbooks/KubemacpoolMACCollisionDetected
+            runbook_url: '{{ printf .RunbookURLTemplate "KubemacpoolMACCollisionDetected" }}'
             summary: MAC address collisions detected.
           expr: count(kmp_mac_collisions > 1) > 0
           for: 30s

--- a/hack/components/bump-kubemacpool.sh
+++ b/hack/components/bump-kubemacpool.sh
@@ -105,6 +105,8 @@ function __parametize_by_object() {
 				yaml-utils::update_param ${f} metadata.namespace '{{ .Namespace }}'
 				# Escape Go template expressions ({{ $value }} -> {{ "{{" }} $value {{ "}}" }})
 				sed -i 's/{{ \$value }}/{{ "{{" }} $value {{ "}}" }}/g' ${f}
+				# Templatize runbook URL to use RUNBOOK_URL_TEMPLATE
+				sed -i "s|runbook_url:.*|runbook_url: '{{ printf .RunbookURLTemplate \"KubemacpoolMACCollisionDetected\" }}'|" ${f}
 				;;
 			./ServiceMonitor_kubemacpool-metrics-monitor.yaml)
 				yaml-utils::update_param ${f} metadata.namespace '{{ .Namespace }}'

--- a/pkg/network/kubemacpool.go
+++ b/pkg/network/kubemacpool.go
@@ -8,11 +8,12 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/kubevirt/cluster-network-addons-operator/pkg/render"
 	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	cnao "github.com/kubevirt/cluster-network-addons-operator/pkg/apis/networkaddonsoperator/shared"
+	"github.com/kubevirt/cluster-network-addons-operator/pkg/monitoring/rules/alerts"
+	"github.com/kubevirt/cluster-network-addons-operator/pkg/render"
 )
 
 // ValidateMultus validates the combination of DisableMultiNetwork and AddtionalNetworks
@@ -123,6 +124,7 @@ func renderKubeMacPool(conf *cnao.NetworkAddonsConfigSpec, manifestDir string, c
 	ciphers, tlsMinVersion := SelectCipherSuitesAndMinTLSVersion(conf.TLSSecurityProfile)
 	data.Data["TLSSecurityProfileCiphers"] = strings.Join(OCPTLSProfileCiphersToGoCipherNames(ciphers), ",")
 	data.Data["TLSMinVersion"] = string(tlsMinVersion)
+	data.Data["RunbookURLTemplate"] = alerts.GetRunbookURLTemplate()
 
 	objs, err := render.RenderDir(filepath.Join(manifestDir, "kubemacpool"), &data)
 	if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
The KubemacpoolMACCollisionDetected alert had a hardcoded runbook URL, bypassing the existing RUNBOOK_URL_TEMPLATE mechanism. 

This PR passes the template through YAML rendering so the URL respects the configured environment variable.

**Special notes for your reviewer**:

**Release note**:

```release-note
Fix KubemacpoolMACCollisionDetected runbook url
```
