### PR TITLE
Wire kubemacpool to the TLS security profile's TLS groups

### DIFF
--- a/data/kubemacpool/kubemacpool.yaml
+++ b/data/kubemacpool/kubemacpool.yaml
@@ -275,6 +275,9 @@ spec:
 {{ if index . "TLSSecurityProfileCiphers" }}
             - "--tls-cipher-suites={{ .TLSSecurityProfileCiphers }}"
 {{ end }}
+{{ if index . "TLSGroupPreferences" }}
+            - "--tls-group-preferences={{ .TLSGroupPreferences }}"
+{{ end }}
           command:
             - /manager
           env:

--- a/hack/components/bump-kubemacpool.sh
+++ b/hack/components/bump-kubemacpool.sh
@@ -79,9 +79,16 @@ function __parametize_by_object() {
 				__set_empty_string_label ${f} 'spec.template.metadata.labels."allow-access-cluster-services"'
 				__unquote_toYaml ${f}
 				__unquote_numeric_and_boolean ${f}
-				# Templatize TLS args
-				sed -i '/            - --wait-time=/a\            - "--tls-min-version={{ .TLSMinVersion }}"' ${f}
-				sed -i '/            - "--tls-min-version={{ .TLSMinVersion }}"/a{{ if index . "TLSSecurityProfileCiphers" }}\n            - "--tls-cipher-suites={{ .TLSSecurityProfileCiphers }}"\n{{ end }}' ${f}
+				# Templatize TLS args after the existing wait-time flag.
+				sed -i '/            - --wait-time=/r /dev/stdin' "${f}" <<'EOF'
+            - "--tls-min-version={{ .TLSMinVersion }}"
+{{ if index . "TLSSecurityProfileCiphers" }}
+            - "--tls-cipher-suites={{ .TLSSecurityProfileCiphers }}"
+{{ end }}
+{{ if index . "TLSGroupPreferences" }}
+            - "--tls-group-preferences={{ .TLSGroupPreferences }}"
+{{ end }}
+EOF
 				;;
 			./NetworkPolicy_kubemacpool-allow-ingress-to-metrics-endpoint.yaml | \
 			./NetworkPolicy_kubemacpool-allow-ingress-to-webhook.yaml)

--- a/pkg/network/kubemacpool.go
+++ b/pkg/network/kubemacpool.go
@@ -124,6 +124,7 @@ func renderKubeMacPool(conf *cnao.NetworkAddonsConfigSpec, manifestDir string, c
 	tlsCfg := SelectTLSSettings(conf.TLSSecurityProfile)
 	data.Data["TLSSecurityProfileCiphers"] = strings.Join(OCPTLSProfileCiphersToGoCipherNames(tlsCfg.CipherSuites), ",")
 	data.Data["TLSMinVersion"] = string(tlsCfg.MinVersion)
+	data.Data["TLSGroupPreferences"] = strings.Join(OCPTLSProfileTLSGroupNames(tlsCfg.Groups), ",")
 	data.Data["RunbookURLTemplate"] = alerts.GetRunbookURLTemplate()
 
 	objs, err := render.RenderDir(filepath.Join(manifestDir, "kubemacpool"), &data)

--- a/pkg/network/kubemacpool_test.go
+++ b/pkg/network/kubemacpool_test.go
@@ -1,8 +1,16 @@
 package network
 
 import (
+	"fmt"
+	"slices"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
+	ocpv1 "github.com/openshift/api/config/v1"
+	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
 
 	cnao "github.com/kubevirt/cluster-network-addons-operator/pkg/apis/networkaddonsoperator/shared"
 )
@@ -242,4 +250,116 @@ var _ = Describe("Testing kubeMacPool", func() {
 			})
 		})
 	})
