### PR TITLE
CI Failure: pull-cluster-network-addons-operator-unit-test / The `pull-cluster-network-addons-operator-unit-test` job

### DIFF
--- a/hack/install-tls-compliance-operator.sh
+++ b/hack/install-tls-compliance-operator.sh
@@ -17,7 +17,7 @@ echo "Installing TLS Compliance Operator ${VERSION} from: ${URL}.."
 # To allow the operator reach and check all services the network-policy is deleted.
 # [1] https://github.com/sebrandon1/tls-compliance-operator/blob/v0.0.10/docs/troubleshooting.md#:~:text=Check%20for%20NetworkPolicy%20restrictions
 echo "Deleting the operator's network-policy to allow egress all services.."
-./cluster/kubectl.sh -n $NAMESPACE delete networkpolicy $NP_NAME 
+./cluster/kubectl.sh -n $NAMESPACE delete networkpolicy $NP_NAME
 
 echo "Patching the operator's Deployment for fine tuning reporting intervals.."
 ./cluster/kubectl.sh -n $NAMESPACE patch deployment $DEPLOY_NAME --type='json' -p='[


### PR DESCRIPTION
Fixes #2786

**What this PR does / why we need it**:

This PR removes a trailing whitespace from `hack/install-tls-compliance-operator.sh:20` that was causing the `pull-cluster-network-addons-operator-unit-test` CI job to fail. The whitespace was detected by the project's whitespace check (`hack/whitespace.sh`) during the `make check` validation phase.

**Special notes for your reviewer**:

This is a simple code quality fix. The trailing whitespace was introduced in commit d7eda1f596 when the TLS compliance check feature was added via PR #2647. The fix ensures the codebase complies with the project's whitespace standards.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```

<!-- oompa-bot v:99fb820 -->