### PR TITLE
CI Failure: pull-e2e-cnao-multus-dynamic-networks-functests / The `pull-e2e-cnao-multus-dynamic-networks-functests` job

### DIFF
--- a/automation/components-functests.setup.sh
+++ b/automation/components-functests.setup.sh
@@ -24,6 +24,12 @@ source cluster/cluster.sh
 USE_KUBEVIRTCI=${USE_KUBEVIRTCI:-"true"}
 CNAO_DEPLOY_KUBEVIRT=${CNAO_DEPLOY_KUBEVIRT:-"false"}
 
+# Pre-pull yq image to avoid timeout issues during yaml parsing
+# The yaml-utils functions use this image multiple times, and pulling
+# on-demand can be slow in CI environments
+echo "Pre-pulling yq container image..."
+${OCI_BIN} pull docker.io/mikefarah/yq:3.3.4 || true
+
 # Export .kubeconfig full path, so it will be possible
 # to use 'kubectl' directly from the component directory path
 export KUBECONFIG=${KUBECONFIG:-$(cluster::kubeconfig)}


### PR DESCRIPTION
Fixes #2750

**What this PR does / why we need it**:

This PR fixes the `pull-e2e-cnao-multus-dynamic-networks-functests` CI job that was failing during infrastructure setup when attempting to pull the `docker.io/mikefarah/yq:3.3.4` container image. The job was being terminated by Prow CI infrastructure before the image pull could complete due to slow network performance.

The fix adds a pre-pull step in `automation/components-functests.setup.sh` to pull the yq container image upfront before yaml-utils functions are called. This ensures the image is cached and subsequent operations use the cached version, preventing timeout failures during critical yaml parsing operations.

**Special notes for your reviewer**:

This fix follows the same pattern used to resolve identical issues in other component functional test jobs (issues #2739, #2741, #2743, #2745, #2747). The pre-pull step benefits all jobs that use `automation/components-functests.setup.sh`, including the multus-dynamic-networks-functests job.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```

<!-- oompa-bot v:b366a0d -->