### PR TITLE
CI Failure: pull-e2e-cluster-network-addons-operator-macvtap-cni-functests / The macvtap-cni functional tests CI job was terminated

### DIFF
--- a/automation/components-functests.setup.sh
+++ b/automation/components-functests.setup.sh
@@ -21,6 +21,9 @@ source hack/components/git-utils.sh
 source hack/components/yaml-utils.sh
 source cluster/cluster.sh
 
+# Pre-pull yq image with retry logic to avoid CI failures during setup
+yaml-utils::prepull_yq_image
+
 USE_KUBEVIRTCI=${USE_KUBEVIRTCI:-"true"}
 CNAO_DEPLOY_KUBEVIRT=${CNAO_DEPLOY_KUBEVIRT:-"false"}
 

--- a/hack/components/yaml-utils.sh
+++ b/hack/components/yaml-utils.sh
@@ -5,9 +5,38 @@ set -xeo pipefail
 source hack/components/docker-utils.sh
 
 export OCI_BIN=${OCI_BIN:-$(docker-utils::determine_cri_bin)}
+export YQ_IMAGE=${YQ_IMAGE:-docker.io/mikefarah/yq:3.3.4}
+
+# Pre-pull the yq image with retry logic to avoid failures during setup
+function yaml-utils::prepull_yq_image() {
+  local max_attempts=3
+  local attempt=1
+  local wait_time=5
+
+  echo "Pre-pulling yq image: ${YQ_IMAGE}"
+
+  while [ $attempt -le $max_attempts ]; do
+    echo "Attempt $attempt of $max_attempts to pull ${YQ_IMAGE}"
+    if ${OCI_BIN} pull ${YQ_IMAGE}; then
+      echo "Successfully pulled ${YQ_IMAGE}"
+      return 0
+    else
+      echo "Failed to pull ${YQ_IMAGE} on attempt $attempt"
+      if [ $attempt -lt $max_attempts ]; then
+        echo "Waiting ${wait_time} seconds before retry..."
+        sleep $wait_time
+        wait_time=$((wait_time * 2))  # Exponential backoff
+      fi
+      attempt=$((attempt + 1))
+    fi
+  done
+
+  echo "ERROR: Failed to pull ${YQ_IMAGE} after $max_attempts attempts"
+  return 1
+}
 
 function __yq() {
-  ${OCI_BIN} run --rm -v ${PWD}:/workdir:Z docker.io/mikefarah/yq:3.3.4 yq "$@"
+  ${OCI_BIN} run --pull=missing --rm -v ${PWD}:/workdir:Z ${YQ_IMAGE} yq "$@"
 }
 
 function yaml-utils::get_param() {


### PR DESCRIPTION
Fixes #2748

**What this PR does / why we need it**:

This PR adds resilience to the CI setup process by implementing retry logic for pulling the yq container image. The macvtap-cni functional tests CI job was experiencing failures during setup when the docker.io/mikefarah/yq:3.3.4 image pull was interrupted by infrastructure-level issues (timeouts, network problems, or resource constraints).

The changes:
1. Add a `yaml-utils::prepull_yq_image()` function with retry logic (3 attempts with exponential backoff)
2. Pre-pull the yq image at the start of components-functests setup to fail fast if there are persistent issues
3. Use `--pull=missing` flag in the `__yq()` function to avoid unnecessary re-pulls if the image is already cached

This makes the CI more resilient to transient network issues and reduces the likelihood of setup failures due to slow or interrupted container image pulls.

**Special notes for your reviewer**:

While the root cause is an infrastructure issue (job termination during image pull), this mitigation makes the setup process more robust by:
- Attempting the pull up to 3 times with exponential backoff before failing
- Using cached images when available to reduce external registry dependencies
- Providing clearer logging about pull attempts and failures

The yq image is now configurable via the `YQ_IMAGE` environment variable if needed.

**Release note**:

```release-note
NONE
```

<!-- oompa-bot v:b366a0d -->