### PR TITLE
[release-0.102] fix(kubemacpool): use RUNBOOK_URL_TEMPLATE for MAC collision alert

### DIFF
--- a/data/kubemacpool/kubemacpool-monitoring.yaml
+++ b/data/kubemacpool/kubemacpool-monitoring.yaml
@@ -63,7 +63,8 @@ spec:
       annotations:
         description: '{{ "{{" }} $value {{ "}}" }} MAC address(es) have collisions. Multiple running
           objects are using the same MAC address.'
-        runbook_url: https://kubevirt.io/monitoring/runbooks/KubemacpoolMACCollisionDetected
+        runbook_url: '{{ printf .RunbookURLTemplate "KubemacpoolMACCollisionDetected"
+          }}'
         summary: MAC address collisions detected.
       expr: count(kmp_mac_collisions > 1) > 0
       for: 30s

--- a/hack/components/bump-kubemacpool.sh
+++ b/hack/components/bump-kubemacpool.sh
@@ -72,6 +72,19 @@ kind: Kustomization
 namespace: "{{ .Namespace }}"
 bases:
 - ../monitoring
+patches:
+- path: cnao_runbook_url_patch.yaml
+  target:
+    group: monitoring.coreos.com
+    version: v1
+    kind: PrometheusRule
+    name: kubemacpool-prometheus-rule
+EOF
+
+    cat <<EOF > config/cnao-monitoring/cnao_runbook_url_patch.yaml
+- op: replace
+  path: /spec/groups/0/rules/0/annotations/runbook_url
+  value: '{{ printf .RunbookURLTemplate "KubemacpoolMACCollisionDetected" }}'
 EOF
 
     cat <<EOF > config/cnao/cnao_kubemacpool_manager_patch.yaml

--- a/pkg/network/kubemacpool.go
+++ b/pkg/network/kubemacpool.go
@@ -8,11 +8,12 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/kubevirt/cluster-network-addons-operator/pkg/render"
 	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	cnao "github.com/kubevirt/cluster-network-addons-operator/pkg/apis/networkaddonsoperator/shared"
+	"github.com/kubevirt/cluster-network-addons-operator/pkg/monitoring/rules/alerts"
+	"github.com/kubevirt/cluster-network-addons-operator/pkg/render"
 )
 
 // ValidateMultus validates the combination of DisableMultiNetwork and AddtionalNetworks
@@ -123,6 +124,7 @@ func renderKubeMacPool(conf *cnao.NetworkAddonsConfigSpec, manifestDir string, c
 	ciphers, tlsMinVersion := SelectCipherSuitesAndMinTLSVersion(conf.TLSSecurityProfile)
 	data.Data["TLSSecurityProfileCiphers"] = strings.Join(OCPTLSProfileCiphersToGoCipherNames(ciphers), ",")
 	data.Data["TLSMinVersion"] = string(tlsMinVersion)
+	data.Data["RunbookURLTemplate"] = alerts.GetRunbookURLTemplate()
 
 	objs, err := render.RenderDir(filepath.Join(manifestDir, "kubemacpool"), &data)
 	if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR is a manual cherry pick of https://github.com/kubevirt/cluster-network-addons-operator/pull/2715

**Special notes for your reviewer**:

**Release note**:

Special notes for your reviewer:

Release note:
```
Fix KubemacpoolMACCollisionDetected runbook url
```
