### PR TITLE
hack: fix trailing whitespace in install-tls-compliance-operator.sh

### DIFF
--- a/hack/install-tls-compliance-operator.sh
+++ b/hack/install-tls-compliance-operator.sh
@@ -17,7 +17,7 @@ echo "Installing TLS Compliance Operator ${VERSION} from: ${URL}.."
 # To allow the operator reach and check all services the network-policy is deleted.
 # [1] https://github.com/sebrandon1/tls-compliance-operator/blob/v1.0.18/docs/troubleshooting.md#:~:text=Check%20for%20NetworkPolicy%20restrictions
 echo "Deleting the operator's network-policy to allow egress all services.."
-./cluster/kubectl.sh -n $NAMESPACE delete networkpolicy $NP_NAME 
+./cluster/kubectl.sh -n $NAMESPACE delete networkpolicy $NP_NAME
 
 echo "Patching the operator's Deployment for fine tuning reporting intervals.."
 ./cluster/kubectl.sh -n $NAMESPACE patch deployment $DEPLOY_NAME --type='json' -p='[


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the main branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it

If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**What this PR does / why we need it**:
Unrelated pre-existing trailing whitespace that trips up `make check`'s whitespace-check target, noticed while validating the TLS groups changes in this branch.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
