### PR TITLE
CI Failure: pull-e2e-cnao-kube-secondary-dns-functests / The `pull-e2e-cnao-kube-secondary-dns-functests` job was

### DIFF
--- a/automation/components-functests.setup.sh
+++ b/automation/components-functests.setup.sh
@@ -21,6 +21,9 @@ source hack/components/git-utils.sh
 source hack/components/yaml-utils.sh
 source cluster/cluster.sh
 
+# Pre-pull yq image with retry logic to avoid CI failures during setup
+yaml-utils::prepull_yq_image
+
 USE_KUBEVIRTCI=${USE_KUBEVIRTCI:-"true"}
 CNAO_DEPLOY_KUBEVIRT=${CNAO_DEPLOY_KUBEVIRT:-"false"}
 

--- a/hack/components/yaml-utils.sh
+++ b/hack/components/yaml-utils.sh
@@ -5,9 +5,38 @@ set -xeo pipefail
 source hack/components/docker-utils.sh
 
 export OCI_BIN=${OCI_BIN:-$(docker-utils::determine_cri_bin)}
+export YQ_IMAGE=${YQ_IMAGE:-docker.io/mikefarah/yq:3.3.4}
+
+# Pre-pull the yq image with retry logic to avoid failures during setup
+function yaml-utils::prepull_yq_image() {
+  local max_attempts=3
+  local attempt=1
+  local wait_time=5
+
+  echo "Pre-pulling yq image: ${YQ_IMAGE}"
+
+  while [ $attempt -le $max_attempts ]; do
+    echo "Attempt $attempt of $max_attempts to pull ${YQ_IMAGE}"
+    if ${OCI_BIN} pull ${YQ_IMAGE}; then
+      echo "Successfully pulled ${YQ_IMAGE}"
+      return 0
+    else
+      echo "Failed to pull ${YQ_IMAGE} on attempt $attempt"
+      if [ $attempt -lt $max_attempts ]; then
+        echo "Waiting ${wait_time} seconds before retry..."
+        sleep $wait_time
+        wait_time=$((wait_time * 2))  # Exponential backoff
+      fi
+      attempt=$((attempt + 1))
+    fi
+  done
+
+  echo "ERROR: Failed to pull ${YQ_IMAGE} after $max_attempts attempts"
+  return 1
+}
 
 function __yq() {
-  ${OCI_BIN} run --rm -v ${PWD}:/workdir:Z docker.io/mikefarah/yq:3.3.4 yq "$@"
+  ${OCI_BIN} run --pull=missing --rm -v ${PWD}:/workdir:Z ${YQ_IMAGE} yq "$@"
 }
 
 function yaml-utils::get_param() {


### PR DESCRIPTION
Fixes #2755

**What this PR does / why we need it**:

This PR fixes CI failures in the `pull-e2e-cnao-kube-secondary-dns-functests` job (and potentially other e2e functional test jobs) that were being terminated during setup when pulling the `docker.io/mikefarah/yq:3.3.4` container image. The failures were caused by infrastructure-level issues such as network timeouts, registry unavailability, or resource constraints.

The fix adds resilience to the CI setup process by:
1. Adding a `yaml-utils::prepull_yq_image()` function with retry logic (3 attempts with exponential backoff: 5s, 10s, 20s)
2. Pre-pulling the yq image at the start of components-functests setup to fail fast with retries if there are persistent issues
3. Using `--pull=missing` flag in the `__yq()` function to avoid unnecessary re-pulls if the image is already cached
4. Making the yq image configurable via the `YQ_IMAGE` environment variable

**Special notes for your reviewer**:

This is the same fix as #2748, which addressed the same infrastructure issue affecting the macvtap-cni functional tests. The root cause is an infrastructure problem (Prow job termination during image pull), but this mitigation makes the setup process more robust by handling transient network issues gracefully.

The fix has been tested in commit 5064b0274 for issue #2748 and follows the same pattern to address this broader CI failure issue.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```

<!-- oompa-bot v:b366a0d -->