### PR TITLE
Allow to configure bridge-marker health port

### DIFF
--- a/data/linux-bridge/003-bridge-marker.yaml
+++ b/data/linux-bridge/003-bridge-marker.yaml
@@ -37,6 +37,8 @@ spec:
           args:
             - -node-name
             - $(NODE_NAME)
+            - -health-probe-port
+            - "{{ .HealthPort }}"
           resources:
             requests:
               cpu: "10m"
@@ -48,7 +50,7 @@ spec:
                   fieldPath: spec.nodeName
           ports:
             - name: healthport
-              containerPort: 8081
+              containerPort: {{ .HealthPort }}
               protocol: TCP
           terminationMessagePolicy: FallbackToLogsOnError
           readinessProbe:

--- a/pkg/apis/networkaddonsoperator/shared/networkaddonsconfig_types.go
+++ b/pkg/apis/networkaddonsoperator/shared/networkaddonsconfig_types.go
@@ -61,7 +61,9 @@ type MultusDynamicNetworks struct {
 }
 
 // LinuxBridge plugin allows users to create a bridge and add the host and the container to it
-type LinuxBridge struct{}
+type LinuxBridge struct {
+	BridgeMarkerHealthPort *int32 `json:"bridgeMarkerHealthPort,omitempty"`
+}
 
 // Ovs plugin allows users to define Kubernetes networks on top of Open vSwitch bridges available on nodes
 type Ovs struct{}

