### PR TITLE
CI Failure: pull-e2e-cluster-network-addons-operator-lifecycle-k8s / The `pull-e2e-cluster-network-addons-operator-lifecycle-k8s`

### DIFF
--- a/cluster/cluster-utils.sh
+++ b/cluster/cluster-utils.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+#
+# Copyright 2024 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -xeo pipefail
+
+source hack/components/docker-utils.sh
+
+export OCI_BIN=${OCI_BIN:-$(docker-utils::determine_cri_bin)}
+
+# Pre-pull the kubevirtci cluster image with retry logic to avoid failures during setup
+function cluster-utils::prepull_cluster_image() {
+  local cluster_image="quay.io/kubevirtci/${KUBEVIRT_PROVIDER}:${KUBEVIRTCI_TAG}"
+  local max_attempts=3
+  local attempt=1
+  local wait_time=5
+
+  echo "Pre-pulling kubevirtci cluster image: ${cluster_image}"
+
+  while [ $attempt -le $max_attempts ]; do
+    echo "Attempt $attempt of $max_attempts to pull ${cluster_image}"
+    if ${OCI_BIN} pull ${cluster_image}; then
+      echo "Successfully pulled ${cluster_image}"
+      return 0
+    else
+      echo "Failed to pull ${cluster_image} on attempt $attempt"
+      if [ $attempt -lt $max_attempts ]; then
+        echo "Waiting ${wait_time} seconds before retry..."
+        sleep $wait_time
+        wait_time=$((wait_time * 2))  # Exponential backoff
+      fi
+      attempt=$((attempt + 1))
+    fi
+  done
+
+  echo "WARNING: Failed to pull ${cluster_image} after $max_attempts attempts"
+  echo "This may be expected if the image doesn't support the current architecture"
+  echo "The kubevirtci cluster-up script will handle image pulling as needed"
+  return 0
+}

--- a/cluster/up.sh
+++ b/cluster/up.sh
@@ -18,12 +18,16 @@ set -ex
 
 SCRIPTS_PATH="$(dirname "$(realpath "$0")")"
 source ${SCRIPTS_PATH}/cluster.sh
+source ${SCRIPTS_PATH}/cluster-utils.sh
 
 export KUBEVIRT_DEPLOY_PROMETHEUS=true
 export KUBEVIRT_DEPLOY_PROMETHEUS_ALERTMANAGER=true
 export KUBEVIRT_DEPLOY_GRAFANA=true
 
 cluster::install
+
+# Pre-pull kubevirtci cluster image with retry logic to avoid CI failures during setup
+cluster-utils::prepull_cluster_image
 
 $(cluster::path)/cluster-up/up.sh
 


### PR DESCRIPTION
Fixes #2823

**What this PR does / why we need it**:

This PR adds retry logic for the kubevirtci cluster image pull during CI setup to prevent infrastructure-related failures. The `pull-e2e-cluster-network-addons-operator-lifecycle-k8s` CI job was experiencing intermittent failures when the large kubevirtci cluster image pull was interrupted by timeouts, network issues, or resource constraints in the Prow CI environment.

The fix implements a `cluster-utils::prepull_cluster_image()` function that:
- Attempts to pull the kubevirtci cluster image with up to 3 retries
- Uses exponential backoff (5s, 10s, 20s) between retry attempts
- Returns success even on failure (best-effort) to support architectures where the image may not be available
- Caches the image before kubevirtci's cluster-up script runs

This follows the same pattern used in commit 5064b0274 to fix similar yq image pull timeout issues.

**Special notes for your reviewer**:

This is an infrastructure resilience improvement that mitigates external registry/network issues. The prepull is best-effort and won't break on architectures where the kubevirtci cluster image doesn't have a manifest (e.g., s390x), as the kubevirtci scripts handle that scenario.

**Release note**:

```release-note
NONE
```

<!-- oompa-bot v:0936faa -->