### PR TITLE
CI Failure: pull-e2e-cluster-network-addons-operator-workflow-k8s / PR #2857 failed during CI environment setup due to a merge

### DIFF
--- a/hack/components/docker-utils.sh
+++ b/hack/components/docker-utils.sh
@@ -13,7 +13,16 @@ set -xo pipefail
 # The image digest
 #
 function docker-utils::get_image_digest() {
-  echo "${2}@$(${OCI_BIN} run --rm quay.io/skopeo/stable:latest inspect "docker://${1}" | jq -r '.Digest')"
+  local digest
+  digest=$(${OCI_BIN} run --rm quay.io/skopeo/stable:latest inspect "docker://${1}" | jq -r '.Digest')
+
+  if [[ -z "${digest}" || "${digest}" == "null" ]]; then
+    echo "Error: Failed to retrieve image digest for ${1}" >&2
+    echo "This may be due to network issues, registry unavailability, or authentication problems" >&2
+    return 1
+  fi
+
+  echo "${2}@${digest}"
 }
 
 # The check_image_exists function checks if an image already exists in the registry.


### PR DESCRIPTION
Fixes #2860

**What this PR does / why we need it**:

This PR adds validation to the `docker-utils::get_image_digest` function to prevent silent failures when retrieving image digests from container registries. Previously, if the skopeo command failed or returned null/empty (due to network issues, registry unavailability, or authentication problems), the function would silently return an incomplete image reference (e.g., `image@` without the SHA256 digest). This caused bump scripts to generate invalid image references in the codebase.

The fix ensures that:
- The digest is captured and validated before being returned
- The function fails with a clear error message if digest retrieval fails
- All bump scripts (multus, kubemacpool, bridge-marker, etc.) are protected from this issue

**Special notes for your reviewer**:

This fix prevents the type of bug seen in PR #2857, where an incomplete image reference was committed because the skopeo command failed silently. The validation is added at the utility function level, so all bump scripts benefit from this protection.

**Release note**:

```release-note
Fix bump scripts to validate image digest retrieval and fail with clear error messages instead of generating incomplete image references
```

---
*🤖 Generated by [oompa](https://github.com/qinqon/oompa). Use `/oompa` to talk with me.* <!-- oompa-bot v:dc1c71d -->