### PR TITLE
CI Failure: kubevirt/cluster-network-addons-operator/kubevirt-ipam-controller.yaml / The kubevirt-ipam-controller e2e test failed during setup

### DIFF
--- a/.github/workflows/kubevirt-ipam-controller.yaml
+++ b/.github/workflows/kubevirt-ipam-controller.yaml
@@ -23,6 +23,9 @@ jobs:
           mysql-server-core-* php-* php7* \
           powershell temurin-* zulu-*
 
+    - name: Pre-pull yq image
+      run: docker pull docker.io/mikefarah/yq:3.3.4
+
     - name: Run e2e tests
       env:
         KIND_ALLOW_SYSTEM_WRITES: true


### PR DESCRIPTION
Fixes #2780

**What this PR does / why we need it**:

This PR adds a pre-pull step for the `docker.io/mikefarah/yq:3.3.4` image in the kubevirt-ipam-controller workflow. The e2e tests were experiencing transient failures due to Docker Hub connectivity issues when pulling the yq image during test execution. By pre-pulling the image as a separate step before running the tests, we ensure the image is cached locally and prevent network-related failures during the critical test setup phase.

**Special notes for your reviewer**:

This addresses a transient infrastructure issue (issue #2780) where the CI failed when pulling the yq image from Docker Hub. The pre-pull step ensures that any network issues are isolated to a dedicated step that can be easily retried, rather than occurring during test execution where it causes the entire test suite to fail.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```

<!-- oompa-bot v:99fb820 -->