### PR TITLE
CI Failure: pull-e2e-cluster-network-addons-operator-kubemacpool-functests / The `pull-e2e-cluster-network-addons-operator-kubemacpool-fu

### DIFF
--- a/build/operator/Dockerfile
+++ b/build/operator/Dockerfile
@@ -28,8 +28,6 @@ ENV ENTRYPOINT=/entrypoint \
     HOME=/home/${USER_NAME}
 
 RUN \
-    yum -y update && \
-    yum clean all && \
     mkdir -p ${HOME} && \
     chown ${USER_UID}:0 ${HOME} && \
     chmod ug+rwx ${HOME}


### PR DESCRIPTION
Fixes #2739

**What this PR does / why we need it**:

This PR fixes a CI timeout issue in the `pull-e2e-cluster-network-addons-operator-kubemacpool-functests` job by removing the `yum -y update` command from the operator Dockerfile.

The CI job was timing out after 4+ hours during the container image build phase while executing `yum -y update`, which downloads and installs all available CentOS Stream 9 package updates. This operation has non-deterministic execution time and adds significant overhead to every CI build without providing value in ephemeral environments.

**Special notes for your reviewer**:

The base image `quay.io/centos/centos:stream9` is regularly updated with security patches upstream. Security updates should be addressed by pulling newer base image versions rather than running updates at build time, which is a common best practice for CI/CD container builds.

This change removes only the `yum -y update` and `yum clean all` commands from the RUN instruction, while preserving all other necessary setup steps (creating home directory, setting permissions).

**Release note**:

```release-note
NONE
```

<!-- oompa-bot v:b366a0d -->