### PR TITLE
CI Failure: pull-e2e-cluster-network-addons-operator-multus-functests / The `pull-e2e-cluster-network-addons-operator-multus-functes

### DIFF
--- a/automation/components-functests.setup.sh
+++ b/automation/components-functests.setup.sh
@@ -24,6 +24,12 @@ source cluster/cluster.sh
 USE_KUBEVIRTCI=${USE_KUBEVIRTCI:-"true"}
 CNAO_DEPLOY_KUBEVIRT=${CNAO_DEPLOY_KUBEVIRT:-"false"}
 
+# Pre-pull yq image to avoid timeout issues during yaml parsing
+# The yaml-utils functions use this image multiple times, and pulling
+# on-demand can be slow in CI environments
+echo "Pre-pulling yq container image..."
+${OCI_BIN} pull docker.io/mikefarah/yq:3.3.4 || true
+
 # Export .kubeconfig full path, so it will be possible
 # to use 'kubectl' directly from the component directory path
 export KUBECONFIG=${KUBECONFIG:-$(cluster::kubeconfig)}


### PR DESCRIPTION
Fixes #2741

**What this PR does / why we need it**:

This PR fixes a CI timeout issue in the `pull-e2e-cluster-network-addons-operator-multus-functests` job by pre-pulling the yq container image before it's needed during setup. The job was timing out while attempting to pull the `docker.io/mikefarah/yq:3.3.4` image during yaml parsing operations.

The fix adds an explicit pre-pull step at the beginning of `components-functests.setup.sh` to ensure the yq image is cached before any yaml-utils functions are invoked. This prevents slow on-demand image pulls from contributing to timeout issues during the setup phase.

**Special notes for your reviewer**:

This follows the same pattern as recent CI timeout mitigation fixes (#2739, #2735, #2732) that addressed similar infrastructure timeout issues by removing or optimizing expensive operations during setup.

The `|| true` suffix ensures the script continues even if the image pull fails (e.g., if the image is already cached or if there's a transient network issue), maintaining backward compatibility.

**Release note**:

```release-note
NONE
```

<!-- oompa-bot v:b366a0d -->