### PR TITLE
CI Failure: pull-e2e-cluster-network-addons-operator-workflow-k8s-s390x / The `pull-e2e-cluster-network-addons-operator-workflow-k8s-s

### DIFF
--- a/hack/install-tls-compliance-operator.sh
+++ b/hack/install-tls-compliance-operator.sh
@@ -26,6 +26,6 @@ echo "Patching the operator's Deployment for fine tuning reporting intervals.."
 ]'
 
 echo "Waiting for TLS Compliance Operator readiness.."
-./cluster/kubectl.sh -n $NAMESPACE rollout status deployment/$DEPLOY_NAME --timeout=120s
+./cluster/kubectl.sh -n $NAMESPACE rollout status deployment/$DEPLOY_NAME --timeout=600s
 
 echo "TLS Compliance Operator is ready"


### PR DESCRIPTION
Fixes #2757

**What this PR does / why we need it**:

Increases the TLS compliance operator deployment timeout from 120s to 600s to address CI failures on the s390x architecture. The `pull-e2e-cluster-network-addons-operator-workflow-k8s-s390x` job was consistently timing out during infrastructure setup because the TLS compliance operator deployment couldn't complete within the 120s timeout window on the slower s390x platform.

The s390x architecture runs significantly slower than x86_64, and with the recent addition of TLS compliance testing (commit d7eda1f59), the total setup time increased beyond what the previous timeout could accommodate. The job was being killed by Prow's overall timeout constraint after ~4 hours while still waiting for the operator deployment to roll out.

This change aligns the TLS compliance operator timeout with other components like KubeVirt (600s) to provide adequate time for deployment on resource-constrained CI environments.

**Special notes for your reviewer**:

This follows the same pattern as the recent fix for issue #2735, which increased the KubeVirt deployment timeout from 360s to 600s for similar infrastructure timeout reasons. While this provides a workaround for the immediate CI failures, the underlying Prow job timeout constraint may need adjustment in the `kubevirt/project-infra` repository for a more permanent solution.

**Release note**:

```release-note
NONE
```

<!-- oompa-bot v:b366a0d -->