### PR TITLE
CI Failure: pull-e2e-cnao-lifecycle-k8s-release-0.101 / The `pull-e2e-cnao-lifecycle-k8s-release-0.101` job was

### DIFF
--- a/automation/check-patch.e2e-lifecycle-k8s.sh
+++ b/automation/check-patch.e2e-lifecycle-k8s.sh
@@ -29,6 +29,7 @@ main() {
     else
         # Don't run all upgrade tests in regular PRs, stick to those released under HCO
         export RELEASES_SELECTOR="{0.89.3,0.91.1,0.93.0,0.95.0,99.0.0}"
+        export E2E_TEST_TIMEOUT=4h
     fi
 
     make cluster-down


### PR DESCRIPTION
Fixes #2888

**What this PR does / why we need it**:

This PR increases the E2E lifecycle test timeout from 3 hours to 4 hours for regular PRs to prevent CI job terminations.

The lifecycle e2e tests perform upgrade testing from 5 different releases ({0.89.3, 0.91.1, 0.93.0, 0.95.0, 99.0.0}), with each upgrade test potentially taking 20-75 minutes. The total test time can approach or exceed 3 hours, causing the `pull-e2e-cnao-lifecycle-k8s-release-0.101` CI job to be terminated by Prow infrastructure before completion.

This change aligns the regular PR timeout with the 4-hour timeout already used for version-changed PRs.

**Special notes for your reviewer**:

This is an infrastructure-related fix addressing CI timeouts. The 4-hour timeout matches what's already configured for version-changed PRs (line 28 of the same file).

**Release note**:

```release-note
NONE
```

---
*🤖 Generated by [oompa](https://github.com/qinqon/oompa). Use `/oompa` to talk with me.* <!-- oompa-bot v:439b5a3 -->