### PR TITLE
CI Failure: pull-cluster-network-addons-operator-unit-test-release-0.102 / The CI job `pull-cluster-network-addons-operator-unit-test-r

### DIFF
--- a/hack/components/yaml-utils.sh
+++ b/hack/components/yaml-utils.sh
@@ -34,7 +34,10 @@ function yaml-utils::update_param() {
 
 	local old_value=$(yaml-utils::get_param ${yaml_file} ${path})
 	if [ ! -z "${old_value}" ]; then
-		yaml-utils::set_param ${yaml_file} ${path} "${new_value}"
+		# Skip the update if the value is already correct to avoid unnecessary file modifications
+		if [ "${old_value}" != "${new_value}" ]; then
+			yaml-utils::set_param ${yaml_file} ${path} "${new_value}"
+		fi
 	else
 		echo Error: ${path} is not found in ${yaml_file}
 		exit 1

--- a/hack/install-tls-compliance-operator.sh
+++ b/hack/install-tls-compliance-operator.sh
@@ -17,7 +17,7 @@ echo "Installing TLS Compliance Operator ${VERSION} from: ${URL}.."
 # To allow the operator reach and check all services the network-policy is deleted.
 # [1] https://github.com/sebrandon1/tls-compliance-operator/blob/v0.0.10/docs/troubleshooting.md#:~:text=Check%20for%20NetworkPolicy%20restrictions
 echo "Deleting the operator's network-policy to allow egress all services.."
-./cluster/kubectl.sh -n $NAMESPACE delete networkpolicy $NP_NAME 
+./cluster/kubectl.sh -n $NAMESPACE delete networkpolicy $NP_NAME
 
 echo "Patching the operator's Deployment for fine tuning reporting intervals.."
 ./cluster/kubectl.sh -n $NAMESPACE patch deployment $DEPLOY_NAME --type='json' -p='[


### PR DESCRIPTION
Fixes #2768

**What this PR does / why we need it**:

This PR fixes two code quality issues that were causing CI failures in the `pull-cluster-network-addons-operator-unit-test-release-0.102` job:

1. **Trailing whitespace removal**: Removes a trailing space character at line 20 of `hack/install-tls-compliance-operator.sh` that was caught by the whitespace check (`./hack/whitespace.sh`)

2. **YAML processing optimization**: Updates `yaml-utils::update_param` in `hack/components/yaml-utils.sh` to skip unnecessary file rewrites when the value is already correct. This prevents yq from reformatting YAML files unnecessarily, which was causing the `runbook_url` field to be wrapped across multiple lines and triggering git diff check failures during `make bump-all`.

**Special notes for your reviewer**:

The second fix addresses a subtle issue where `yaml-utils::update_param` was calling `yq w -i` even when the value hadn't changed. This caused yq (version 3.3.4) to reformat the file and apply line-wrapping to long values, creating unwanted diffs that failed the `verify_metrics_docs_updated` check.

**Release note**:

```release-note
NONE
```

<!-- oompa-bot v:99fb820 -->