### PR TITLE
CI Failure: pull-e2e-cluster-network-addons-operator-workflow-k8s / The `pull-e2e-cluster-network-addons-operator-workflow-k8s`

### DIFF
--- a/hack/deploy-kubevirt.sh
+++ b/hack/deploy-kubevirt.sh
@@ -26,6 +26,6 @@ until ./cluster/kubectl.sh -n kubevirt get kv kubevirt; do
     sleep 1
 done
 
-./cluster/kubectl.sh wait -n kubevirt kv kubevirt --for condition=Available --timeout 360s || (echo "KubeVirt not ready in time" && exit 1)
+./cluster/kubectl.sh wait -n kubevirt kv kubevirt --for condition=Available --timeout 600s || (echo "KubeVirt not ready in time" && exit 1)
 
 echo "basename -- $0 done"


### PR DESCRIPTION
Fixes #2735

**What this PR does / why we need it**:

This PR increases the KubeVirt deployment timeout from 360s (6 minutes) to 600s (10 minutes) in the `hack/deploy-kubevirt.sh` script to address CI timeouts in the `pull-e2e-cluster-network-addons-operator-workflow-k8s` job.

The CI job was failing during infrastructure setup because:
- Cluster image download takes ~6 minutes
- KubeVirt deployment timeout was only 360s (6 minutes)
- The job was terminated before KubeVirt could fully initialize

The new 600s timeout aligns with other component timeouts in the codebase (e.g., operator install uses 600s) and provides more breathing room for KubeVirt to become ready in CI environments with variable performance.

**Special notes for your reviewer**:

While this change addresses the immediate timeout issue in the repository's control, it doesn't fully resolve the underlying Prow job timeout constraint (~10 minutes overall). If this pattern persists, the Prow job configuration in kubevirt/project-infra may need adjustment to increase the overall job timeout to 20-30 minutes.

**Release note**:

```release-note
NONE
```

<!-- oompa-bot v:b366a0d -->