### PR TITLE
CI Failure: pull-e2e-cluster-network-addons-operator-workflow-k8s-s390x / The CI job failed during initial cluster cleanup when

### DIFF
--- a/cluster/cluster.sh
+++ b/cluster/cluster.sh
@@ -22,6 +22,32 @@ function cluster::_get_tag() {
     git -C ${CLUSTER_PATH} describe --tags
 }
 
+function cluster::_clone_with_retry() {
+    local repo_url=$1
+    local target_path=$2
+    local max_attempts=5
+    local attempt=1
+    local wait_time=2
+
+    while [ $attempt -le $max_attempts ]; do
+        echo "Attempting to clone kubevirtci (attempt $attempt/$max_attempts)..."
+        if git clone "$repo_url" "$target_path"; then
+            echo "Successfully cloned kubevirtci"
+            return 0
+        fi
+
+        if [ $attempt -lt $max_attempts ]; then
+            echo "Clone failed, retrying in ${wait_time}s..."
+            sleep $wait_time
+            wait_time=$((wait_time * 2))
+        fi
+        attempt=$((attempt + 1))
+    done
+
+    echo "Failed to clone kubevirtci after $max_attempts attempts"
+    return 1
+}
+
 function cluster::install() {
     if [ -d ${CLUSTER_PATH} ]; then
         if [[ $(cluster::_get_tag) != ${KUBEVIRTCI_TAG} ]]; then
@@ -30,7 +56,7 @@ function cluster::install() {
     fi
 
     if [ ! -d ${CLUSTER_PATH} ]; then
-        git clone https://github.com/kubevirt/kubevirtci.git ${CLUSTER_PATH}
+        cluster::_clone_with_retry https://github.com/kubevirt/kubevirtci.git ${CLUSTER_PATH}
         (
             cd ${CLUSTER_PATH}
             git checkout ${KUBEVIRTCI_TAG}


### PR DESCRIPTION
Fixes #2863

**What this PR does / why we need it**:

This PR adds retry logic with exponential backoff to the kubevirtci repository cloning operation in `cluster/cluster.sh`. The s390x CI environment occasionally experiences transient DNS resolution failures when attempting to access github.com, causing the `pull-e2e-cluster-network-addons-operator-workflow-k8s-s390x` CI job to fail during initial cluster cleanup.

The fix implements a retry mechanism with up to 5 attempts and exponential backoff delays (2s, 4s, 8s, 16s) to make the CI infrastructure more resilient to temporary network/DNS issues.

**Special notes for your reviewer**:

This is a known recurring issue in the s390x CI environment (previously seen in #2762 and #2791). The retry logic is isolated to a new helper function `cluster::_clone_with_retry` that wraps the git clone operation, making the change minimal and focused.

**Release note**:

```release-note
NONE
```

---
*🤖 Generated by [oompa](https://github.com/qinqon/oompa). Use `/oompa` to talk with me.* <!-- oompa-bot v:dc1c71d -->