### PR TITLE
CI Failure: pull-e2e-cluster-network-addons-operator-multus-functests / The `pull-e2e-cluster-network-addons-operator-multus-functes

### DIFF
--- a/cluster/up.sh
+++ b/cluster/up.sh
@@ -18,12 +18,21 @@ set -ex
 
 SCRIPTS_PATH="$(dirname "$(realpath "$0")")"
 source ${SCRIPTS_PATH}/cluster.sh
+source ${SCRIPTS_PATH}/../hack/components/docker-utils.sh
 
 export KUBEVIRT_DEPLOY_PROMETHEUS=true
 export KUBEVIRT_DEPLOY_PROMETHEUS_ALERTMANAGER=true
 export KUBEVIRT_DEPLOY_GRAFANA=true
 
 cluster::install
+
+# Pre-pull kubevirtci cluster image to avoid timeout issues during cluster-up
+# The cluster-up script downloads this large image, which can be slow in CI environments
+# and cause Prow job timeouts. Pre-pulling ensures the image is cached.
+OCI_BIN=${OCI_BIN:-$(docker-utils::determine_cri_bin)}
+CLUSTER_IMAGE="quay.io/kubevirtci/${KUBEVIRT_PROVIDER}:${KUBEVIRTCI_TAG}"
+echo "Pre-pulling kubevirtci cluster image: ${CLUSTER_IMAGE}..."
+${OCI_BIN} pull ${CLUSTER_IMAGE} || true
 
 $(cluster::path)/cluster-up/up.sh
 


### PR DESCRIPTION
Fixes #2807

Fix #2807: CI Failure: pull-e2e-cluster-network-addons-operator-multus-functests

fix(ci): pre-pull kubevirtci cluster image to prevent timeout during setup

The multus-functests CI job was timing out during infrastructure setup
while attempting to download the kubevirtci cluster container image
quay.io/kubevirtci/k8s-1.34:2603311027-36247754. The job was terminated
by Prow infrastructure after ~2.5 minutes before completing cluster
initialization.

This failure is part of a broader pattern of Prow CI infrastructure
timeout issues affecting multiple test jobs in this repository. The
specific issue here is that the large kubevirtci cluster image is
downloaded on-demand during the cluster-up process, which can be slow
in CI environments with variable network performance.

This change adds an explicit pre-pull step for the kubevirtci cluster
image in cluster/up.sh, before the kubevirtci up.sh script is invoked.
This ensures:
- The image is pulled once and cached for subsequent operations
- Image pull operations don't contribute to timeout during cluster-up
- Setup phase completes more reliably within Prow timeout constraints

The approach follows the same pattern as recent CI timeout mitigation
fixes that pre-pull container images before they are needed (e.g., the
yq image pre-pull in commits addressing issues #2741, #2745, etc.).

Fixes #2807

---

<!-- oompa-bot v:116817e -->