### PR TITLE
CI Failure: pull-e2e-cnao-multus-dynamic-networks-functests / The `pull-e2e-cnao-multus-dynamic-networks-functests` job

### DIFF
--- a/automation/components-functests.setup.sh
+++ b/automation/components-functests.setup.sh
@@ -101,6 +101,16 @@ git-utils::fetch_component ${component_path} ${component_url} ${component_commit
 export TMP_COMPONENT_PATH=${component_path}
 
 if [[ $USE_KUBEVIRTCI == true ]]; then
+  # Pre-pull kubevirtci cluster image to avoid timeout issues during cluster setup
+  if [ -z "${OCI_BIN:-}" ]; then
+    export OCI_BIN=$(if podman ps >/dev/null 2>&1; then echo podman; elif docker ps >/dev/null 2>&1; then echo docker; fi)
+  fi
+  if [ -n "${OCI_BIN:-}" ]; then
+    KUBEVIRTCI_IMAGE="quay.io/kubevirtci/${KUBEVIRT_PROVIDER}:${KUBEVIRTCI_TAG}"
+    echo "Pre-pulling kubevirtci cluster image: ${KUBEVIRTCI_IMAGE}..."
+    ${OCI_BIN} pull ${KUBEVIRTCI_IMAGE} || true
+  fi
+
   deploy_cluster
   deploy_cnao
   patch_restricted_namespace


### PR DESCRIPTION
Fixes #2815

**What this PR does / why we need it**:

This PR adds pre-pulling logic for the kubevirtci cluster image to prevent timeout failures in the `pull-e2e-cnao-multus-dynamic-networks-functests` CI job.

The job was experiencing timeouts when downloading the large k8s-1.34 cluster image due to slow network performance in the Prow CI environment. By pre-pulling the image before cluster deployment (with a non-blocking `|| true` retry), the download can complete outside the critical cluster setup phase, reducing the likelihood of timeout failures.

This fix mirrors the solution already applied to other component functional tests (commit 69153d007).

**Special notes for your reviewer**:

This is an infrastructure fix addressing a known pattern of CI failures (#2813, #2810, #2807, #2804, #2793, #2791, #2762) related to kubevirtci image downloads timing out. The pre-pull logic uses `|| true` to allow graceful failure while still allowing cluster-up to retry if needed.

**Release note**:

```release-note
NONE
```

<!-- oompa-bot v:116817e -->