### PR TITLE
CI Failure: kubevirt/cluster-network-addons-operator/kubevirt-ipam-controller.yaml / The kubevirt-ipam-controller e2e test failed with "OCI_BIN:

### DIFF
--- a/automation/check-patch.e2e-kubevirt-ipam-controller-functests.sh
+++ b/automation/check-patch.e2e-kubevirt-ipam-controller-functests.sh
@@ -20,7 +20,7 @@ teardown() {
 }
 
 increase_ulimit() {
-    if [ -z "${OCI_BIN}" ];then
+    if [ -z "${OCI_BIN:-}" ];then
       export OCI_BIN=$(if podman ps >/dev/null 2>&1; then echo podman; elif docker ps >/dev/null 2>&1; then echo docker; else echo "Neither podman nor docker is available." >&2; exit 1; fi)
     fi
 


### PR DESCRIPTION
Fixes #2835

**What this PR does / why we need it**:

This PR fixes a CI failure in the kubevirt-ipam-controller e2e test that was failing with "OCI_BIN: unbound variable" error. 

The root cause was the `increase_ulimit()` function checking `${OCI_BIN}` without a default value while running with `set -u` enabled. This became an issue after the yq v4 upgrade removed the OCI_BIN initialization that was previously done for yq v3's container-based execution.

The fix uses `${OCI_BIN:-}` syntax to provide an empty string default when OCI_BIN is unset, preventing the error while maintaining the correct conditional logic.

**Special notes for your reviewer**:

This is a one-line fix changing line 23 of `automation/check-patch.e2e-kubevirt-ipam-controller-functests.sh` from:
```bash
if [ -z "${OCI_BIN}" ];then
```
to:
```bash
if [ -z "${OCI_BIN:-}" ];then
```

The `:-` parameter expansion is the standard bash idiom for handling potentially unset variables when `set -u` is active.

**Release note**:

```release-note
NONE
```

<!-- oompa-bot v:a0cadae -->