### PR TITLE
chore(gsutil): Migrate gsutil to gcloud storage

### DIFF
--- a/automation/test-nightly-build.sh
+++ b/automation/test-nightly-build.sh
@@ -57,17 +57,17 @@ main() {
     # publish the nightly build manifests
     SRC_DIR="./_out/cluster-network-addons/${VERSION}"
     DEST="gs://${cnao_bucket}/${build_date}"
-    gsutil cp "${SRC_DIR}/namespace.yaml" "${DEST}/namespace.yaml"
-    gsutil cp "${SRC_DIR}/cluster-network-addons-operator.${VERSION}.clusterserviceversion.yaml" "${DEST}/cluster-network-addons-operator.${VERSION}.clusterserviceversion.yaml"
-    gsutil cp "${SRC_DIR}/network-addons-config.crd.yaml" "${DEST}/network-addons-config.crd.yaml"
-    gsutil cp "${SRC_DIR}/operator.yaml" "${DEST}/operator.yaml"
-    gsutil cp "${SRC_DIR}/network-addons-config-example.cr.yaml" "${DEST}/network-addons-config-example.cr.yaml"
+    gcloud storage cp "${SRC_DIR}/namespace.yaml" "${DEST}/namespace.yaml"
+    gcloud storage cp "${SRC_DIR}/cluster-network-addons-operator.${VERSION}.clusterserviceversion.yaml" "${DEST}/cluster-network-addons-operator.${VERSION}.clusterserviceversion.yaml"
+    gcloud storage cp "${SRC_DIR}/network-addons-config.crd.yaml" "${DEST}/network-addons-config.crd.yaml"
+    gcloud storage cp "${SRC_DIR}/operator.yaml" "${DEST}/operator.yaml"
+    gcloud storage cp "${SRC_DIR}/network-addons-config-example.cr.yaml" "${DEST}/network-addons-config-example.cr.yaml"
 
     git show -s --format=%H > ${SRC_DIR}/commit
-    gsutil cp ${SRC_DIR}/commit "${DEST}/commit"
+    gcloud storage cp ${SRC_DIR}/commit "${DEST}/commit"
 
     echo "${build_date}" > "${SRC_DIR}/build-date"
-    gsutil cp "${SRC_DIR}/build-date" gs://${cnao_bucket}/latest
+    gcloud storage cp "${SRC_DIR}/build-date" gs://${cnao_bucket}/latest
 }
 
 main


### PR DESCRIPTION
**What this PR does / why we need it**:
gsutil is being depreciated in March 2027, we are undergoing a migration to gcloud storage. gcloud storage is already available in the bootstrap image via the installed google-cloud-sdk, no image changes needed. All commands are drop-in replacements

Migration [reference](https://docs.cloud.google.com/storage/docs/gsutil-transition-to-gcloud)

**Special notes for your reviewer**:
/cc @dollierp @oshoval 