### PR TITLE
CI Failure: pull-e2e-cluster-network-addons-operator-monitoring-k8s / The monitoring e2e test suite (`pull-e2e-cluster-network-add

### DIFF
--- a/build/operator/Dockerfile
+++ b/build/operator/Dockerfile
@@ -1,13 +1,6 @@
 ARG BUILD_ARCH=amd64
-FROM --platform=linux/${BUILD_ARCH} quay.io/centos/centos:stream9 AS builder
+FROM --platform=linux/${BUILD_ARCH} docker.io/library/golang:1.25.7 AS builder
 
-RUN dnf install -y tar gzip jq && dnf clean all
-RUN ARCH=$(uname -m | sed 's/x86_64/amd64/') && \
-    GO_VERSION=$(curl -L -s "https://go.dev/dl/?mode=json" | jq -r '.[0].version') && \
-    curl -L "https://go.dev/dl/${GO_VERSION}.linux-${ARCH}.tar.gz" -o go.tar.gz && \
-    tar -C /usr/local -xzf go.tar.gz && \
-    rm go.tar.gz
-ENV PATH=$PATH:/usr/local/go/bin
 WORKDIR /go/src/cluster-network-addons-operator
 COPY . .
 


### PR DESCRIPTION
Fixes #2788

**What this PR does / why we need it**:

This PR fixes CI timeout failures in the `pull-e2e-cluster-network-addons-operator-monitoring-k8s` test suite by optimizing the operator Dockerfile build process. The monitoring e2e tests were being terminated after ~18-20 minutes before completing all 8 test cases.

The root cause was an inefficient Dockerfile that dynamically downloaded Go during the container build phase, adding significant overhead. This PR replaces the CentOS base image with the pre-built `golang:1.25.7` image, eliminating:
- Network calls to go.dev during build
- dnf package installation overhead  
- Go tarball download and extraction time

This reduces build time by several minutes, providing sufficient budget for all 8 tests to complete within Prow's timeout window.

**Special notes for your reviewer**:

This is a build configuration fix that addresses an infrastructure issue, not a code or test bug. The same fix was previously applied in commit `45d93080d` for issue #2783. All tests that ran before the timeout were passing successfully.

**Release note**:
```release-note
NONE
```

<!-- oompa-bot v:99fb820 -->