--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -36,7 +36,7 @@ const (
 	MultusImageDefault                 = "ghcr.io/k8snetworkplumbingwg/multus-cni@sha256:2b9671447f3ea4e7e56730843dbf59445b9307246f393b61386b896d56ae51c9"
 	MultusDynamicNetworksImageDefault  = "ghcr.io/k8snetworkplumbingwg/multus-dynamic-networks-controller@sha256:2a2bb32c0ea8b232b3dbe81c0323a107e8b05f8cad06704fca2efd0d993a87be"
 	LinuxBridgeCniImageDefault         = "quay.io/kubevirt/cni-default-plugins@sha256:976a24392c2a096c38c2663d234b2d3131f5c24558889196d30b9ac1b6716788"
-	LinuxBridgeMarkerImageDefault      = "quay.io/kubevirt/bridge-marker@sha256:f9611ec10bb4aec44b0ec19f9b9d748a36255c089a1f59bc76e5fc37acc0fed2"
+	LinuxBridgeMarkerImageDefault      = "quay.io/kubevirt/bridge-marker@sha256:a8139c4fc4abaf8ce02d6afc46fc6597536065b58ff79494bc491a7409181408"
 	KubeMacPoolImageDefault            = "quay.io/kubevirt/kubemacpool@sha256:5cced3ea271ba4e3f9c8c56775607fb21c76c88475893729f48cddbc87f7f145"
 	OvsCniImageDefault                 = "ghcr.io/k8snetworkplumbingwg/ovs-cni-plugin@sha256:435f374b434b3bc70a5cfaba0011fdcf5f433d96b98b06d29306cbd8db3a8c21"
 	MacvtapCniImageDefault             = "quay.io/kubevirt/macvtap-cni@sha256:5266955a654a4cb4e425424ab274cf31e7a6deb3f340e3679a11d689bfa734d0"
@@ -1371,6 +1371,13 @@ func GetCrd() *extv1.CustomResourceDefinition {
 						"linuxBridge": extv1.JSONSchemaProps{
 							Description: "LinuxBridge plugin allows users to create a bridge and add the host and the container to it",
 							Type:        "object",
+							Properties: map[string]extv1.JSONSchemaProps{
+								"bridgeMarkerHealthPort": extv1.JSONSchemaProps{
+									Description: "BridgeMarkerHealthPort defines the health check port for the linux-bridge marker container",
+									Type:        "integer",
+									Format:      "int32",
+								},
+							},
 						},
 						"macvtap": extv1.JSONSchemaProps{
 							Description: "MacvtapCni plugin allows users to define Kubernetes networks on top of existing host interfaces",

--- a/pkg/network/cni/cni.go
+++ b/pkg/network/cni/cni.go
@@ -1,8 +1,9 @@
 package cni
 
 const (
-	ConfigDir           = "/etc/cni/net.d"
-	BinDir              = "/opt/cni/bin"
-	ConfigDirOpenShift4 = "/etc/kubernetes/cni/net.d"
-	BinDirOpenShift4    = "/var/lib/cni/bin"
+	ConfigDir                     = "/etc/cni/net.d"
+	BinDir                        = "/opt/cni/bin"
+	ConfigDirOpenShift4           = "/etc/kubernetes/cni/net.d"
+	BinDirOpenShift4              = "/var/lib/cni/bin"
+	DefaultBridgeMarkerHealthPort = "8081"
 )

--- a/pkg/network/linux-bridge.go
+++ b/pkg/network/linux-bridge.go
@@ -1,8 +1,10 @@
 package network
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 
 	"github.com/kubevirt/cluster-network-addons-operator/pkg/render"
 	"github.com/pkg/errors"
@@ -11,6 +13,17 @@ import (
 	cnao "github.com/kubevirt/cluster-network-addons-operator/pkg/apis/networkaddonsoperator/shared"
 	"github.com/kubevirt/cluster-network-addons-operator/pkg/network/cni"
 )
+
+func validateLinuxBridge(conf *cnao.NetworkAddonsConfigSpec) []error {
+	if conf.LinuxBridge == nil || conf.LinuxBridge.BridgeMarkerHealthPort == nil {
+		return nil
+	}
+	port := *conf.LinuxBridge.BridgeMarkerHealthPort
+	if port < 1 || port > 65535 {
+		return []error{fmt.Errorf("linuxBridge.bridgeMarkerHealthPort %d is out of range [1, 65535]", port)}
+	}
+	return nil
+}
 
 // renderLinuxBridge generates the manifests of Linux Bridge
 func renderLinuxBridge(conf *cnao.NetworkAddonsConfigSpec, manifestDir string, clusterInfo *ClusterInfo) ([]*unstructured.Unstructured, error) {
@@ -31,6 +44,11 @@ func renderLinuxBridge(conf *cnao.NetworkAddonsConfigSpec, manifestDir string, c
 	}
 	data.Data["EnableSCC"] = clusterInfo.SCCAvailable
 	data.Data["Placement"] = conf.PlacementConfiguration.Workloads
+	if conf.LinuxBridge.BridgeMarkerHealthPort != nil {
+		data.Data["HealthPort"] = strconv.Itoa(int(*conf.LinuxBridge.BridgeMarkerHealthPort))
+	} else {
+		data.Data["HealthPort"] = cni.DefaultBridgeMarkerHealthPort
+	}
 
 	objs, err := render.RenderDir(filepath.Join(manifestDir, "linux-bridge"), &data)
 	if err != nil {

--- a/pkg/network/linux_bridge_test.go
+++ b/pkg/network/linux_bridge_test.go
@@ -1,0 +1,161 @@
+package network
+
+import (
+	"slices"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	cnao "github.com/kubevirt/cluster-network-addons-operator/pkg/apis/networkaddonsoperator/shared"
+	"github.com/kubevirt/cluster-network-addons-operator/pkg/network/cni"
+)
+
+func int32Ptr(v int32) *int32 { return &v }
+
+var _ = Describe("validateLinuxBridge", func() {
+	DescribeTable("port validation",
+		func(port *int32, expectError bool) {
+			conf := &cnao.NetworkAddonsConfigSpec{
+				LinuxBridge: &cnao.LinuxBridge{BridgeMarkerHealthPort: port},
+			}
+			errs := validateLinuxBridge(conf)
+			if expectError {
+				Expect(errs).NotTo(BeEmpty())
+			} else {
+				Expect(errs).To(BeEmpty())
+			}
+		},
+		Entry("valid port", int32Ptr(9090), false),
+		Entry("minimum valid port", int32Ptr(1), false),
+		Entry("maximum valid port", int32Ptr(65535), false),
+		Entry("default port", int32Ptr(8081), false),
+		Entry("port zero", int32Ptr(0), true),
+		Entry("port too large", int32Ptr(65536), true),
+		Entry("negative port", int32Ptr(-1), true),
+	)
+
+	It("passes when LinuxBridge is nil", func() {
+		conf := &cnao.NetworkAddonsConfigSpec{}
+		Expect(validateLinuxBridge(conf)).To(BeEmpty())
+	})
+
+	It("passes when BridgeMarkerHealthPort is nil", func() {
+		conf := &cnao.NetworkAddonsConfigSpec{
+			LinuxBridge: &cnao.LinuxBridge{},
+		}
+		Expect(validateLinuxBridge(conf)).To(BeEmpty())
+	})
+})
+
+var _ = Describe("renderLinuxBridge", func() {
+	const manifestDir = "../../data"
+
+	var clusterInfo *ClusterInfo
+
+	BeforeEach(func() {
+		clusterInfo = &ClusterInfo{SCCAvailable: false, OpenShift4: false}
+	})
+
+	Context("when LinuxBridge is nil", func() {
+		It("returns nil without error", func() {
+			conf := &cnao.NetworkAddonsConfigSpec{}
+			objs, err := renderLinuxBridge(conf, manifestDir, clusterInfo)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(objs).To(BeNil())
+		})
+	})
+
+	Context("when LinuxBridge is set without a custom health port", func() {
+		It("uses the default health port in the rendered DaemonSet", func() {
+			conf := &cnao.NetworkAddonsConfigSpec{
+				ImagePullPolicy: v1.PullIfNotPresent,
+				LinuxBridge:     &cnao.LinuxBridge{},
+				PlacementConfiguration: &cnao.PlacementConfiguration{
+					Workloads: &cnao.Placement{},
+				},
+			}
+
+			objs, err := renderLinuxBridge(conf, manifestDir, clusterInfo)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(objs).NotTo(BeEmpty())
+
+			ds, err := getBridgeMarkerDaemonSet(objs)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(healthPortFromDaemonSet(ds)).To(Equal(int32(8081)),
+				"expected default health port %s", cni.DefaultBridgeMarkerHealthPort)
+			Expect(healthPortArgFromDaemonSet(ds)).To(Equal(cni.DefaultBridgeMarkerHealthPort))
+		})
+	})
+
+	Context("when LinuxBridge is set with a custom health port", func() {
+		It("uses the custom health port in the rendered DaemonSet", func() {
+			conf := &cnao.NetworkAddonsConfigSpec{
+				ImagePullPolicy: v1.PullIfNotPresent,
+				LinuxBridge:     &cnao.LinuxBridge{BridgeMarkerHealthPort: int32Ptr(9090)},
+				PlacementConfiguration: &cnao.PlacementConfiguration{
+					Workloads: &cnao.Placement{},
+				},
+			}
+
+			objs, err := renderLinuxBridge(conf, manifestDir, clusterInfo)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(objs).NotTo(BeEmpty())
+
+			ds, err := getBridgeMarkerDaemonSet(objs)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(healthPortFromDaemonSet(ds)).To(Equal(int32(9090)))
+			Expect(healthPortArgFromDaemonSet(ds)).To(Equal("9090"))
+		})
+	})
+})
+
+func getBridgeMarkerDaemonSet(objs []*unstructured.Unstructured) (*appsv1.DaemonSet, error) {
+	idx := slices.IndexFunc(objs, func(obj *unstructured.Unstructured) bool {
+		return obj.GetKind() == "DaemonSet" && obj.GetName() == "bridge-marker"
+	})
+	if idx == -1 {
+		return nil, nil
+	}
+	ds := &appsv1.DaemonSet{}
+	err := runtime.DefaultUnstructuredConverter.FromUnstructured(objs[idx].Object, ds)
+	if err != nil {
+		return nil, err
+	}
+	return ds, nil
+}
+
+// healthPortFromDaemonSet returns the containerPort named "healthport" from the bridge-marker container.
+func healthPortFromDaemonSet(ds *appsv1.DaemonSet) int32 {
+	for _, c := range ds.Spec.Template.Spec.Containers {
+		if c.Name != "bridge-marker" {
+			continue
+		}
+		for _, p := range c.Ports {
+			if p.Name == "healthport" {
+				return p.ContainerPort
+			}
+		}
+	}
+	return 0
+}
+
+// healthPortArgFromDaemonSet returns the value passed to -health-probe-port in the bridge-marker container args.
+func healthPortArgFromDaemonSet(ds *appsv1.DaemonSet) string {
+	for _, c := range ds.Spec.Template.Spec.Containers {
+		if c.Name != "bridge-marker" {
+			continue
+		}
+		for i, arg := range c.Args {
+			if arg == "-health-probe-port" && i+1 < len(c.Args) {
+				return c.Args[i+1]
+			}
+		}
+	}
+	return ""
+}

--- a/pkg/network/network.go
+++ b/pkg/network/network.go
@@ -46,6 +46,7 @@ func Validate(conf *cnao.NetworkAddonsConfigSpec, openshiftNetworkConfig *osv1.N
 	errs = append(errs, validateSelfSignConfiguration(conf)...)
 	errs = append(errs, validateMultusDynamicNetworks(conf, openshiftNetworkConfig)...)
 	errs = append(errs, validateMacvtap(conf, openshiftNetworkConfig)...)
+	errs = append(errs, validateLinuxBridge(conf)...)
 
 	if len(errs) > 0 {
 		return errors.Errorf("invalid configuration:\n%s", errorListToMultiLineString(errs))

--- a/test/releases/99.0.0.go
+++ b/test/releases/99.0.0.go
@@ -30,7 +30,7 @@ func init() {
 				ParentName: "bridge-marker",
 				ParentKind: "DaemonSet",
 				Name:       "bridge-marker",
-				Image:      "quay.io/kubevirt/bridge-marker@sha256:f9611ec10bb4aec44b0ec19f9b9d748a36255c089a1f59bc76e5fc37acc0fed2",
+				Image:      "quay.io/kubevirt/bridge-marker@sha256:a8139c4fc4abaf8ce02d6afc46fc6597536065b58ff79494bc491a7409181408",
 			},
 			{
 				ParentName: "kube-cni-linux-bridge-plugin",


### PR DESCRIPTION
Unittests added with Claude

Fixes: #2832 

**What this PR does / why we need it**:
Adds a `bridgeMarkerHealthPort` field to the `linuxBridge` section of `NetworkAddonsConfig`, allowing users to override the default health probe port (`8081`) of the `bridge-marker` container. This is needed in environments where the default port conflicts with other workloads or is restricted by network policies. The port value is validated to be a valid integer in range [1, 65535]. When not set, the existing default is preserved for full backwards compatibility.

**Special notes for your reviewer**:
The `bridge-marker` container already supports the `-health-probe-port` flag  (commit merged 9fe89af95800813048b6d4c3babd1fedd442dec8)— this change only exposes it through the operator API. Both the container port declaration and the CLI argument are templated from the same value to keep them in sync.

**Release note**:

```release-note
Added optional `bridgeMarkerHealthPort` field to the `linuxBridge` spec, allowing users to configure a custom health probe port for the bridge-marker container. Defaults to `8081` if not set.
```
