### PR TITLE
CI Failure: pull-cluster-network-addons-operator-unit-test-release-0.102 / The `pull-cluster-network-addons-operator-unit-test-release-

### DIFF
--- a/hack/components/yaml-utils.sh
+++ b/hack/components/yaml-utils.sh
@@ -34,7 +34,10 @@ function yaml-utils::update_param() {
 
 	local old_value=$(yaml-utils::get_param ${yaml_file} ${path})
 	if [ ! -z "${old_value}" ]; then
-		yaml-utils::set_param ${yaml_file} ${path} "${new_value}"
+		# Skip the update if the value is already correct to avoid unnecessary file modifications
+		if [ "${old_value}" != "${new_value}" ]; then
+			yaml-utils::set_param ${yaml_file} ${path} "${new_value}"
+		fi
 	else
 		echo Error: ${path} is not found in ${yaml_file}
 		exit 1

--- a/hack/install-tls-compliance-operator.sh
+++ b/hack/install-tls-compliance-operator.sh
@@ -17,7 +17,7 @@ echo "Installing TLS Compliance Operator ${VERSION} from: ${URL}.."
 # To allow the operator reach and check all services the network-policy is deleted.
 # [1] https://github.com/sebrandon1/tls-compliance-operator/blob/v0.0.10/docs/troubleshooting.md#:~:text=Check%20for%20NetworkPolicy%20restrictions
 echo "Deleting the operator's network-policy to allow egress all services.."
-./cluster/kubectl.sh -n $NAMESPACE delete networkpolicy $NP_NAME 
+./cluster/kubectl.sh -n $NAMESPACE delete networkpolicy $NP_NAME
 
 echo "Patching the operator's Deployment for fine tuning reporting intervals.."
 ./cluster/kubectl.sh -n $NAMESPACE patch deployment $DEPLOY_NAME --type='json' -p='[


### PR DESCRIPTION
Fixes #2764

**What this PR does / why we need it**:

This PR fixes two code quality issues that were causing the `pull-cluster-network-addons-operator-unit-test-release-0.102` CI job to fail:

1. **Trailing whitespace**: Removed a trailing space from `hack/install-tls-compliance-operator.sh:20` that violated the project's whitespace standards
2. **YAML reformatting during component bumps**: Modified `yaml-utils::update_param` to skip updates when the value is already correct, preventing yq from unnecessarily reformatting YAML files (particularly `data/kubemacpool/kubemacpool-monitoring.yaml`) during `make bump-all` operations

**Special notes for your reviewer**:

The second fix prevents yq from reformatting YAML files when the value being set is already correct. This avoids spurious diffs during component bumps where yq would reformat files (e.g., wrapping long lines) even though no semantic changes were made.

**Release note**:

```release-note
NONE
```

<!-- oompa-bot v:99fb820 -->