### PR TITLE
CI Failure: pull-e2e-cluster-network-addons-operator-workflow-k8s-s390x / The CI job failed during initial cluster cleanup when

### DIFF
--- a/cluster/cluster.sh
+++ b/cluster/cluster.sh
@@ -22,6 +22,32 @@ function cluster::_get_tag() {
     git -C ${CLUSTER_PATH} describe --tags
 }
 
+function cluster::_clone_with_retry() {
+    local repo_url=$1
+    local target_path=$2
+    local max_attempts=5
+    local attempt=1
+    local wait_time=2
+
+    while [ $attempt -le $max_attempts ]; do
+        echo "Attempting to clone kubevirtci (attempt $attempt/$max_attempts)..."
+        if git clone "$repo_url" "$target_path"; then
+            echo "Successfully cloned kubevirtci"
+            return 0
+        fi
+
+        if [ $attempt -lt $max_attempts ]; then
+            echo "Clone failed, retrying in ${wait_time}s..."
+            sleep $wait_time
+            wait_time=$((wait_time * 2))
+        fi
+        attempt=$((attempt + 1))
+    done
+
+    echo "Failed to clone kubevirtci after $max_attempts attempts"
+    return 1
+}
+
 function cluster::install() {
     if [ -d ${CLUSTER_PATH} ]; then
         if [[ $(cluster::_get_tag) != ${KUBEVIRTCI_TAG} ]]; then
@@ -30,7 +56,7 @@ function cluster::install() {
     fi
 
     if [ ! -d ${CLUSTER_PATH} ]; then
-        git clone https://github.com/kubevirt/kubevirtci.git ${CLUSTER_PATH}
+        cluster::_clone_with_retry https://github.com/kubevirt/kubevirtci.git ${CLUSTER_PATH}
         (
             cd ${CLUSTER_PATH}
             git checkout ${KUBEVIRTCI_TAG}


### PR DESCRIPTION
Fixes #2863

**What this PR does / why we need it**:

This PR adds retry logic with exponential backoff to the kubevirtci repository clone operation in `cluster/cluster.sh` to handle transient DNS failures that occasionally occur in the s390x CI environment.

The s390x CI job periodically fails during initial cluster cleanup when attempting to clone the kubevirtci repository due to DNS resolution failures for github.com. This is a known recurring infrastructure issue in the s390x CI runners.

The fix implements a `cluster::_clone_with_retry` function that retries the git clone operation up to 5 times with exponential backoff (2s, 4s, 8s, 16s delays between attempts), making the CI more resilient to temporary network/DNS issues.

**Special notes for your reviewer**:

This is the same solution that was previously developed for similar issues #2762 and #2791, but those fixes were not merged. This PR addresses the same root cause: transient DNS failures in the s390x CI environment preventing access to github.com.

The retry mechanism provides reasonable defaults:
- Maximum 5 retry attempts
- Exponential backoff starting at 2 seconds
- Clear logging of each attempt and outcome
- Total maximum wait time of ~30 seconds (2+4+8+16) before final failure

**Release note**:

```release-note
NONE
```

---
*🤖 Generated by [oompa](https://github.com/qinqon/oompa). Use `/oompa` to talk with me.* <!-- oompa-bot v:dc1c71d -->