### PR TITLE
hack: update tls-compliance-operator to v1.1.12

### DIFF
--- a/hack/install-tls-compliance-operator.sh
+++ b/hack/install-tls-compliance-operator.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-VERSION=${VERSION:-v1.0.18}
+VERSION=${VERSION:-v1.1.12}
 
 readonly URL="https://github.com/sebrandon1/tls-compliance-operator/releases/download/${VERSION}/install.yaml"
 readonly NAMESPACE="tls-compliance-operator-system"
@@ -15,7 +15,7 @@ echo "Installing TLS Compliance Operator ${VERSION} from: ${URL}.."
 # By default the operator scan common TLS ports (443, 6443, 8443, 9443), and installs
 # permissive network-policy for those ports only [1].
 # To allow the operator reach and check all services the network-policy is deleted.
-# [1] https://github.com/sebrandon1/tls-compliance-operator/blob/v1.0.18/docs/troubleshooting.md#:~:text=Check%20for%20NetworkPolicy%20restrictions
+# [1] https://github.com/sebrandon1/tls-compliance-operator/blob/v1.1.12/docs/troubleshooting.md#:~:text=Check%20for%20NetworkPolicy%20restrictions
 echo "Deleting the operator's network-policy to allow egress all services.."
 ./cluster/kubectl.sh -n $NAMESPACE delete networkpolicy $NP_NAME
 


### PR DESCRIPTION
## Summary

- Bump tls-compliance-operator from v1.0.18 to [v1.1.12](https://github.com/sebrandon1/tls-compliance-operator/releases/tag/v1.1.12)
- Update troubleshooting doc link to v1.1.12 tag

## v1.1.12 highlights

- Cross-operator image certification enrichment via [imagecertinfo-operator](https://github.com/sebrandon1/imagecertinfo-operator)
- 15 new fields on `status.imageCertificationInfo`
- Graceful degradation when imagecertinfo-operator is absent