### PR TITLE
CI Failure: pull-e2e-cnao-multus-dynamic-networks-functests / The `pull-e2e-cnao-multus-dynamic-networks-functests` CI

### DIFF
--- a/cluster/cert-manager-install.sh
+++ b/cluster/cert-manager-install.sh
@@ -23,7 +23,9 @@ if [[ $DEPLOY_CERT_MANAGER == true ]]; then
 	echo "Installing cert-manager..."
 	manifest="https://github.com/cert-manager/cert-manager/releases/download/${CERT_MANAGER_VERSION}/cert-manager.yaml"
 	./cluster/kubectl.sh apply -f "$manifest"
-	./cluster/kubectl.sh wait --namespace cert-manager --for=condition=Available deployment/cert-manager --timeout=5m
-	./cluster/kubectl.sh wait --namespace cert-manager --for=condition=Available deployment/cert-manager-cainjector --timeout=5m
-	./cluster/kubectl.sh wait --namespace cert-manager --for=condition=Available deployment/cert-manager-webhook --timeout=5m
+	# Wrap kubectl wait with timeout to prevent indefinite hangs due to API server issues
+	# Using 7m wrapper timeout to fail faster if kubectl wait becomes unresponsive
+	timeout 7m ./cluster/kubectl.sh wait --namespace cert-manager --for=condition=Available deployment/cert-manager --timeout=5m
+	timeout 7m ./cluster/kubectl.sh wait --namespace cert-manager --for=condition=Available deployment/cert-manager-cainjector --timeout=5m
+	timeout 7m ./cluster/kubectl.sh wait --namespace cert-manager --for=condition=Available deployment/cert-manager-webhook --timeout=5m
 fi

--- a/cluster/operator-install.sh
+++ b/cluster/operator-install.sh
@@ -17,7 +17,11 @@
 set -ex
 
 ./cluster/kubectl.sh create -f _out/cluster-network-addons/${VERSION}/operator.yaml
-if [[ ! $(./cluster/kubectl.sh -n cluster-network-addons wait deployment cluster-network-addons-operator --for condition=Available --timeout=600s) ]]; then
+
+# Wrap kubectl wait with timeout to prevent indefinite hangs due to API server issues
+# kubectl has its own --timeout=600s, but can hang if API server becomes unresponsive
+# Using 15m wrapper timeout to fail faster than Prow job timeout
+if ! timeout 15m ./cluster/kubectl.sh -n cluster-network-addons wait deployment cluster-network-addons-operator --for condition=Available --timeout=600s; then
 	echo "Failed to wait for CNAO deployment to be ready"
 	./cluster/kubectl.sh get pods -n cluster-network-addons
 	./cluster/kubectl.sh describe deployment cluster-network-addons-operator -n cluster-network-addons


### PR DESCRIPTION
Fixes #2752

**What this PR does / why we need it**:

This PR adds wrapper timeouts to `kubectl wait` commands in CI scripts to prevent indefinite hangs when the Kubernetes API server becomes unresponsive. In issue #2752, the `kubectl wait` command hung for 4+ hours despite having its own `--timeout` flag, eventually hitting the Prow job timeout. 

The fix wraps all `kubectl wait` commands with the `timeout` utility to ensure failures occur within a reasonable timeframe:
- `operator-install.sh`: 15-minute wrapper timeout (kubectl's own timeout: 600s)
- `cert-manager-install.sh`: 7-minute wrapper timeout (kubectl's own timeout: 5m)

This improves CI reliability by failing faster on infrastructure issues rather than waiting hours for the Prow timeout.

**Special notes for your reviewer**:

While the original issue was classified as an infrastructure failure (not a code bug), this change adds resilience to prevent similar incidents from wasting CI resources. The wrapper timeout values provide a buffer beyond kubectl's own timeout while still failing much faster than the 4-hour Prow job timeout.

**Release note**:

```release-note
NONE
```

<!-- oompa-bot v:b366a0d -->