### PR TITLE
vendor: Bump go 1.26

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -120,7 +120,7 @@ make bump-kubevirtci       # Update kubevirtci version
 
 ## Build Toolchain
 
-- **Go version**: 1.25 (max allowed; auto-installed to `build/_output/bin/go/` via `hack/install-go.sh`)
+- **Go version**: 1.26 (max allowed; auto-installed to `build/_output/bin/go/` via `hack/install-go.sh`)
 - **Build flags**: `GOFLAGS=-mod=vendor GO111MODULE=on CGO_ENABLED=0`
 - **Multi-arch**: Builds for `linux/amd64`, `linux/arm64`, `linux/s390x`
 - **Container runtime**: Auto-detects podman or docker (`OCI_BIN`)

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ VERSION_REPLACES ?= 0.102.0
 
 DEPLOY_DIR ?= manifests
 
-MAX_GO_VERSION=1.25
+MAX_GO_VERSION=1.26
 
 IMAGE_REGISTRY ?= quay.io/kubevirt
 IMAGE_TAG ?= latest

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/kubevirt/cluster-network-addons-operator
 
-go 1.25.7
+go 1.26
+
+toolchain go1.26.6
 
 tool (
 	github.com/github-release/github-release

--- a/hack/go-version.sh
+++ b/hack/go-version.sh
@@ -1,2 +1,2 @@
 #!/bin/bash -e
-grep ^go go.mod | awk '{print $2}'
+grep ^toolchain go.mod | awk '{print $2}' | sed 's/^go//'


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the main branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it

If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**What this PR does / why we need it**:
This PR bump Go to 1.26

**Special notes for your reviewer**:
Along many improvements, newer Go version support additional TLS groups for post-quantum cryptography (PQC) readiness [1].
PQC readiness is crucial for our d/s product (Openshift).

The Go directive (go keyword in go.mod) is set to 1.26, omitting the path version, by the it set the minimal version of the project to 1.26.
The Go toolchain  directive (toolchain keyword in go.mod) is set and specifies the project new target version including the patch version.

Having go directive committing patch version together with toolchain directive, enable consumers use their own toolchain and patch versions.
Its safe because patch version skew should not break build, as long the consumer use minor version fitting the minimal version set (1.26).

[1] https://go.dev/doc/go1.26#:~:text=crypto/tls,post-quantum%20key%20exchanges

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
vendor: Bump go 1.26
```
