### PR TITLE
fix(ci): query gcloud stable for KubeVirt version in deploy script

### DIFF
--- a/hack/deploy-kubevirt.sh
+++ b/hack/deploy-kubevirt.sh
@@ -2,8 +2,7 @@
 set -exo pipefail
 
 if [ -z "${KUBEVIRT_VERSION}" ];then
-  # Get latest stable KubeVirt version
-  export KUBEVIRT_VERSION=$(curl -s https://api.github.com/repos/kubevirt/kubevirt/releases | grep tag_name | grep -v -- - | sort -V | tail -1 | awk -F':' '{print $2}' | sed 's/,//' | xargs)
+  export KUBEVIRT_VERSION=$(curl -sSfL https://storage.googleapis.com/kubevirt-prow/release/kubevirt/kubevirt/stable.txt)
 fi
 
 ./cluster/kubectl.sh apply -f https://github.com/kubevirt/kubevirt/releases/download/${KUBEVIRT_VERSION}/kubevirt-operator.yaml


### PR DESCRIPTION
Fixes #2821

**What this PR does / why we need it**:

This PR fixes a flaky CI test failure in the kubevirt-ipam-controller.yaml periodic job. The issue was caused by the `hack/deploy-kubevirt.sh` script querying the GitHub API to determine the latest KubeVirt version, which is subject to rate limiting (60 requests/hour for unauthenticated requests). When the rate limit was exceeded, the API returned an empty response, causing a malformed download URL and CI failure.

The fix replaces the GitHub API query with a more reliable method that fetches the version from Google Cloud Storage (stable.txt). This is the same approach already used in the main test script for downloading virtctl, ensuring consistency and eliminating the rate limiting issue.

**Special notes for your reviewer**:

- The same pattern is already used in `automation/check-patch.e2e-kubevirt-ipam-controller-functests.sh:41` for downloading virtctl
- This change maintains the same behavior (getting the latest stable version) while avoiding GitHub API rate limits
- No functional changes to the deployment process, just a more reliable source for version information

**Release note**:

```release-note
NONE
```

<!-- oompa-bot v:0936faa -->