### PR TITLE
CI Failure: pull-e2e-cluster-network-addons-operator-workflow-k8s-s390x / The CI job failed during the initial cluster teardown phase

### DIFF
--- a/cluster/cluster.sh
+++ b/cluster/cluster.sh
@@ -22,6 +22,32 @@ function cluster::_get_tag() {
     git -C ${CLUSTER_PATH} describe --tags
 }
 
+function cluster::_clone_with_retry() {
+    local repo_url=$1
+    local target_path=$2
+    local max_attempts=5
+    local attempt=1
+    local wait_time=2
+
+    while [ $attempt -le $max_attempts ]; do
+        echo "Attempting to clone kubevirtci (attempt $attempt/$max_attempts)..."
+        if git clone "$repo_url" "$target_path"; then
+            echo "Successfully cloned kubevirtci"
+            return 0
+        fi
+
+        if [ $attempt -lt $max_attempts ]; then
+            echo "Clone failed, retrying in ${wait_time}s..."
+            sleep $wait_time
+            wait_time=$((wait_time * 2))
+        fi
+        attempt=$((attempt + 1))
+    done
+
+    echo "Failed to clone kubevirtci after $max_attempts attempts"
+    return 1
+}
+
 function cluster::install() {
     if [ -d ${CLUSTER_PATH} ]; then
         if [[ $(cluster::_get_tag) != ${KUBEVIRTCI_TAG} ]]; then
@@ -30,7 +56,7 @@ function cluster::install() {
     fi
 
     if [ ! -d ${CLUSTER_PATH} ]; then
-        git clone https://github.com/kubevirt/kubevirtci.git ${CLUSTER_PATH}
+        cluster::_clone_with_retry https://github.com/kubevirt/kubevirtci.git ${CLUSTER_PATH}
         (
             cd ${CLUSTER_PATH}
             git checkout ${KUBEVIRTCI_TAG}


### PR DESCRIPTION
Fixes #2791

**What this PR does / why we need it**:

This PR adds retry logic with exponential backoff to the kubevirtci repository cloning operation in `cluster/cluster.sh`. The s390x CI job occasionally fails during cluster teardown due to transient DNS resolution failures when attempting to clone the kubevirtci repository from GitHub. The new retry mechanism (up to 5 attempts with exponential backoff: 2s, 4s, 8s, 16s) makes the CI more resilient to temporary network and DNS issues.

**Special notes for your reviewer**:

The failure was occurring during the initial cluster teardown phase (`make cluster-down`) when the `cluster::install` function tried to clone kubevirtci. The DNS resolution failure for `github.com` was transient and external to our code, but adding retry logic prevents these infrastructure hiccups from failing the entire CI run.

**Release note**:

```release-note
NONE
```

<!-- oompa-bot v:99fb820 -->