### PR TITLE
CI Failure: pull-e2e-cluster-network-addons-operator-lifecycle-k8s / The CI job was terminated during cluster setup while

### DIFF
--- a/cluster/cluster.sh
+++ b/cluster/cluster.sh
@@ -13,6 +13,11 @@
 # limitations under the License.
 
 export KUBEVIRT_PROVIDER=${KUBEVIRT_PROVIDER:-'k8s-1.34'}
+# Using stable tag 2606300938-ede497bd (2026-06-30) instead of latest to avoid
+# CI download timeout issues. Newer tags (2607080711-242cd8d2 and later) have
+# been observed to cause >5min image download times that exceed Prow job timeouts.
+# See: https://github.com/kubevirt/cluster-network-addons-operator/issues/2883
+# Only bump this tag after verifying the new image downloads reliably in CI.
 export KUBEVIRTCI_TAG=${KUBEVIRTCI_TAG:-2606300938-ede497bd}
 
 # The CLUSTER_PATH var is used in cluster folder and points to the _kubevirtci where the cluster is deployed from.


### PR DESCRIPTION
Fixes #2883

**What this PR does / why we need it**:

This PR adds documentation to `cluster/cluster.sh` to prevent automatic bumps to kubevirtci tags that cause CI download timeout failures. The current stable tag (2606300938-ede497bd from 2026-06-30) works reliably, but newer tags like 2607080711-242cd8d2 have been observed to cause >5 minute image download times that exceed Prow job timeout limits, preventing tests from running.

The added comment serves as a guard against automated tag updates and reminds maintainers to verify that new kubevirtci images download reliably in CI before bumping.

**Special notes for your reviewer**:

This is a documentation-only change that doesn't modify any functional code. The KUBEVIRTCI_TAG value remains unchanged at the current stable version. The issue (#2883) was classified as an infrastructure problem where the CI environment was overriding the default tag to use the latest version, which then failed due to download timeouts.

While the root fix requires changes to Prow job configuration (outside this repository's scope), this documentation helps prevent manual or automated bumps to problematic tags and provides context for future maintainers.

**Release note**:

```release-note
NONE
```

---
*🤖 Generated by [oompa](https://github.com/qinqon/oompa). Use `/oompa` to talk with me.* <!-- oompa-bot v:439b5a3 -->