### PR TITLE
CI Failure: kubevirt/cluster-network-addons-operator/kubevirt-ipam-controller.yaml / The kubevirt-ipam-controller e2e test is failing during

### DIFF
--- a/automation/check-patch.e2e-kubevirt-ipam-controller-functests.sh
+++ b/automation/check-patch.e2e-kubevirt-ipam-controller-functests.sh
@@ -56,7 +56,7 @@ main() {
 
     cd ${TMP_COMPONENT_PATH}
     export KUBECONFIG=${TMP_COMPONENT_PATH}/.output/kubeconfig
-    export KIND_ARGS="-ic -i6 -mne -nse"
+    export KIND_ARGS="-i6 -mne -nse"
     make cluster-up
 
     trap teardown EXIT


### PR DESCRIPTION
Fixes #2730

**What this PR does / why we need it**:

This PR fixes the failing kubevirt-ipam-controller e2e test by removing the invalid `-ic` flag from the `KIND_ARGS` environment variable in the test setup script.

The test was failing during cluster setup because the `-ic` flag is no longer recognized by the ovn-kubernetes `kind.sh` script. The ovn-kubernetes repository (cloned from master branch by ipam-extensions) either removed this flag or never supported it, causing the script to reject the arguments and exit with error code 1.

**Special notes for your reviewer**:

The fix is minimal and surgical - it only removes the problematic `-ic` flag while keeping all other flags (`-i6`, `-mne`, `-nse`) that are still valid and required for the test environment setup.

The periodic CI job has been failing since May 19, 2026, after ovn-kubernetes introduced a breaking change to their argument parsing.

**Release note**:

```release-note
NONE
```

<!-- oompa-bot v:b463d3b -->