### PR TITLE
CI Failure: pull-e2e-cluster-network-addons-operator-workflow-k8s-s390x / The CI job failed during initial cluster cleanup when

### DIFF
--- a/cluster/cluster.sh
+++ b/cluster/cluster.sh
@@ -22,6 +22,30 @@ function cluster::_get_tag() {
     git -C ${CLUSTER_PATH} describe --tags
 }
 
+function cluster::_retry_git_clone() {
+    local url=$1
+    local destination=$2
+    local max_attempts=3
+    local retry_delay=5
+
+    for attempt in $(seq 1 ${max_attempts}); do
+        echo "Attempting to clone ${url} (attempt ${attempt}/${max_attempts})"
+        if git clone ${url} ${destination}; then
+            echo "Successfully cloned repository"
+            return 0
+        else
+            if [ ${attempt} -lt ${max_attempts} ]; then
+                echo "Clone failed, retrying in ${retry_delay} seconds..."
+                sleep ${retry_delay}
+                retry_delay=$((retry_delay * 2))
+            fi
+        fi
+    done
+
+    echo "Failed to clone repository after ${max_attempts} attempts"
+    return 1
+}
+
 function cluster::install() {
     if [ -d ${CLUSTER_PATH} ]; then
         if [[ $(cluster::_get_tag) != ${KUBEVIRTCI_TAG} ]]; then
@@ -30,7 +54,7 @@ function cluster::install() {
     fi
 
     if [ ! -d ${CLUSTER_PATH} ]; then
-        git clone https://github.com/kubevirt/kubevirtci.git ${CLUSTER_PATH}
+        cluster::_retry_git_clone https://github.com/kubevirt/kubevirtci.git ${CLUSTER_PATH}
         (
             cd ${CLUSTER_PATH}
             git checkout ${KUBEVIRTCI_TAG}


### PR DESCRIPTION
Fixes #2762

**What this PR does / why we need it**:

This PR adds retry logic to the kubevirtci git clone operation to handle transient DNS failures in CI environments. The s390x CI job was failing during initial cluster cleanup when attempting to clone the kubevirtci repository due to "Could not resolve host: github.com" errors.

The fix implements a retry mechanism with exponential backoff (3 attempts with 5s, 10s delays) to make the cluster setup more resilient to temporary network issues.

**Special notes for your reviewer**:

- This addresses an infrastructure-related failure but makes the code more robust
- The retry logic is only used during the kubevirtci clone operation in `cluster::install()`
- The implementation uses exponential backoff to avoid hammering the network
- No changes to test logic or cluster behavior, only improved reliability

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```

<!-- oompa-bot v:99fb820 -->