### PR TITLE
CI Failure: pull-e2e-cluster-network-addons-operator-ovs-cni-functests / The `pull-e2e-cluster-network-addons-operator-ovs-cni-functe

### DIFF
--- a/automation/components-functests.setup.sh
+++ b/automation/components-functests.setup.sh
@@ -24,6 +24,20 @@ source cluster/cluster.sh
 USE_KUBEVIRTCI=${USE_KUBEVIRTCI:-"true"}
 CNAO_DEPLOY_KUBEVIRT=${CNAO_DEPLOY_KUBEVIRT:-"false"}
 
+# Pre-pull kubevirtci cluster image to avoid timeout issues during cluster setup
+# The cluster-up process downloads this large image, and pulling on-demand can be
+# slow in CI environments, potentially exceeding Prow timeout constraints
+if [[ $USE_KUBEVIRTCI == true ]]; then
+  if [ -z "${OCI_BIN:-}" ]; then
+    export OCI_BIN=$(if podman ps >/dev/null 2>&1; then echo podman; elif docker ps >/dev/null 2>&1; then echo docker; fi)
+  fi
+  if [ -n "${OCI_BIN:-}" ]; then
+    KUBEVIRTCI_IMAGE="quay.io/kubevirtci/${KUBEVIRT_PROVIDER}:${KUBEVIRTCI_TAG}"
+    echo "Pre-pulling kubevirtci cluster image: ${KUBEVIRTCI_IMAGE}..."
+    ${OCI_BIN} pull ${KUBEVIRTCI_IMAGE} || true
+  fi
+fi
+
 # Export .kubeconfig full path, so it will be possible
 # to use 'kubectl' directly from the component directory path
 export KUBECONFIG=${KUBECONFIG:-$(cluster::kubeconfig)}


### PR DESCRIPTION
Fixes #2810

**What this PR does / why we need it**:

This PR fixes intermittent CI failures in the `pull-e2e-cluster-network-addons-operator-ovs-cni-functests` job caused by slow network downloads of the kubevirtci cluster image (`quay.io/kubevirtci/k8s-1.34:2603311027-36247754`) during cluster setup.

The fix adds a pre-pull step in `automation/components-functests.setup.sh` to cache the kubevirtci cluster image before cluster deployment begins. This prevents timeout failures when the Prow CI environment experiences slow network performance to container registries.

**Special notes for your reviewer**:

- This follows the same pattern as previous infrastructure fixes for similar timeout issues
- The pre-pull operation uses `|| true` to avoid failing if the pull encounters issues (the cluster setup will still attempt to pull the image if pre-pull fails)
- The fix only applies when `USE_KUBEVIRTCI=true` (the default for CI jobs)
- OCI_BIN (podman/docker) is auto-detected if not already set

**Release note**:
```release-note
NONE
```

<!-- oompa-bot v:116817e -->