### PR TITLE
CI Failure: pull-cluster-network-addons-operator-unit-test / The CI job failed during a multi-platform container build

### DIFF
--- a/hack/components/bump-linux-bridge.sh
+++ b/hack/components/bump-linux-bridge.sh
@@ -87,7 +87,25 @@ build_podman_image() {
     podman manifest create "${LINUX_BRIDGE_IMAGE_TAGGED}"
 
     for platform in "${PLATFORM_LIST[@]}"; do
-        podman build --platform "$platform" --manifest "${LINUX_BRIDGE_IMAGE_TAGGED}" .
+        local max_retries=3
+        local retry_count=0
+        local retry_delay=5
+
+        while [ $retry_count -lt $max_retries ]; do
+            if podman build --platform "$platform" --manifest "${LINUX_BRIDGE_IMAGE_TAGGED}" .; then
+                break
+            else
+                retry_count=$((retry_count + 1))
+                if [ $retry_count -lt $max_retries ]; then
+                    echo "Build failed for platform $platform, attempt $retry_count/$max_retries. Retrying in ${retry_delay}s..."
+                    sleep $retry_delay
+                    retry_delay=$((retry_delay * 2))
+                else
+                    echo "Build failed for platform $platform after $max_retries attempts."
+                    return 1
+                fi
+            fi
+        done
     done
 }
 


### PR DESCRIPTION
Fixes #2826

**What this PR does / why we need it**:

This PR adds retry logic with exponential backoff to the `bump-linux-bridge.sh` script to handle transient network failures during multi-platform container image builds. The CI job `pull-cluster-network-addons-operator-unit-test` was failing intermittently due to network interruptions when pulling base images from container registries (specifically `registry.access.redhat.com/ubi8/ubi-minimal:latest` via CDN endpoints).

The changes include:
- 3 retry attempts per platform build
- Exponential backoff starting at 5 seconds (5s, 10s delay between retries)
- Clear logging to indicate retry progress
- Proper error handling after all retries are exhausted

This mitigation allows the build process to recover from transient infrastructure issues without requiring manual CI job restarts.

**Special notes for your reviewer**:

The retry logic is specifically added to the `build_podman_image()` function which builds container images for multiple platforms (linux/amd64, linux/s390x, linux/arm64). The original issue showed that the network failure occurred during the linux/arm64 build while downloading a blob from the CDN. With this change, such transient failures will be automatically retried before failing the entire build.

The docker build path (`build_docker_image()`) was not modified as docker buildx may have its own retry mechanisms.

**Release note**:

```release-note
NONE
```

<!-- oompa-bot v:0936faa -->