### PR TITLE
build, dockerfile: use quay.io golang image instead of install go

### DIFF
--- a/build/operator/Dockerfile
+++ b/build/operator/Dockerfile
@@ -1,13 +1,6 @@
 ARG BUILD_ARCH=amd64
-FROM --platform=linux/${BUILD_ARCH} quay.io/centos/centos:stream9 AS builder
-
-RUN dnf install -y tar gzip jq && dnf clean all
-RUN ARCH=$(uname -m | sed 's/x86_64/amd64/') && \
-    GO_VERSION=$(curl -L -s "https://go.dev/dl/?mode=json" | jq -r '.[0].version') && \
-    curl -L "https://go.dev/dl/${GO_VERSION}.linux-${ARCH}.tar.gz" -o go.tar.gz && \
-    tar -C /usr/local -xzf go.tar.gz && \
-    rm go.tar.gz
-ENV PATH=$PATH:/usr/local/go/bin
+ARG GO_VERSION
+FROM --platform=linux/${BUILD_ARCH} quay.io/projectquay/golang:${GO_VERSION} AS builder
 WORKDIR /go/src/cluster-network-addons-operator
 COPY . .
 

--- a/hack/build-operator-docker.sh
+++ b/hack/build-operator-docker.sh
@@ -7,7 +7,9 @@ fi
 
 IFS=',' read -r -a PLATFORM_LIST <<< "$PLATFORMS"
 
-BUILD_ARGS="--build-arg BUILD_ARCH=$ARCH -f build/operator/Dockerfile -t $OPERATOR_IMAGE_TAGGED --push ."
+GO_VERSION=$(./hack/go-version.sh | cut -d'.' -f1-2)
+
+BUILD_ARGS="--build-arg BUILD_ARCH=$ARCH --build-arg GO_VERSION=$GO_VERSION -f build/operator/Dockerfile -t $OPERATOR_IMAGE_TAGGED --push ."
 
 if [ ${#PLATFORM_LIST[@]} -eq 1 ]; then
     docker build --platform "$PLATFORMS" $BUILD_ARGS

--- a/hack/build-operator-podman.sh
+++ b/hack/build-operator-podman.sh
@@ -7,6 +7,8 @@ fi
 
 IFS=',' read -r -a PLATFORM_LIST <<< "$PLATFORMS"
 
+GO_VERSION=$(./hack/go-version.sh | cut -d'.' -f1-2)
+
 # Remove any existing manifest and image
 podman manifest rm "${OPERATOR_IMAGE_TAGGED}" 2>/dev/null || true
 podman rmi "${OPERATOR_IMAGE_TAGGED}" 2>/dev/null || true
@@ -17,6 +19,7 @@ podman manifest create "${OPERATOR_IMAGE_TAGGED}"
 for platform in "${PLATFORM_LIST[@]}"; do
     podman build \
         --build-arg BUILD_ARCH="$ARCH" \
+        --build-arg GO_VERSION="$GO_VERSION" \
         --platform "$platform" \
         --manifest "${OPERATOR_IMAGE_TAGGED}" \
         -f build/operator/Dockerfile \


### PR DESCRIPTION
Fixes #2799

**What this PR does / why we need it**:

Replaces the dynamic Go download from go.dev API with a pre-built `quay.io/projectquay/golang` base image in the operator Dockerfile.

The previous approach downloaded Go dynamically by querying the go.dev API and extracting a tarball during the build. This caused intermittent build failures when the API returned invalid JSON responses, resulting in jq parse errors.

**Changes:**
- Replaced `quay.io/centos/centos:stream9` base image with `quay.io/projectquay/golang:1.25`
- Removed dynamic Go download logic (curl + jq commands)
- Removed unnecessary dnf package installations (tar, gzip, jq)

**Benefits:**
- Eliminates external API dependency during container builds
- More reliable builds (no network/API failures)
- Faster build times (no download overhead)
- No Docker Hub rate limits
- Consistency with other KubeVirt org repos

**Release note**:

```release-note
NONE
```