+
+	Describe("renderKubeMacPool", func() {
+		const manifestDir = "../../data"
+
+		var clusterInfo = &ClusterInfo{}
+
+		DescribeTable("should set TLS settings flags correctly, given TLS profile is",
+			func(testTLSSecurityProfile *ocpv1.TLSSecurityProfile, expectedFlags []string) {
+				conf := &cnao.NetworkAddonsConfigSpec{
+					PlacementConfiguration: &cnao.PlacementConfiguration{
+						Infra: &cnao.Placement{NodeSelector: map[string]string{"test": "infra"}},
+					},
+					SelfSignConfiguration: &cnao.SelfSignConfiguration{},
+					TLSSecurityProfile:    testTLSSecurityProfile,
+					KubeMacPool:           &cnao.KubeMacPool{},
+				}
+
+				objs, err := renderKubeMacPool(conf, manifestDir, clusterInfo)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(objs).NotTo(BeEmpty())
+				deployment, err := getKubeMacPoolMacControllerManagerDeployment(objs...)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(deployment.Spec.Template.Spec.Containers[0].Args).To(ContainElements(expectedFlags))
+			},
+			Entry("Old",
+				&ocpv1.TLSSecurityProfile{Type: ocpv1.TLSProfileOldType},
+				[]string{
+					"--tls-min-version=VersionTLS10",
+					"--tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256," +
+						"TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256," +
+						"TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256," +
+						"TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA," +
+						"TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,TLS_RSA_WITH_AES_128_GCM_SHA256,TLS_RSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_128_CBC_SHA256," +
+						"TLS_RSA_WITH_AES_128_CBC_SHA,TLS_RSA_WITH_AES_256_CBC_SHA,TLS_RSA_WITH_3DES_EDE_CBC_SHA",
+					"--tls-group-preferences=X25519MLKEM768,X25519,CurveP256,CurveP384",
+				},
+			),
+			Entry("Intermediate",
+				&ocpv1.TLSSecurityProfile{Type: ocpv1.TLSProfileIntermediateType},
+				[]string{
+					"--tls-min-version=VersionTLS12",
+					"--tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384," +
+						"TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256",
+					"--tls-group-preferences=X25519MLKEM768,X25519,CurveP256,CurveP384",
+				},
+			),
+			Entry("Modern",
+				&ocpv1.TLSSecurityProfile{Type: ocpv1.TLSProfileModernType},
+				[]string{
+					"--tls-min-version=VersionTLS13",
+					"--tls-group-preferences=X25519MLKEM768,X25519,CurveP256,CurveP384",
+				},
+			),
+			Entry("Custom, min TLS version 1.3 and ciphers, should not specify ciphers flag",
+				&ocpv1.TLSSecurityProfile{
+					Type: ocpv1.TLSProfileCustomType,
+					Custom: &ocpv1.CustomTLSProfile{
+						TLSProfileSpec: ocpv1.TLSProfileSpec{
+							MinTLSVersion: ocpv1.VersionTLS13,
+							Ciphers:       []string{"TLS_AES_128_GCM_SHA256", "TLS_AES_256_GCM_SHA384"},
+						},
+					},
+				},
+				[]string{"--tls-min-version=VersionTLS13"},
+			),
+			Entry("Custom, min TLS version 1.2 and ciphers",
+				&ocpv1.TLSSecurityProfile{
+					Type: ocpv1.TLSProfileCustomType,
+					Custom: &ocpv1.CustomTLSProfile{
+						TLSProfileSpec: ocpv1.TLSProfileSpec{
+							MinTLSVersion: ocpv1.VersionTLS12,
+							Ciphers:       []string{"AES128-SHA", "AES256-SHA"},
+						},
+					},
+				},
+				[]string{
+					"--tls-min-version=VersionTLS12",
+					"--tls-cipher-suites=TLS_RSA_WITH_AES_128_CBC_SHA,TLS_RSA_WITH_AES_256_CBC_SHA",
+				},
+			),
+			Entry("Custom, min TLS version 1.3 and groups",
+				&ocpv1.TLSSecurityProfile{
+					Type: ocpv1.TLSProfileCustomType,
+					Custom: &ocpv1.CustomTLSProfile{
+						TLSProfileSpec: ocpv1.TLSProfileSpec{
+							MinTLSVersion: ocpv1.VersionTLS13,
+							Groups:        []ocpv1.TLSGroup{ocpv1.TLSGroupX25519MLKEM768},
+						},
+					},
+				},
+				[]string{
+					"--tls-min-version=VersionTLS13",
+					"--tls-group-preferences=X25519MLKEM768",
+				},
+			),
+		)
+	})
 })
+
+func getKubeMacPoolMacControllerManagerDeployment(objs ...*unstructured.Unstructured) (*appsv1.Deployment, error) {
+	idx := slices.IndexFunc(objs, func(obj *unstructured.Unstructured) bool {
+		return obj.GetKind() == "Deployment" && obj.GetName() == "kubemacpool-mac-controller-manager"
+	})
+	if idx == -1 {
+		return nil, fmt.Errorf("kubemacpool-mac-controller-manager deployment not found")
+	}
+	deployment := &appsv1.Deployment{}
+	err := runtime.DefaultUnstructuredConverter.FromUnstructured(objs[idx].Object, deployment)
+	if err != nil {
+		return nil, err
+	}
+	return deployment, nil
+}

