### PR TITLE
CI Failure: pull-e2e-cluster-network-addons-operator-br-marker-functests / The `pull-e2e-cluster-network-addons-operator-br-marker-func

### DIFF
--- a/automation/components-functests.setup.sh
+++ b/automation/components-functests.setup.sh
@@ -24,6 +24,12 @@ source cluster/cluster.sh
 USE_KUBEVIRTCI=${USE_KUBEVIRTCI:-"true"}
 CNAO_DEPLOY_KUBEVIRT=${CNAO_DEPLOY_KUBEVIRT:-"false"}
 
+# Pre-pull yq image to avoid timeout issues during yaml parsing
+# The yaml-utils functions use this image multiple times, and pulling
+# on-demand can be slow in CI environments
+echo "Pre-pulling yq container image..."
+${OCI_BIN} pull docker.io/mikefarah/yq:3.3.4 || true
+
 # Export .kubeconfig full path, so it will be possible
 # to use 'kubectl' directly from the component directory path
 export KUBECONFIG=${KUBECONFIG:-$(cluster::kubeconfig)}


### PR DESCRIPTION
Fixes #2743

**What this PR does / why we need it**:

This PR fixes a CI failure in the `pull-e2e-cluster-network-addons-operator-br-marker-functests` job by pre-pulling the `docker.io/mikefarah/yq:3.3.4` container image before it's needed by yaml-utils functions.

The bridge-marker-functests CI job was timing out during infrastructure setup when attempting to pull the yq container image on-demand. In the Prow CI environment, slow or variable network performance caused the image pull to exceed timeout constraints, terminating the job before tests could even begin.

The fix adds a pre-pull step in `automation/components-functests.setup.sh` that:
- Pulls the yq image upfront with explicit error handling (`|| true`)
- Ensures subsequent yaml-utils function calls use the cached image
- Prevents image pull operations from contributing to timeout during critical yaml parsing

This is the same root cause and solution as issue #2741 (multus-functests) and applies to all component functests that use the shared setup infrastructure.

**Special notes for your reviewer**:

- This fix follows the same pattern used to resolve similar timeout issues in other component functest jobs (#2732, #2735, #2737, #2739, #2741)
- The `|| true` ensures that if the pre-pull fails for any reason, it won't hard-fail the setup (the image will be pulled on first use as before)
- The pre-pull happens after sourcing `yaml-utils.sh` which exports `${OCI_BIN}`, so the variable is guaranteed to be available

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```

<!-- oompa-bot v:b366a0d -->