### PR TITLE
CI Failure: pull-e2e-cluster-network-addons-operator-macvtap-cni-functests / The `pull-e2e-cluster-network-addons-operator-macvtap-cni-fu

### DIFF
--- a/automation/components-functests.setup.sh
+++ b/automation/components-functests.setup.sh
@@ -101,6 +101,16 @@ git-utils::fetch_component ${component_path} ${component_url} ${component_commit
 export TMP_COMPONENT_PATH=${component_path}
 
 if [[ $USE_KUBEVIRTCI == true ]]; then
+  # Pre-pull kubevirtci cluster image to avoid timeout issues during cluster setup
+  if [ -z "${OCI_BIN:-}" ]; then
+    export OCI_BIN=$(if podman ps >/dev/null 2>&1; then echo podman; elif docker ps >/dev/null 2>&1; then echo docker; fi)
+  fi
+  if [ -n "${OCI_BIN:-}" ]; then
+    KUBEVIRTCI_IMAGE="quay.io/kubevirtci/${KUBEVIRT_PROVIDER}:${KUBEVIRTCI_TAG}"
+    echo "Pre-pulling kubevirtci cluster image: ${KUBEVIRTCI_IMAGE}..."
+    ${OCI_BIN} pull ${KUBEVIRTCI_IMAGE} || true
+  fi
+
   deploy_cluster
   deploy_cnao
   patch_restricted_namespace


### PR DESCRIPTION
Fixes #2813

**What this PR does / why we need it**:

This PR adds pre-pulling of the kubevirtci cluster image in the components-functests setup script to prevent CI timeout failures during cluster setup.

The macvtap-cni-functests job was experiencing failures when the Prow CI environment had slow network connectivity to the quay.io registry, causing large image downloads to exceed timeout constraints and result in job termination. By pre-pulling the kubevirtci cluster image before cluster setup begins, we ensure the image is cached and available, with graceful failure handling (`|| true`) to allow the cluster-up process to retry if needed.

**Special notes for your reviewer**:

This fix addresses a CI infrastructure issue that has been observed in multiple test jobs. The pre-pull logic:
- Detects the available container runtime (podman or docker)
- Pulls the kubevirtci cluster image before `make cluster-up` is invoked
- Uses graceful error handling to prevent the pre-pull from blocking the setup if it fails

**Release note**:

```release-note
NONE
```

<!-- oompa-bot v:116817e -->