### PR TITLE
CI Failure: pull-e2e-cluster-network-addons-operator-ovs-cni-functests / The `pull-e2e-cluster-network-addons-operator-ovs-cni-functe

### DIFF
--- a/automation/components-functests.setup.sh
+++ b/automation/components-functests.setup.sh
@@ -24,6 +24,12 @@ source cluster/cluster.sh
 USE_KUBEVIRTCI=${USE_KUBEVIRTCI:-"true"}
 CNAO_DEPLOY_KUBEVIRT=${CNAO_DEPLOY_KUBEVIRT:-"false"}
 
+# Pre-pull yq image to avoid timeout issues during yaml parsing
+# The yaml-utils functions use this image multiple times, and pulling
+# on-demand can be slow in CI environments
+echo "Pre-pulling yq container image..."
+${OCI_BIN} pull docker.io/mikefarah/yq:3.3.4 || true
+
 # Export .kubeconfig full path, so it will be possible
 # to use 'kubectl' directly from the component directory path
 export KUBECONFIG=${KUBECONFIG:-$(cluster::kubeconfig)}


### PR DESCRIPTION
Fixes #2745

**What this PR does / why we need it**:

This PR fixes a CI failure in the `pull-e2e-cluster-network-addons-operator-ovs-cni-functests` job caused by timeout issues during container image pulls.

The job was failing during infrastructure setup when attempting to pull the `docker.io/mikefarah/yq:3.3.4` container image. Slow network performance in the Prow CI environment caused the image pull to exceed timeout constraints, resulting in the job being terminated before the test could even start.

The fix adds a pre-pull step in `automation/components-functests.setup.sh` to pull the yq container image upfront before yaml-utils functions are called. This ensures the image is cached and subsequent operations use the cached version, preventing timeout failures during critical yaml parsing operations.

This follows the same pattern applied to other component functional test jobs in recent commits (bridge-marker-functests, multus-functests, kubemacpool-functests, monitoring-k8s, and workflow-k8s).

**Special notes for your reviewer**:

The change is minimal and follows the exact same pattern used in commits 1b3be1292, ae46f5975, f97168ec6, 4f7417351, and e44441d7e which fixed identical timeout issues for other component tests.

The `|| true` ensures the setup continues even if the pull fails, allowing subsequent operations to retry if needed.

**Release note**:

```release-note
NONE
```

<!-- oompa-bot v:b366a0d -->