### PR TITLE
CI Failure: pull-e2e-cnao-kube-secondary-dns-functests / The `pull-e2e-cnao-kube-secondary-dns-functests` CI job

### DIFF
--- a/automation/components-functests.setup.sh
+++ b/automation/components-functests.setup.sh
@@ -29,9 +29,33 @@ CNAO_DEPLOY_KUBEVIRT=${CNAO_DEPLOY_KUBEVIRT:-"false"}
 export KUBECONFIG=${KUBECONFIG:-$(cluster::kubeconfig)}
 
 function deploy_cluster {
-  # Spin up Kubernetes cluster
+  # Spin up Kubernetes cluster with retry logic for transient failures
   export KUBEVIRT_MEMORY_SIZE=10240M
-  make cluster-down cluster-up
+  local max_attempts=3
+  local attempt=1
+
+  while [ $attempt -le $max_attempts ]; do
+    echo "Attempting cluster deployment (attempt $attempt of $max_attempts)..."
+
+    if make cluster-down cluster-up; then
+      echo "Cluster deployment succeeded on attempt $attempt"
+      return 0
+    else
+      echo "Cluster deployment failed on attempt $attempt"
+
+      if [ $attempt -lt $max_attempts ]; then
+        echo "Waiting 10 seconds before retry..."
+        sleep 10
+        echo "Cleaning up before retry..."
+        make cluster-down || true
+      fi
+
+      attempt=$((attempt + 1))
+    fi
+  done
+
+  echo "ERROR: Cluster deployment failed after $max_attempts attempts"
+  return 1
 }
 
 function deploy_cnao {


### PR DESCRIPTION
Fixes #2793

**What this PR does / why we need it**:

This PR adds retry logic to the cluster deployment function in the component functional tests setup script to handle transient infrastructure failures during kubevirtci cluster initialization.

The `pull-e2e-cnao-kube-secondary-dns-functests` CI job (and potentially other component functional test jobs) occasionally fails during cluster setup when etcd times out during the control-plane taint removal operation. This is a known transient infrastructure issue that occurs when etcd is temporarily overloaded during the rapid cluster initialization sequence.

The mitigation adds retry logic (up to 3 attempts with 10-second delays) to the `deploy_cluster` function, improving CI stability for all component functional test jobs that share this common setup script.

**Special notes for your reviewer**:

- This is a defensive infrastructure improvement, not a fix for a code bug
- The root cause is in kubevirtci's cluster initialization timing, external to this repository
- The retry logic applies to 8 different component functional test jobs that use `components-functests.setup.sh`
- The failure is transient and typically succeeds on retry

**Release note**:

```release-note
NONE
```

<!-- oompa-bot v:99fb820 -->