### PR TITLE
fix(ci): pin K8S_VERSION to v1.36.1 for ipam-ext e2e tests

### DIFF
--- a/automation/check-patch.e2e-kubevirt-ipam-controller-functests.sh
+++ b/automation/check-patch.e2e-kubevirt-ipam-controller-functests.sh
@@ -57,6 +57,7 @@ main() {
     cd ${TMP_COMPONENT_PATH}
     export KUBECONFIG=${TMP_COMPONENT_PATH}/.output/kubeconfig
     export KIND_ARGS="-i6 -mne -nse"
+    export K8S_VERSION=v1.36.1
     make cluster-up
 
     trap teardown EXIT

--- a/cluster/up.sh
+++ b/cluster/up.sh
@@ -23,6 +23,8 @@ export KUBEVIRT_DEPLOY_PROMETHEUS=true
 export KUBEVIRT_DEPLOY_PROMETHEUS_ALERTMANAGER=true
 export KUBEVIRT_DEPLOY_GRAFANA=true
 
+export KUBEVIRT_MEMORY_SIZE=8192M
+
 cluster::install
 
 $(cluster::path)/cluster-up/up.sh


### PR DESCRIPTION
## What this PR does / why we need it

Fixes the `ipam-ext` E2E job failing on all CNAO PRs with:
```
ERROR: failed to create cluster: failed to pull image "kindest/node:v1.36.2"
Command Output: Error response from daemon: manifest for kindest/node:v1.36.2 not found
```

The kubevirt-ipam-controller repo defaults to `K8S_VERSION=v1.36.2`, whose custom-built kind node image is not published/accessible in CI. This PR overrides it to `v1.36.1`, which is available on `docker.io/kindest/node`.

## Special notes for your reviewer

Stopgap fix to unblock CI. Once ovn-kubernetes publishes their custom `v1.36.2` node images, we can revert this override.

## Release note

```release-note
NONE
```

