### PR TITLE
CI Failure: pull-e2e-cluster-network-addons-operator-monitoring-k8s / The `pull-e2e-cluster-network-addons-operator-monitoring-k8s

### DIFF
--- a/build/operator/Dockerfile
+++ b/build/operator/Dockerfile
@@ -1,13 +1,6 @@
 ARG BUILD_ARCH=amd64
-FROM --platform=linux/${BUILD_ARCH} quay.io/centos/centos:stream9 AS builder
+FROM --platform=linux/${BUILD_ARCH} docker.io/library/golang:1.25.7 AS builder
 
-RUN dnf install -y tar gzip jq && dnf clean all
-RUN ARCH=$(uname -m | sed 's/x86_64/amd64/') && \
-    GO_VERSION=$(curl -L -s "https://go.dev/dl/?mode=json" | jq -r '.[0].version') && \
-    curl -L "https://go.dev/dl/${GO_VERSION}.linux-${ARCH}.tar.gz" -o go.tar.gz && \
-    tar -C /usr/local -xzf go.tar.gz && \
-    rm go.tar.gz
-ENV PATH=$PATH:/usr/local/go/bin
 WORKDIR /go/src/cluster-network-addons-operator
 COPY . .
 


### PR DESCRIPTION
Fixes #2737

**What this PR does / why we need it**:

This PR addresses intermittent CI failures in the monitoring e2e test by making the Docker build process more resilient and efficient. The Dockerfile was dynamically downloading Go from go.dev during each build, which added unnecessary network dependencies, increased build time, and made builds more susceptible to infrastructure issues.

The change replaces the CentOS base image with dynamic Go installation with the official `golang:1.25.7` builder image. This eliminates network calls during the build, uses the exact Go version specified in go.mod, and makes builds more deterministic and faster.

**Special notes for your reviewer**:

- The change only affects the builder stage of the Dockerfile - the final runtime image remains unchanged (CentOS Stream 9)
- The Go version (1.25.7) matches what is specified in the project's go.mod file
- This should reduce build times and make the CI more reliable by removing external network dependencies during the build phase

**Release note**:

```release-note
NONE
```

<!-- oompa-bot v:b366a0d -->