### PR TITLE
[release-0.101] Revert "bump multus-dynamic-networks to v0.3.8"

### DIFF
--- a/components.yaml
+++ b/components.yaml
@@ -43,10 +43,10 @@ components:
     metadata: v4.2.3
   multus-dynamic-networks:
     url: https://github.com/k8snetworkplumbingwg/multus-dynamic-networks-controller
-    commit: 3793ea8b6af2f7fe91b5cb56466dc4ebd2799f1c
+    commit: 4a3cac67b6ea6e2d08e0d59aef38452e92acd869
     branch: main
     update-policy: static
-    metadata: v0.3.8
+    metadata: v0.3.7
   ovs-cni:
     url: https://github.com/k8snetworkplumbingwg/ovs-cni
     commit: 6ef93aa45fdf95de667e43b73225f16f81f171c7

--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -33,7 +33,7 @@ var (
 
 const (
 	MultusImageDefault                 = "ghcr.io/k8snetworkplumbingwg/multus-cni@sha256:e93af9e533cc16ca7847aeec3b516c9b1e8891c2b95c727991e94c9b59c4970e"
-	MultusDynamicNetworksImageDefault  = "ghcr.io/k8snetworkplumbingwg/multus-dynamic-networks-controller@sha256:c7d137a7f4ddd81233b9778d02ae57a496e892ddedf74d49382d86df50ddcc27"
+	MultusDynamicNetworksImageDefault  = "ghcr.io/k8snetworkplumbingwg/multus-dynamic-networks-controller@sha256:2a2bb32c0ea8b232b3dbe81c0323a107e8b05f8cad06704fca2efd0d993a87be"
 	LinuxBridgeCniImageDefault         = "quay.io/kubevirt/cni-default-plugins@sha256:976a24392c2a096c38c2663d234b2d3131f5c24558889196d30b9ac1b6716788"
 	LinuxBridgeMarkerImageDefault      = "quay.io/kubevirt/bridge-marker@sha256:f9611ec10bb4aec44b0ec19f9b9d748a36255c089a1f59bc76e5fc37acc0fed2"
 	KubeMacPoolImageDefault            = "quay.io/kubevirt/kubemacpool@sha256:e06a2a0c642ee648097d2fff58098c99799c26d1a6f7ca5272a0ff0e474af9fb"

--- a/test/releases/99.0.0.go
+++ b/test/releases/99.0.0.go
@@ -18,7 +18,7 @@ func init() {
 				ParentName: "dynamic-networks-controller-ds",
 				ParentKind: "DaemonSet",
 				Name:       "dynamic-networks-controller",
-				Image:      "ghcr.io/k8snetworkplumbingwg/multus-dynamic-networks-controller@sha256:c7d137a7f4ddd81233b9778d02ae57a496e892ddedf74d49382d86df50ddcc27",
+				Image:      "ghcr.io/k8snetworkplumbingwg/multus-dynamic-networks-controller@sha256:2a2bb32c0ea8b232b3dbe81c0323a107e8b05f8cad06704fca2efd0d993a87be",
 			},
 			{
 				ParentName: "multus",


### PR DESCRIPTION
**What this PR does / why we need it**:

Reverts #2867, rolling back multus-dynamic-networks from v0.3.8 to v0.3.7 on the release-0.101 branch.

**Special notes for your reviewer**:

This is a clean revert of commit f50ccfd4a.

**Release note**:

```release-note
Revert multus-dynamic-networks bump to v0.3.8, rolling back to v0.3.7
```