### PR TITLE
CI Failure: pull-e2e-cluster-network-addons-operator-monitoring-k8s / The `pull-e2e-cluster-network-addons-operator-monitoring-k8s

### DIFF
--- a/automation/check-patch.e2e-monitoring-k8s.sh
+++ b/automation/check-patch.e2e-monitoring-k8s.sh
@@ -17,6 +17,12 @@ main() {
     source automation/check-patch.setup.sh
     cd ${TMP_PROJECT_PATH}
 
+    # Set extended timeout to accommodate cluster setup variability and test execution
+    # The monitoring test suite includes 8 specs with deployment waits (15min) and
+    # alert verification (5min), requiring ~20-30 minutes total execution time.
+    # See issue #2877 for context on timeout requirements.
+    export E2E_TEST_TIMEOUT=4h
+
     export MONITORING_NAMESPACE="monitoring"
     make cluster-down
     make cluster-up


### PR DESCRIPTION
Fixes #2877

**What this PR does / why we need it**:

This PR adds an explicit 4-hour timeout to the monitoring E2E test suite to provide buffer for cluster setup variability and test execution. The monitoring tests include 8 specs that require approximately 20-30 minutes to complete, with deployment waits and alert verification steps.

While the root cause of issue #2877 was infrastructure-related (abnormally slow cluster setup taking ~4 hours), this change provides reasonable mitigation for typical CI environment variability where cluster setup might take 2-3 hours instead of the normal 30-60 minutes.

**Special notes for your reviewer**:

- This follows the same pattern as the lifecycle test suite (`automation/check-patch.e2e-lifecycle-k8s.sh`), which already uses `E2E_TEST_TIMEOUT=4h` for extended test runs
- The timeout adjustment does not solve cases where cluster setup exceeds ~3h 40m, but those are infrastructure issues outside the scope of this repository
- The change is purely defensive and does not modify any test logic

**Release note**:

```release-note
NONE
```

---
*🤖 Generated by [oompa](https://github.com/qinqon/oompa). Use `/oompa` to talk with me.* <!-- oompa-bot v:439b5a3 -->