### PR TITLE
e2e/compliance,hack: shorten tls-compliance-operator scan/cleanup intervals

### DIFF
--- a/hack/install-tls-compliance-operator.sh
+++ b/hack/install-tls-compliance-operator.sh
@@ -21,8 +21,8 @@ echo "Deleting the operator's network-policy to allow egress all services.."
 
 echo "Patching the operator's Deployment for fine tuning reporting intervals.."
 ./cluster/kubectl.sh -n $NAMESPACE patch deployment $DEPLOY_NAME --type='json' -p='[
-  {"op": "add", "path": "/spec/template/spec/containers/0/args/-", "value": "--scan-interval=30s"},
-  {"op": "add", "path": "/spec/template/spec/containers/0/args/-", "value": "--cleanup-interval=15s"}
+  {"op": "add", "path": "/spec/template/spec/containers/0/args/-", "value": "--scan-interval=5s"},
+  {"op": "add", "path": "/spec/template/spec/containers/0/args/-", "value": "--cleanup-interval=7s"}
 ]'
 
 echo "Waiting for TLS Compliance Operator readiness.."


### PR DESCRIPTION
Recently we saw flakes on CI in the compliance e2e suite TLS tests, due to timeout of the assert on the tls-reports genereted by the tls-compliance-operator.
For example  https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_cluster-network-addons-operator/2948/pull-e2e-cluster-network-addons-operator-workflow-k8s/2095159128644128768

This PR reduce the tls-compliance-operator scan and cleanup intervals so tls-report CRs get updated more quickly.
This change should eliminate such flakes.


```release-note
NONE
```