### PR TITLE
Wire kubevirt-ipam-controller to the TLS secutiy profile's TLS groups

### DIFF
--- a/data/kubevirt-ipam-controller/001-kubevirtipamcontroller.yaml
+++ b/data/kubevirt-ipam-controller/001-kubevirtipamcontroller.yaml
@@ -191,6 +191,9 @@ spec:
 {{ if index . "TLSSecurityProfileCiphers" }}
             - "--tls-cipher-suites={{ .TLSSecurityProfileCiphers }}"
 {{ end }}
+{{ if index . "TLSGroupPreferences" }}
+            - "--tls-group-preferences={{ .TLSGroupPreferences }}"
+{{ end }}
           command:
             - /manager
           env:

--- a/hack/components/bump-kubevirt-ipam-controller.sh
+++ b/hack/components/bump-kubevirt-ipam-controller.sh
@@ -32,6 +32,7 @@ function __parametize_by_object() {
         yaml-utils::set_param ${f} 'spec.template.metadata.labels."allow-access-cluster-services"' '""'
         yaml-utils::remove_single_quotes_from_yaml ${f}
         # sed operation is done after all yq operations to avoid unexpected yq error
+        sed -i '/            - "--certificates-dir={{ .CertDir }}"/a{{ if index . "TLSGroupPreferences" }}\n            - "--tls-group-preferences={{ .TLSGroupPreferences }}"\n{{ end }}' ${f}
         sed -i '/            - "--certificates-dir={{ .CertDir }}"/a{{ if index . "TLSSecurityProfileCiphers" }}\n            - "--tls-cipher-suites={{ .TLSSecurityProfileCiphers }}"\n{{ end }}' ${f}
         sed -i '/            - "--certificates-dir={{ .CertDir }}"/a\\            - "--tls-min-version={{ .TLSMinVersion }}"' ${f}
         sed -i '/            - "--certificates-dir={{ .CertDir }}"/a{{- if ne .DefaultNetNADNs "" }}\n            - "--default-network-nad-namespace={{ .DefaultNetNADNs }}"\n{{ end }}' ${f}

--- a/pkg/network/kubemacpool.go
+++ b/pkg/network/kubemacpool.go
@@ -124,7 +124,7 @@ func renderKubeMacPool(conf *cnao.NetworkAddonsConfigSpec, manifestDir string, c
 	tlsCfg := SelectTLSSettings(conf.TLSSecurityProfile)
 	data.Data["TLSSecurityProfileCiphers"] = strings.Join(OCPTLSProfileCiphersToGoCipherNames(tlsCfg.CipherSuites), ",")
 	data.Data["TLSMinVersion"] = string(tlsCfg.MinVersion)
-	data.Data["TLSGroupPreferences"] = strings.Join(OCPTLSProfileTLSGroupNames(tlsCfg.Groups), ",")
+	data.Data["TLSGroupPreferences"] = strings.Join(OCPTLSProfileTLSGroupToGoTLSGroupNames(tlsCfg.Groups), ",")
 	data.Data["RunbookURLTemplate"] = alerts.GetRunbookURLTemplate()
 
 	objs, err := render.RenderDir(filepath.Join(manifestDir, "kubemacpool"), &data)

--- a/pkg/network/kubevirt_ipam_controller.go
+++ b/pkg/network/kubevirt_ipam_controller.go
@@ -35,6 +35,7 @@ func RenderKubevirtIPAMController(conf *cnao.NetworkAddonsConfigSpec, manifestDi
 	tlsCfg := SelectTLSSettings(conf.TLSSecurityProfile)
 	data.Data["TLSMinVersion"] = tlsCfg.MinVersion
 	data.Data["TLSSecurityProfileCiphers"] = strings.Join(OCPTLSProfileCiphersToGoCipherNames(tlsCfg.CipherSuites), ",")
+	data.Data["TLSGroupPreferences"] = strings.Join(OCPTLSProfileTLSGroupToGoTLSGroupNames(tlsCfg.Groups), ",")
 
 	if clusterInfo.OpenShift4 {
 		data.Data["WebhookAnnotation"] = `service.beta.openshift.io/inject-cabundle: "true"`

--- a/pkg/network/kubevirt_ipam_controller_test.go
+++ b/pkg/network/kubevirt_ipam_controller_test.go
@@ -51,6 +51,7 @@ var _ = Describe("RenderKubevirtIPAMController", func() {
 					"TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA," +
 					"TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,TLS_RSA_WITH_AES_128_GCM_SHA256,TLS_RSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_128_CBC_SHA256," +
 					"TLS_RSA_WITH_AES_128_CBC_SHA,TLS_RSA_WITH_AES_256_CBC_SHA,TLS_RSA_WITH_3DES_EDE_CBC_SHA",
+				"--tls-group-preferences=X25519MLKEM768,X25519,CurveP256,CurveP384",
 			},
 		),
 		Entry("Intermediate",
@@ -58,11 +59,16 @@ var _ = Describe("RenderKubevirtIPAMController", func() {
 			[]string{
 				"--tls-min-version=VersionTLS12",
 				"--tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384," +
-					"TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256"},
+					"TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256",
+				"--tls-group-preferences=X25519MLKEM768,X25519,CurveP256,CurveP384",
+			},
 		),
 		Entry("Modern",
 			&ocpv1.TLSSecurityProfile{Type: ocpv1.TLSProfileModernType},
-			[]string{"--tls-min-version=VersionTLS13"},
+			[]string{
+				"--tls-min-version=VersionTLS13",
+				"--tls-group-preferences=X25519MLKEM768,X25519,CurveP256,CurveP384",
+			},
 		),
 		Entry("Custom, min TLS version 1.3 and ciphers, should not specify ciphers flag",
 			&ocpv1.TLSSecurityProfile{
@@ -89,6 +95,21 @@ var _ = Describe("RenderKubevirtIPAMController", func() {
 			[]string{
 				"--tls-min-version=VersionTLS12",
 				"--tls-cipher-suites=TLS_RSA_WITH_AES_128_CBC_SHA,TLS_RSA_WITH_AES_256_CBC_SHA",
+			},
+		),
+		Entry("Custom, min TLS version 1.3 and groups",
+			&ocpv1.TLSSecurityProfile{
+				Type: ocpv1.TLSProfileCustomType,
+				Custom: &ocpv1.CustomTLSProfile{
+					TLSProfileSpec: ocpv1.TLSProfileSpec{
+						MinTLSVersion: ocpv1.VersionTLS13,
+						Groups:        []ocpv1.TLSGroup{ocpv1.TLSGroupX25519MLKEM768},
+					},
+				},
+			},
+			[]string{
+				"--tls-min-version=VersionTLS13",
+				"--tls-group-preferences=X25519MLKEM768",
 			},
 		),
 	)

--- a/pkg/network/tlsSecurityProfile.go
+++ b/pkg/network/tlsSecurityProfile.go
@@ -157,13 +157,13 @@ func CurveIDs(groups []ocpv1.TLSGroup) []tls.CurveID {
 	return ids
 }
 
-// OCPTLSProfileTLSGroupNames converts OpenShift TLS group identifiers to their corresponding
+// OCPTLSProfileTLSGroupToGoTLSGroupNames converts OpenShift TLS group identifiers to their corresponding
 // Go crypto/tls.CurveID constant names (e.g. "X25519", "CurveP256"), suitable
 // for operands whose CLI flags accept named TLS groups (e.g. kubevirt-ipam-controller's
 // '--tls-group-preferences').
 // Groups with no matching crypto/tls.CurveID are dropped and logged. If none remain,
 // TLS groups are selected by the runtime.
-func OCPTLSProfileTLSGroupNames(groups []ocpv1.TLSGroup) []string {
+func OCPTLSProfileTLSGroupToGoTLSGroupNames(groups []ocpv1.TLSGroup) []string {
 	var names []string
 	var dropped []ocpv1.TLSGroup
 	for _, g := range groups {

--- a/pkg/network/tlsSecurityProfile_test.go
+++ b/pkg/network/tlsSecurityProfile_test.go
@@ -321,13 +321,13 @@ var _ = Describe("TLS Security Profile", func() {
 		})
 	})
 
-	Context("OCPTLSProfileTLSGroupNames", func() {
+	Context("OCPTLSProfileTLSGroupToGoTLSGroupNames", func() {
 		It("should return nil for empty input", func() {
-			Expect(OCPTLSProfileTLSGroupNames(nil)).To(BeNil())
-			Expect(OCPTLSProfileTLSGroupNames([]ocpv1.TLSGroup{})).To(BeNil())
+			Expect(OCPTLSProfileTLSGroupToGoTLSGroupNames(nil)).To(BeNil())
+			Expect(OCPTLSProfileTLSGroupToGoTLSGroupNames([]ocpv1.TLSGroup{})).To(BeNil())
 		})
-		It("should convert OCP TLSGroup to names", func() {
-			names := OCPTLSProfileTLSGroupNames([]ocpv1.TLSGroup{
+		It("should convert OCP TLSGroup to Go crypto/tls constant names", func() {
+			names := OCPTLSProfileTLSGroupToGoTLSGroupNames([]ocpv1.TLSGroup{
 				ocpv1.TLSGroupX25519MLKEM768,
 				ocpv1.TLSGroupX25519,
 				ocpv1.TLSGroupSecP256r1,
@@ -347,7 +347,7 @@ var _ = Describe("TLS Security Profile", func() {
 			}))
 		})
 		It("should skip groups with no known crypto/tls.CurveID", func() {
-			names := OCPTLSProfileTLSGroupNames([]ocpv1.TLSGroup{
+			names := OCPTLSProfileTLSGroupToGoTLSGroupNames([]ocpv1.TLSGroup{
 				ocpv1.TLSGroupX25519,
 				"my-non-exist-tls-group",
 			})

--- a/test/e2e/compliance/tls_compliance_test.go
+++ b/test/e2e/compliance/tls_compliance_test.go
@@ -64,68 +64,41 @@ var _ = Describe("TLS", func() {
 		ipamExtHost := "kubevirt-ipam-controller-webhook-service." + cnaoNamespace
 		kmpMetricsHost := "kubemacpool-metrics-service." + cnaoNamespace
 		kmpSvcHost := "kubemacpool-service." + cnaoNamespace
-
 		expectedStatus := tlsReportStatus{
 			QuantumReady:     true,
 			NegotiatedCurves: map[string]string{"TLS 1.3": "X25519MLKEM768"},
 			Conditions: []metav1.Condition{
-				{
-					Type:   "Available",
-					Status: metav1.ConditionTrue,
-				},
-				{
-					Type:   "TLSCompliant",
-					Status: metav1.ConditionTrue,
-				},
-				{
-					Type:   "CertificateValid",
-					Status: "True",
-				},
-				{
-					Type:   "PQCCompliant",
-					Status: metav1.ConditionTrue,
-				},
+				{Type: "Available", Status: metav1.ConditionTrue},
+				{Type: "TLSCompliant", Status: metav1.ConditionTrue},
+				{Type: "CertificateValid", Status: metav1.ConditionTrue},
+				{Type: "PQCCompliant", Status: metav1.ConditionTrue},
 			},
 		}
 		expectedReports := []tlsReport{
 			{
-				Spec: tlsReportSpec{
-					Host:            cnaoHost,
-					Port:            8443,
-					SourceNamespace: cnaoNamespace,
-				},
+				Spec:   tlsReportSpec{Host: cnaoHost, Port: 8443, SourceNamespace: cnaoNamespace},
 				Status: expectedStatus,
 			},
 			{
-				Spec: tlsReportSpec{
-					Host:            ipamExtHost,
-					Port:            443,
-					SourceNamespace: cnaoNamespace,
-				},
+				Spec:   tlsReportSpec{Host: ipamExtHost, Port: 443, SourceNamespace: cnaoNamespace},
 				Status: expectedStatus,
 			},
 			{
-				Spec: tlsReportSpec{
-					Host:            kmpMetricsHost,
-					Port:            8443,
-					SourceNamespace: cnaoNamespace,
-				},
+				Spec:   tlsReportSpec{Host: kmpMetricsHost, Port: 8443, SourceNamespace: cnaoNamespace},
 				Status: expectedStatus,
 			},
 			{
-				Spec: tlsReportSpec{
-					Host:            kmpSvcHost,
-					Port:            443,
-					SourceNamespace: cnaoNamespace,
-				},
+				Spec:   tlsReportSpec{Host: kmpSvcHost, Port: 443, SourceNamespace: cnaoNamespace},
 				Status: expectedStatus,
 			},
 		}
+		expectedHostReports := []string{cnaoHost, ipamExtHost, kmpMetricsHost, kmpSvcHost}
+
 		By("asserting TLS reports")
 		Eventually(func(g Gomega) {
 			tlsReports, err := getNamespaceTLSReports(cnaoNamespace)
 			g.Expect(err).NotTo(HaveOccurred())
-			actualReports := filterTLSReportsBySpecHost(tlsReports, cnaoHost, ipamExtHost, kmpMetricsHost, kmpSvcHost)
+			actualReports := filterTLSReportsBySpecHost(tlsReports, expectedHostReports...)
 			g.Expect(actualReports).To(WithTransform(normalizeConditions, ConsistOf(expectedReports)))
 		}, 5*time.Minute, 1*time.Second).Should(Succeed())
 
@@ -160,7 +133,7 @@ var _ = Describe("TLS", func() {
 		Eventually(func(g Gomega) {
 			tlsReports, err := getNamespaceTLSReports(cnaoNamespace)
 			g.Expect(err).NotTo(HaveOccurred())
-			actualReports := filterTLSReportsBySpecHost(tlsReports, cnaoHost, ipamExtHost, kmpMetricsHost, kmpSvcHost)
+			actualReports := filterTLSReportsBySpecHost(tlsReports, expectedHostReports...)
 			g.Expect(actualReports).To(WithTransform(normalizeConditions, ConsistOf(expectedReports)))
 		}, 5*time.Minute, 1*time.Second).Should(Succeed())
 	})

--- a/test/e2e/compliance/tls_compliance_test.go
+++ b/test/e2e/compliance/tls_compliance_test.go
@@ -3,6 +3,7 @@ package test
 import (
 	"encoding/json"
 	"slices"
+	"strings"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -71,24 +72,18 @@ var _ = Describe("TLS", func() {
 				{
 					Type:   "Available",
 					Status: metav1.ConditionTrue,
-					Reason: "EndpointDiscovered",
 				},
 				{
-					Type:    "TLSCompliant",
-					Status:  metav1.ConditionTrue,
-					Reason:  "Compliant",
-					Message: "Endpoint supports modern TLS (1.2 or 1.3)",
+					Type:   "TLSCompliant",
+					Status: metav1.ConditionTrue,
 				},
 				{
 					Type:   "CertificateValid",
 					Status: "True",
-					Reason: "Valid",
 				},
 				{
-					Type:    "PQCCompliant",
-					Status:  metav1.ConditionTrue,
-					Reason:  "PQCReady",
-					Message: "Endpoint supports TLS 1.3 with post-quantum key exchange (ML-KEM)",
+					Type:   "PQCCompliant",
+					Status: metav1.ConditionTrue,
 				},
 			},
 		}
@@ -134,7 +129,7 @@ var _ = Describe("TLS", func() {
 			g.Expect(actualReports).To(WithTransform(normalizeConditions, ConsistOf(expectedReports)))
 		}, 5*time.Minute, 1*time.Second).Should(Succeed())
 
-		By("set tlsSecurityProfile with custom type and explicit TLS group")
+		By("set tlsSecurityProfile with custom type and explicit non PQC TLS group")
 		c := operations.ConvertToConfigV1(operations.GetConfig(operations.GetCnaoV1GroupVersionKind()))
 		c.Spec.TLSSecurityProfile = &ocpv1.TLSSecurityProfile{}
 		c.Spec.TLSSecurityProfile.Type = ocpv1.TLSProfileCustomType
@@ -151,19 +146,22 @@ var _ = Describe("TLS", func() {
 			check.CheckDoNotRepeat,
 		)
 
-		// TODO: remove below slice and assert all tested components once they are all wired to tlsSecurityProfile groups
-		tlsGroupSupportedHosts := []string{cnaoHost, kmpMetricsHost, kmpSvcHost}
-
 		By("asserting the specified TLS group is set")
-		expectedNegotiatedCurves := map[string]string{"TLS 1.3": "CurveP521"}
+		for i := range expectedReports {
+			// expect non PQC compliant state because we configured non PQC TLS group
+			expectedReports[i].Status.NegotiatedCurves = map[string]string{"TLS 1.3": "CurveP521"}
+			expectedReports[i].Status.QuantumReady = false
+			for j := range expectedReports[i].Status.Conditions {
+				if expectedReports[j].Status.Conditions[j].Type == "PQCCompliant" {
+					expectedReports[j].Status.Conditions[j].Status = metav1.ConditionFalse
+				}
+			}
+		}
 		Eventually(func(g Gomega) {
 			tlsReports, err := getNamespaceTLSReports(cnaoNamespace)
 			g.Expect(err).NotTo(HaveOccurred())
-			actualReports := filterTLSReportsBySpecHost(tlsReports, tlsGroupSupportedHosts...)
-			g.Expect(actualReports).To(HaveLen(len(tlsGroupSupportedHosts)))
-			for _, report := range actualReports {
-				g.Expect(report.Status.NegotiatedCurves).To(Equal(expectedNegotiatedCurves))
-			}
+			actualReports := filterTLSReportsBySpecHost(tlsReports, cnaoHost, ipamExtHost, kmpMetricsHost, kmpSvcHost)
+			g.Expect(actualReports).To(WithTransform(normalizeConditions, ConsistOf(expectedReports)))
 		}, 5*time.Minute, 1*time.Second).Should(Succeed())
 	})
 })
@@ -200,10 +198,10 @@ func filterTLSReportsBySpecHost(reports []tlsReport, hosts ...string) []tlsRepor
 	return filteredReports
 }
 
+var dynamicTextTLSReportConditionTypes = strings.Join([]string{"Available", "CertificateValid", "PQCCompliant"}, " ")
+
 // normalizeConditions strip status.Condition non-deterministic fields values.
-// Removes all conditions LastTransitionTime.
-// For condition of type 'Available' and 'CertificateValid' the 'Message' field is trimmed
-// because it contains non-deterministic text.
+// Removes all condition's LastTransitionTime, Message and Reason attributes.
 func normalizeConditions(reports []tlsReport) []tlsReport {
 	clonedReports := slices.Clone(reports)
 	// deep copy Conditions because slices.Clone perform shallow copy
@@ -214,16 +212,8 @@ func normalizeConditions(reports []tlsReport) []tlsReport {
 	for i, report := range clonedReports {
 		for j := range report.Status.Conditions {
 			clonedReports[i].Status.Conditions[j].LastTransitionTime = metav1.Time{}
-		}
-	}
-
-	// The following conditions type message's containing non-deterministic text,
-	// hence remove Message field value
-	for i, report := range clonedReports {
-		for j, condition := range report.Status.Conditions {
-			if condition.Type == "Available" || condition.Type == "CertificateValid" {
-				clonedReports[i].Status.Conditions[j].Message = ""
-			}
+			clonedReports[i].Status.Conditions[j].Message = ""
+			clonedReports[i].Status.Conditions[j].Reason = ""
 		}
 	}
 


### PR DESCRIPTION
**Rebased on top #2923, see the last tree commits.**

<!-- Thanks for sending a pull request!

Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the main branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it

If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**What this PR does / why we need it**:
This PR wire kubevirt-ipam-controller to the operator TLS security profile's TLS groups.

With this change TLS groups configured by `NetworkAddonsConfig` CR's `tlsSecurityProfile` passed down to kubevirt-ipam-controller app, via `tls-group-prefrences` flag. Similar to other TLS settings.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
Wire kubevirt-ipam-controller to TLS security profile's TLS groups
```
