### PR TITLE
CI Failure: pull-e2e-cnao-kube-secondary-dns-functests / The `pull-e2e-cnao-kube-secondary-dns-functests` job was

### DIFF
--- a/automation/components-functests.setup.sh
+++ b/automation/components-functests.setup.sh
@@ -101,6 +101,16 @@ git-utils::fetch_component ${component_path} ${component_url} ${component_commit
 export TMP_COMPONENT_PATH=${component_path}
 
 if [[ $USE_KUBEVIRTCI == true ]]; then
+  # Pre-pull kubevirtci cluster image to avoid timeout issues during cluster setup
+  if [ -z "${OCI_BIN:-}" ]; then
+    export OCI_BIN=$(if podman ps >/dev/null 2>&1; then echo podman; elif docker ps >/dev/null 2>&1; then echo docker; fi)
+  fi
+  if [ -n "${OCI_BIN:-}" ]; then
+    KUBEVIRTCI_IMAGE="quay.io/kubevirtci/${KUBEVIRT_PROVIDER}:${KUBEVIRTCI_TAG}"
+    echo "Pre-pulling kubevirtci cluster image: ${KUBEVIRTCI_IMAGE}..."
+    ${OCI_BIN} pull ${KUBEVIRTCI_IMAGE} || true
+  fi
+
   deploy_cluster
   deploy_cnao
   patch_restricted_namespace


### PR DESCRIPTION
Fixes #2817

**What this PR does / why we need it**:

This PR fixes CI timeout failures in the `pull-e2e-cnao-kube-secondary-dns-functests` job by adding pre-pull logic for the kubevirtci cluster container image before cluster deployment.

The job was experiencing intermittent failures during infrastructure setup when downloading the k8s-1.34 cluster image (`quay.io/kubevirtci/k8s-1.34:2603311027-36247754`). The Prow entrypoint was terminating the job after ~2 minutes due to slow network performance in the CI environment.

By pre-pulling the image with a non-blocking retry (`|| true`), we allow the download to complete outside the critical cluster setup phase, reducing timeout-related failures.

**Special notes for your reviewer**:

This fix mirrors the solution already applied to other component functional tests to address similar infrastructure timeout issues. The pre-pull logic:
- Detects the available container runtime (podman or docker)
- Pre-pulls the kubevirtci cluster image before cluster deployment
- Uses `|| true` to make it non-blocking, so failures don't prevent the test from running
- Helps reduce transient CI flakes caused by network performance variability

**Release note**:

```release-note
NONE
```

<!-- oompa-bot v:116817e -->