--- a/pkg/network/tlsSecurityProfile.go
+++ b/pkg/network/tlsSecurityProfile.go
@@ -156,3 +156,28 @@ func CurveIDs(groups []ocpv1.TLSGroup) []tls.CurveID {
 	}
 	return ids
 }
+
+// OCPTLSProfileTLSGroupNames converts OpenShift TLS group identifiers to their corresponding
+// Go crypto/tls.CurveID constant names (e.g. "X25519", "CurveP256"), suitable
+// for operands whose CLI flags accept named TLS groups (e.g. kubevirt-ipam-controller's
+// '--tls-group-preferences').
+// Groups with no matching crypto/tls.CurveID are dropped and logged. If none remain,
+// TLS groups are selected by the runtime.
+func OCPTLSProfileTLSGroupNames(groups []ocpv1.TLSGroup) []string {
+	var names []string
+	var dropped []ocpv1.TLSGroup
+	for _, g := range groups {
+		if id, ok := ocpTLSProfileGroupIDs[g]; ok {
+			names = append(names, id.String())
+			continue
+		}
+		dropped = append(dropped, g)
+	}
+	if len(dropped) > 0 {
+		renderLog.Info("dropping TLS groups with no matching crypto/tls.CurveID; they will not be passed to the operand. If none remain, the runtime selects defaults",
+			"dropped", dropped,
+			"applied", names,
+		)
+	}
+	return names
+}

--- a/pkg/network/tlsSecurityProfile_test.go
+++ b/pkg/network/tlsSecurityProfile_test.go
@@ -320,4 +320,38 @@ var _ = Describe("TLS Security Profile", func() {
 			Expect(ids).To(Equal([]tls.CurveID{tls.X25519}))
 		})
 	})
+
+	Context("OCPTLSProfileTLSGroupNames", func() {
+		It("should return nil for empty input", func() {
+			Expect(OCPTLSProfileTLSGroupNames(nil)).To(BeNil())
+			Expect(OCPTLSProfileTLSGroupNames([]ocpv1.TLSGroup{})).To(BeNil())
+		})
+		It("should convert OCP TLSGroup to names", func() {
+			names := OCPTLSProfileTLSGroupNames([]ocpv1.TLSGroup{
+				ocpv1.TLSGroupX25519MLKEM768,
+				ocpv1.TLSGroupX25519,
+				ocpv1.TLSGroupSecP256r1,
+				ocpv1.TLSGroupSecP384r1,
+				ocpv1.TLSGroupSecP521r1,
+				ocpv1.TLSGroupSecP256r1MLKEM768,
+				ocpv1.TLSGroupSecP384r1MLKEM1024,
+			})
+			Expect(names).To(Equal([]string{
+				"X25519MLKEM768",
+				"X25519",
+				"CurveP256",
+				"CurveP384",
+				"CurveP521",
+				"SecP256r1MLKEM768",
+				"SecP384r1MLKEM1024",
+			}))
+		})
+		It("should skip groups with no known crypto/tls.CurveID", func() {
+			names := OCPTLSProfileTLSGroupNames([]ocpv1.TLSGroup{
+				ocpv1.TLSGroupX25519,
+				"my-non-exist-tls-group",
+			})
+			Expect(names).To(Equal([]string{"X25519"}))
+		})
+	})
 })

--- a/test/e2e/compliance/tls_compliance_test.go
+++ b/test/e2e/compliance/tls_compliance_test.go
@@ -152,7 +152,7 @@ var _ = Describe("TLS", func() {
 		)
 
 		// TODO: remove below slice and assert all tested components once they are all wired to tlsSecurityProfile groups
-		tlsGroupSupportedHosts := []string{cnaoHost}
+		tlsGroupSupportedHosts := []string{cnaoHost, kmpMetricsHost, kmpSvcHost}
 
 		By("asserting the specified TLS group is set")
 		expectedNegotiatedCurves := map[string]string{"TLS 1.3": "CurveP521"}


### PR DESCRIPTION
**What this PR does / why we need it**:
Pass NetworkAddonsConfig `tlsSecurityProfile` groups into kubemacpool as
`--tls-group-preferences`, the same way min TLS version and ciphers are already
wired. Needed so KMP webhook and metrics honor the selected TLS groups
(CNV-85518).

**Special notes for your reviewer**:
- `OCPTLSProfileTLSGroupNames` is also introduced in #2938. Whichever of these
  PRs merges second should drop the duplicate helper in conflict resolution.

**Release note**:
```release-note
Wire kubemacpool to TLS security profile TLS groups
```