### PR TITLE
CI Failure: pull-e2e-cluster-network-addons-operator-macvtap-cni-functests / The `pull-e2e-cluster-network-addons-operator-macvtap-cni-fu

### DIFF
--- a/build/operator/Dockerfile
+++ b/build/operator/Dockerfile
@@ -1,14 +1,15 @@
 ARG BUILD_ARCH=amd64
-FROM --platform=linux/${BUILD_ARCH} quay.io/centos/centos:stream9 AS builder
+# Use official Go image instead of downloading Go manually
+FROM --platform=linux/${BUILD_ARCH} docker.io/library/golang:1.25.7 AS builder
 
-RUN dnf install -y tar gzip jq && dnf clean all
-RUN ARCH=$(uname -m | sed 's/x86_64/amd64/') && \
-    GO_VERSION=$(curl -L -s "https://go.dev/dl/?mode=json" | jq -r '.[0].version') && \
-    curl -L "https://go.dev/dl/${GO_VERSION}.linux-${ARCH}.tar.gz" -o go.tar.gz && \
-    tar -C /usr/local -xzf go.tar.gz && \
-    rm go.tar.gz
-ENV PATH=$PATH:/usr/local/go/bin
 WORKDIR /go/src/cluster-network-addons-operator
+
+# Copy go.mod and go.sum first to leverage Docker layer caching
+# This allows dependency downloads to be cached separately from source code
+COPY go.mod go.sum ./
+RUN go mod download
+
+# Now copy the rest of the source code
 COPY . .
 
 ARG TARGETOS


### PR DESCRIPTION
Fixes #2747

**What this PR does / why we need it**:

This PR fixes a CI timeout issue in the `pull-e2e-cluster-network-addons-operator-macvtap-cni-functests` job. The job was exceeding its ~4-hour timeout limit during the operator container image build phase due to slow network performance when downloading the Go toolchain and all module dependencies on every build.

The fix optimizes the operator Dockerfile to:
1. Use the official `golang:1.25.7` base image instead of manually downloading Go from go.dev
2. Leverage Docker layer caching by separating dependency downloads from source code compilation
3. Only re-download dependencies when go.mod/go.sum change

This significantly reduces build time in CI environments and prevents timeout failures.

**Special notes for your reviewer**:

This follows the same optimization pattern used to address similar CI timeout issues in the project (see #2745). The change is backwards compatible and doesn't affect runtime behavior - it only optimizes the build process.

The key optimization is the multi-stage approach in the Dockerfile:
- Copy go.mod and go.sum first → run `go mod download` → cached layer
- Copy source code → build → invalidated only when source changes

**Release note**:

```release-note
NONE
```

<!-- oompa-bot v:b366a0d -->