### PR TITLE
hack: update tls-compliance-operator to v1.0.18

### DIFF
--- a/hack/install-tls-compliance-operator.sh
+++ b/hack/install-tls-compliance-operator.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-VERSION=${VERSION:-v0.0.10}
+VERSION=${VERSION:-v1.0.18}
 
 readonly URL="https://github.com/sebrandon1/tls-compliance-operator/releases/download/${VERSION}/install.yaml"
 readonly NAMESPACE="tls-compliance-operator-system"
@@ -15,7 +15,7 @@ echo "Installing TLS Compliance Operator ${VERSION} from: ${URL}.."
 # By default the operator scan common TLS ports (443, 6443, 8443, 9443), and installs
 # permissive network-policy for those ports only [1].
 # To allow the operator reach and check all services the network-policy is deleted.
-# [1] https://github.com/sebrandon1/tls-compliance-operator/blob/v0.0.10/docs/troubleshooting.md#:~:text=Check%20for%20NetworkPolicy%20restrictions
+# [1] https://github.com/sebrandon1/tls-compliance-operator/blob/v1.0.18/docs/troubleshooting.md#:~:text=Check%20for%20NetworkPolicy%20restrictions
 echo "Deleting the operator's network-policy to allow egress all services.."
 ./cluster/kubectl.sh -n $NAMESPACE delete networkpolicy $NP_NAME 
 

--- a/test/e2e/compliance/tls_compliance_test.go
+++ b/test/e2e/compliance/tls_compliance_test.go
@@ -77,6 +77,12 @@ var _ = Describe("TLS", func() {
 					Status: "True",
 					Reason: "Valid",
 				},
+				{
+					Type:    "PQCCompliant",
+					Status:  metav1.ConditionTrue,
+					Reason:  "PQCReady",
+					Message: "Endpoint supports TLS 1.3 with post-quantum key exchange (ML-KEM)",
+				},
 			},
 		}
 		expectedReports := []tlsReport{


### PR DESCRIPTION
## Summary

- Update the default TLS Compliance Operator version from `v0.0.10` to `v1.0.18`
- Update troubleshooting doc reference link to point to the `v1.0.18` tag
- Add expected `PQCCompliant` condition to TLS compliance e2e test

The [v1.0.18 release](https://github.com/sebrandon1/tls-compliance-operator/releases/tag/v1.0.18) includes numerous improvements since v0.0.10, including PQC readiness classification, health check metrics with Prometheus alerts, certificate chain details, SBOM generation, and kubectl plugin enhancements.