### PR TITLE
CI Failure: pull-cluster-network-addons-operator-unit-test / The `pull-cluster-network-addons-operator-unit-test` job

### DIFF
--- a/hack/components/bump-kubevirt-ipam-controller.sh
+++ b/hack/components/bump-kubevirt-ipam-controller.sh
@@ -32,6 +32,13 @@ function __parametize_by_object() {
         yaml-utils::set_param ${f} 'spec.template.metadata.labels."allow-access-cluster-services"' '""'
         yaml-utils::remove_single_quotes_from_yaml ${f}
         # sed operation is done after all yq operations to avoid unexpected yq error
+        # NOTE: When using sed '/pattern/a' to append multiple blocks after the same line,
+        # the LAST sed command's output appears FIRST (closest to the anchor line).
+        # These commands are ordered to produce the following args sequence:
+        # 1. --certificates-dir (already present)
+        # 2. DefaultNetNADNs block (from last sed, appears first)
+        # 3. --tls-min-version (from middle sed, appears second)
+        # 4. TLSSecurityProfileCiphers block (from first sed, appears third)
         sed -i '/            - "--certificates-dir={{ .CertDir }}"/a{{ if index . "TLSSecurityProfileCiphers" }}\n            - "--tls-cipher-suites={{ .TLSSecurityProfileCiphers }}"\n{{ end }}' ${f}
         sed -i '/            - "--certificates-dir={{ .CertDir }}"/a\\            - "--tls-min-version={{ .TLSMinVersion }}"' ${f}
         sed -i '/            - "--certificates-dir={{ .CertDir }}"/a{{- if ne .DefaultNetNADNs "" }}\n            - "--default-network-nad-namespace={{ .DefaultNetNADNs }}"\n{{ end }}' ${f}


### PR DESCRIPTION
Fixes #2837

**What this PR does / why we need it**:

Adds clarifying comments to the kubevirt-ipam-controller bump script to document the non-intuitive behavior of multiple `sed '/pattern/a'` commands appending after the same line. This prevents future confusion about the order of sed commands when maintaining the script.

Investigation found that the issue analysis was incorrect - the current code is working correctly. Tests pass and `make bump-all` produces no uncommitted changes. The sed commands are already in the correct order and produce the expected manifest output.

**Special notes for your reviewer**:

This PR adds documentation/comments only. The actual sed command order was already correct and matches the committed manifest. The issue appeared to be a misanalysis of how sed's append command works when multiple commands target the same anchor line.

**Release note**:

```release-note
NONE
```

<!-- oompa-bot v:338a5e9 -->