### PR TITLE
CI Failure: pull-e2e-cluster-network-addons-operator-monitoring-k8s / The `pull-e2e-cluster-network-addons-operator-monitoring-k8s

### DIFF
--- a/build/operator/Dockerfile
+++ b/build/operator/Dockerfile
@@ -1,13 +1,6 @@
 ARG BUILD_ARCH=amd64
-FROM --platform=linux/${BUILD_ARCH} quay.io/centos/centos:stream9 AS builder
+FROM --platform=linux/${BUILD_ARCH} docker.io/library/golang:1.25.7 AS builder
 
-RUN dnf install -y tar gzip jq && dnf clean all
-RUN ARCH=$(uname -m | sed 's/x86_64/amd64/') && \
-    GO_VERSION=$(curl -L -s "https://go.dev/dl/?mode=json" | jq -r '.[0].version') && \
-    curl -L "https://go.dev/dl/${GO_VERSION}.linux-${ARCH}.tar.gz" -o go.tar.gz && \
-    tar -C /usr/local -xzf go.tar.gz && \
-    rm go.tar.gz
-ENV PATH=$PATH:/usr/local/go/bin
 WORKDIR /go/src/cluster-network-addons-operator
 COPY . .
 


### PR DESCRIPTION
Fixes #2783

**What this PR does / why we need it**:

This PR optimizes the operator Dockerfile to reduce build time and eliminate network dependencies during container builds. The change replaces the CentOS base image with dynamic Go version download with a pre-built `golang:1.25.7` builder image.

This addresses CI timeout failures in the `pull-e2e-cluster-network-addons-operator-monitoring-k8s` test suite, which was being terminated after exceeding Prow's ~18-20 minute job timeout. The dynamic Go download added unnecessary build overhead that contributed to the total execution time.

**Special notes for your reviewer**:

The fix makes the build more deterministic and faster by:
- Eliminating the network call to go.dev to detect the latest Go version
- Removing the need to download and extract the Go tarball during each build
- Using the official golang:1.25.7 image which has Go pre-installed

This is similar to fixes applied in other branches for related CI timeout issues (e.g., #2777).

**Release note**:

```release-note
NONE
```

<!-- oompa-bot v:99fb820 -->