### PR TITLE
CI Failure: pull-e2e-cluster-network-addons-operator-workflow-k8s / The `pull-e2e-cluster-network-addons-operator-workflow-k8s`

### DIFF
--- a/cluster/cluster.sh
+++ b/cluster/cluster.sh
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 export KUBEVIRT_PROVIDER=${KUBEVIRT_PROVIDER:-'k8s-1.34'}
-export KUBEVIRTCI_TAG=${KUBEVIRTCI_TAG:-2603311027-36247754}
+export KUBEVIRTCI_TAG=${KUBEVIRTCI_TAG:-2606300938-ede497bd}
 
 # The CLUSTER_PATH var is used in cluster folder and points to the _kubevirtci where the cluster is deployed from.
 CLUSTER_PATH=${CLUSTER_PATH:-"${PWD}/_kubevirtci/"}


### PR DESCRIPTION
Fixes #2849

**What this PR does / why we need it**:

This PR bumps the kubevirtci tag from `2603311027-36247754` to `2606300938-ede497bd` to address CI timeout issues in the `pull-e2e-cluster-network-addons-operator-workflow-k8s` job.

The CI job was failing because downloading the k8s-1.34 container image took approximately 14 minutes, exceeding the ~15 minute Prow job timeout. The newer kubevirtci image may be already cached on CI workers or include optimizations that reduce download time.

**Special notes for your reviewer**:

This change aligns with the pending kubevirtci bump on branch `bump_kubevirtci_28485054367`. While the root cause is an infrastructure issue (slow registry download speeds), updating to the latest kubevirtci tag may help mitigate the problem by using a version that's more likely to be cached on CI workers.

**Release note**:

```release-note
NONE
```

---
*🤖 Generated by [oompa](https://github.com/qinqon/oompa). Use `/oompa` to talk with me.* <!-- oompa-bot v:dc1c71d -->