### PR TITLE
ci: bump deprecated GitHub Actions to latest major versions

### DIFF
--- a/.github/workflows/check_hashicorp_modules.yaml
+++ b/.github/workflows/check_hashicorp_modules.yaml
@@ -5,6 +5,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
     - name: Run script
       run: ./hack/check_hashicorp.sh

--- a/.github/workflows/component-bumper.yaml
+++ b/.github/workflows/component-bumper.yaml
@@ -28,7 +28,7 @@ jobs:
       - name: Login to Quay
         run: docker login -u="kubevirt+network" -p="${{ secrets.QUAY_ROBOT_TOKEN }}" quay.io
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           ref: ${{ matrix.branch }}
       - name: Pull latest of latest branch

--- a/.github/workflows/kubevirt-ipam-controller.yaml
+++ b/.github/workflows/kubevirt-ipam-controller.yaml
@@ -5,10 +5,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Set up Go
-      uses: actions/setup-go@v3
+      uses: actions/setup-go@v5
       with:
         go-version-file: 'go.mod'
 

--- a/.github/workflows/kubevirtci-bumper.yaml
+++ b/.github/workflows/kubevirtci-bumper.yaml
@@ -44,7 +44,7 @@ jobs:
 
       - name: Create Pull Request
         if: steps.changes.outputs.changed == 'true'
-        uses: peter-evans/create-pull-request@v5
+        uses: peter-evans/create-pull-request@v7
         with:
           token: ${{ secrets.KUBEVIRT_BOT_TOKEN }}
           committer: GitHub <noreply@github.com>

--- a/.github/workflows/prepare-release-branch.yaml
+++ b/.github/workflows/prepare-release-branch.yaml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.event.inputs.baseTag }}
           fetch-depth: 0
@@ -36,7 +36,7 @@ jobs:
           git config --global user.name "CNAO Version bot"
 
       - name: Check out main branch code into the Go module directory
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           ref: main
           fetch-depth: 0
@@ -45,7 +45,7 @@ jobs:
         run: make update-workflows-branches git_base_tag=${{ github.event.inputs.baseTag }} branch_name=${{ github.event.inputs.branchName }}
 
       - name: Create new release branch PR
-        uses: peter-evans/create-pull-request@v3
+        uses: peter-evans/create-pull-request@v7
         with:
           branch: main-update-worflows-new-branch-${{ github.event.inputs.branchName }}
           token: ${{ secrets.KUBEVIRT_BOT_TOKEN }}
@@ -76,7 +76,7 @@ jobs:
           git config --global user.name "CNAO Version bot"
 
       - name: Check out main branch code into the Go module directory
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.event.inputs.branchName }}
           fetch-depth: 0
@@ -85,7 +85,7 @@ jobs:
         run: make statify-components
 
       - name: Create components update PR on release branch
-        uses: peter-evans/create-pull-request@v3
+        uses: peter-evans/create-pull-request@v7
         with:
           branch: ${{ github.event.inputs.branchName }}-statify-components
           token: ${{ secrets.KUBEVIRT_BOT_TOKEN }}

--- a/.github/workflows/prepare-version.yaml
+++ b/.github/workflows/prepare-version.yaml
@@ -43,7 +43,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.event.inputs.baseBranch }}
           fetch-depth: 0
@@ -59,7 +59,7 @@ jobs:
         run: |
           echo "RELEASE_VERSION=$(./hack/version.sh)" >> $GITHUB_ENV
       - name: Create version PR
-        uses: peter-evans/create-pull-request@v3
+        uses: peter-evans/create-pull-request@v7
         with:
           branch: rel-pr-${{ env.RELEASE_VERSION }}
           token: ${{ secrets.KUBEVIRT_BOT_TOKEN }}

--- a/.github/workflows/test-release-notes.yaml
+++ b/.github/workflows/test-release-notes.yaml
@@ -38,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.event.inputs.baseBranch }}
           fetch-depth: 0
@@ -49,7 +49,7 @@ jobs:
           echo "LAST_VERSION=$(./hack/version.sh)" >> $GITHUB_ENV
           echo "START_SHA=$(git rev-list -n 1 v$(./hack/version.sh))" >> $GITHUB_ENV
           echo "END_SHA=$(git rev-parse HEAD)" >> $GITHUB_ENV
-      - uses: actions/setup-go@v2
+      - uses: actions/setup-go@v5
         with:
           go-version: '1.16'
       - name: Dump release-notes


### PR DESCRIPTION
**What this PR does / why we need it**:
Bumps all GitHub Actions to their latest major versions to resolve
Node.js 20 deprecation warnings across all workflow runs.

- `actions/checkout` v2, v3 → v4
- `actions/setup-go` v2, v3 → v5
- `peter-evans/create-pull-request` v3, v5 → v7

**Special notes for your reviewer**:
All 7 workflow files under `.github/workflows/` were updated.
`actions/upload-artifact@v4` was already up to date.

**Release note**:
```release-note
NONE
```