### PR TITLE
[release-0.95] Pin OVN-K to release-1.1 for ipam e2e tests

### DIFF
--- a/automation/check-patch.e2e-kubevirt-ipam-controller-functests.sh
+++ b/automation/check-patch.e2e-kubevirt-ipam-controller-functests.sh
@@ -33,6 +33,7 @@ main() {
     COMPONENT="kubevirt-ipam-controller" source automation/components-functests.setup.sh
 
     cd ${TMP_COMPONENT_PATH}
+    export OVN_KUBERNETES_BRANCH=release-1.1
     export KIND_ARGS="-ic -i6 -mne"
     make cluster-up
     export KUBECONFIG=${TMP_COMPONENT_PATH}/.output/kubeconfig


### PR DESCRIPTION
**What this PR does / why we need it**:

The ipam-controller e2e tests clone OVN-Kubernetes from upstream master to set up the kind cluster. OVN-K master has evolved significantly since Nov 2025 (including a Helm migration in Apr 2026 and flag removals), making it incompatible with the older ipam-extensions commit and KubeVirt v1.3.x pinned on this stable branch.

This PR pins OVN-K to upstream `ovn-org/ovn-kubernetes` `release-1.1`, which is from the same era (Oct 2025) as the last passing CI run on this branch (Nov 2025).

**Special notes for your reviewer**:

The `-ic` (interconnect) flag is kept — it's valid on `release-1.1`.

**Release note**:

```release-note
NONE
```