### PR TITLE
CI Failure: pull-e2e-cnao-lifecycle-k8s-release-0.101 / The `pull-e2e-cnao-lifecycle-k8s-release-0.101` job was

### DIFF
--- a/automation/check-patch.e2e-lifecycle-k8s.sh
+++ b/automation/check-patch.e2e-lifecycle-k8s.sh
@@ -29,6 +29,7 @@ main() {
     else
         # Don't run all upgrade tests in regular PRs, stick to those released under HCO
         export RELEASES_SELECTOR="{0.89.3,0.91.1,0.93.0,0.95.0,99.0.0}"
+        export E2E_TEST_TIMEOUT=3h
     fi
 
     make cluster-down


### PR DESCRIPTION
Fixes #2888

**What this PR does / why we need it**:

This PR fixes CI timeouts in the `pull-e2e-cnao-lifecycle-k8s-release-0.101` job by adding an explicit 3-hour timeout for lifecycle e2e tests in regular PRs.

The lifecycle tests run upgrade tests from 5 older releases to the current version. Each upgrade path takes 20+ minutes (install old version, deploy config, upgrade, and verify), resulting in total test time that can exceed 2 hours. While version-changed PRs already had a 4-hour timeout configured, regular PRs did not have an explicit timeout set, causing them to be terminated by Prow CI infrastructure when exceeding the default timeout.

**Special notes for your reviewer**:

The 3-hour timeout was chosen as a balance between:
- Providing sufficient time for 5 upgrade paths (~2+ hours) with overhead
- Being less than the 4-hour timeout used for version-changed PRs (which test more upgrade paths)

**Release note**:

```release-note
NONE
```

---
*🤖 Generated by [oompa](https://github.com/qinqon/oompa). Use `/oompa` to talk with me.* <!-- oompa-bot v:439b5a3 -->